### PR TITLE
feat: rework header UI with shared components and improved layout

### DIFF
--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
+  import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
   import MergedHeaderIcon from '$lib/components/merged-header-icon/merged-header-icon.svelte';
   import Popover from '$lib/components/popover/popover.svelte';
   import {
     baseHeaderClasses,
-    baseIconClasses,
-    nTranslateXHeaderFa,
-    pHeaderFa,
-    pxScreen,
-    translateXHeaderFa
+    headerDividerClasses,
+    labelIconClasses,
+    pxScreen
   } from '$lib/css-classes';
   import { SortDirection } from '$lib/data/sort-types';
   import { FilesystemStorageHandler } from '$lib/data/storage/handler/filesystem-handler';
@@ -32,17 +31,16 @@
   } from '$lib/data/store';
   import { inputAllowDirectory } from '$lib/functions/file-dom/input-allow-directory';
   import { inputFile } from '$lib/functions/file-dom/input-file';
-  import { dummyFn, isMobile$, isOnOldUrl } from '$lib/functions/utils';
+  import { dummyFn, isMobile$ } from '$lib/functions/utils';
   import {
     faArrowDownShortWide,
     faArrowDownWideShort,
+    faBug,
     faCalendarXmark,
-    faChartLine,
     faCircleXmark,
     faCloudArrowUp,
     faSortDown,
     faSortUp,
-    faTimes,
     faTrash
   } from '@fortawesome/free-solid-svg-icons';
   import { createEventDispatcher } from 'svelte';
@@ -50,7 +48,6 @@
   import { quintOut } from 'svelte/easing';
   import { scale } from 'svelte/transition';
 
-  export let hasBookOpened: boolean;
   export let selectMode: boolean;
   export let selectedCount: number;
   export let hasBooks: boolean;
@@ -62,12 +59,9 @@
   const dispatch = createEventDispatcher<{
     selectAllClick: void;
     removeClick: void;
-    domainHintClick: void;
     bugReportClick: void;
-    backToBookClick: void;
     filesChange: FileList;
     importBackup: File;
-    selectionToStatistics: void;
     deleteStatistics: void;
     replicateData: void;
     cancelReplication: void;
@@ -97,11 +91,9 @@
   let countImportElm: HTMLInputElement;
   let storageSourceElm: Popover;
   let sortOptionsElm: Popover;
-  let isOldUrl = false;
   let showLoadCount = false;
 
   $: if (browser) {
-    isOldUrl = isOnOldUrl(window);
     showLoadCount = new URLSearchParams(window.location.search).has('count');
 
     importMenuItems.push(
@@ -238,99 +230,37 @@
 <div class={baseHeaderClasses}>
   {#if !replicationToProgress}
     <div class="flex h-full justify-between {pxScreen}">
-      {#if selectedCount === 0}
+      <div class="flex transform-gpu {nTranslateXHeaderMat}">
         <div
+          tabindex="0"
+          role="button"
           title={selectMode ? 'Disable Book Selection' : 'Enable Book Selection'}
-          class="transform-gpu {nTranslateXHeaderMat}"
-          in:scale={inAnimationParams}
-          out:scale={outAnimationParams}
+          class={labelIconClasses}
+          class:opacity-100={selectMode}
+          class:opacity-60={!selectMode}
+          on:click={() => (selectMode = hasBooks && !selectMode)}
+          on:keyup={dummyFn}
         >
           <svg
-            tabindex="0"
-            role="button"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class:opacity-100={selectMode}
-            class:opacity-60={!selectMode}
-            class={baseIconClasses}
-            on:click={() => (selectMode = hasBooks && !selectMode)}
-            on:keyup={dummyFn}
+            class="h-3.5 w-3.5 xl:h-3 xl:w-3"
           >
             <path
               class="fill-current"
               d="M20,4v12H8V4H20 M20,2H8C6.9,2,6,2.9,6,4v12c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2L20,2z M12.47,14 L9,10.5l1.4-1.41l2.07,2.08L17.6,6L19,7.41L12.47,14z M4,6H2v14c0,1.1,0.9,2,2,2h14v-2H4V6z"
             />
           </svg>
+          <span>Select</span>
         </div>
-      {:else}
-        <div
-          class="flex h-full transform-gpu items-center {nTranslateXHeaderFa} text-xl font-medium"
-        >
-          <div
-            tabindex="0"
-            role="button"
-            title="Disable Book Selection"
-            class="flex h-full items-center text-2xl xl:text-xl {pHeaderFa} cursor-pointer"
-            in:scale={inAnimationParams}
-            out:scale={outAnimationParams}
-            on:click={() => (selectMode = !selectMode)}
-            on:keyup={dummyFn}
-          >
-            <Fa icon={faTimes} />
-          </div>
+        {#if selectMode}
           <span
-            class="translate-x-2 transform-gpu"
-            in:scale={inAnimationParams}
-            out:scale={outAnimationParams}>{selectedCount}</span
+            class="flex items-center px-2 text-xl font-medium xl:text-lg"
+            title="{selectedCount} {selectedCount === 1 ? 'book' : 'books'} selected"
+            >{selectedCount}</span
           >
-        </div>
-      {/if}
-
-      <div class="absolute left-1/2 h-full -translate-x-1/2 transform-gpu">
-        {#if !selectMode}
-          {#if hasBookOpened}
-            <div title="Back to Book">
-              <svg
-                tabindex="0"
-                role="button"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                class={baseIconClasses}
-                in:scale={inAnimationParams}
-                out:scale={outAnimationParams}
-                on:click={() => dispatch('backToBookClick')}
-                on:keyup={dummyFn}
-              >
-                <path
-                  class="fill-current"
-                  d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5zm-3.5-8c.88 0 1.73.09 2.5.26V9.24c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99zM13 12.49v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26V11.9c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.3-4.5.83zm4.5 1.84c-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26v-1.52c-.79-.16-1.64-.24-2.5-.24z"
-                />
-              </svg>
-            </div>
-          {/if}
-        {:else}
-          <div title="Select all Books">
-            <svg
-              tabindex="0"
-              role="button"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              class={baseIconClasses}
-              in:scale={inAnimationParams}
-              out:scale={outAnimationParams}
-              on:click={() => dispatch('selectAllClick')}
-              on:keyup={dummyFn}
-            >
-              <path
-                class="fill-current"
-                d="M18 7l-1.41-1.41-6.34 6.34 1.41 1.41L18 7zm4.24-1.41L11.66 16.17 7.48 12l-1.41 1.41L11.66 19l12-12-1.42-1.41zM.41 13.41L6 19l1.41-1.41L1.83 12 .41 13.41z"
-              />
-            </svg>
-          </div>
         {/if}
-      </div>
-
-      <div class="flex transform-gpu {translateXHeaderFa}">
+        <div class={headerDividerClasses} />
         {#if !selectMode}
           <div
             class="relative transform-gpu"
@@ -343,6 +273,90 @@
               on:action={triggerInput}
             />
           </div>
+          <div
+            tabindex="0"
+            role="button"
+            title="Report an Issue"
+            class={labelIconClasses}
+            in:scale={inAnimationParams}
+            out:scale={outAnimationParams}
+            on:click={() => dispatch('bugReportClick')}
+            on:keyup={dummyFn}
+          >
+            <Fa icon={faBug} class="text-sm xl:text-xs" />
+            <span>Issue Report</span>
+          </div>
+        {:else}
+          <div
+            tabindex="0"
+            role="button"
+            title="Select all Books"
+            class={labelIconClasses}
+            in:scale={inAnimationParams}
+            out:scale={outAnimationParams}
+            on:click={() => dispatch('selectAllClick')}
+            on:keyup={dummyFn}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              class="h-3.5 w-3.5 xl:h-3 xl:w-3"
+            >
+              <path
+                class="fill-current"
+                d="M18 7l-1.41-1.41-6.34 6.34 1.41 1.41L18 7zm4.24-1.41L11.66 16.17 7.48 12l-1.41 1.41L11.66 19l12-12-1.42-1.41zM.41 13.41L6 19l1.41-1.41L1.83 12 .41 13.41z"
+              />
+            </svg>
+            <span>All</span>
+          </div>
+          {#if selectedCount > 0}
+            <div
+              tabindex="0"
+              role="button"
+              title="Open Export Menu"
+              class="transform-gpu {labelIconClasses}"
+              in:scale={inAnimationParams}
+              out:scale={outAnimationParams}
+              on:click={() => dispatch('replicateData')}
+              on:keyup={dummyFn}
+            >
+              <Fa icon={faCloudArrowUp} class="text-sm xl:text-xs" />
+              <span>Export</span>
+            </div>
+            {#if $storageSource$ === StorageKey.BROWSER}
+              <div
+                tabindex="0"
+                role="button"
+                title="Delete Statistics for selected Books"
+                class="transform-gpu {labelIconClasses}"
+                in:scale={inAnimationParams}
+                out:scale={outAnimationParams}
+                on:click={() => dispatch('deleteStatistics')}
+                on:keyup={dummyFn}
+              >
+                <Fa icon={faCalendarXmark} class="text-sm xl:text-xs" />
+                <span>Delete Statistics</span>
+              </div>
+            {/if}
+            <div
+              tabindex="0"
+              role="button"
+              title="Delete selected Books"
+              class="transform-gpu {labelIconClasses}"
+              in:scale={inAnimationParams}
+              out:scale={outAnimationParams}
+              on:click={() => dispatch('removeClick')}
+              on:keyup={dummyFn}
+            >
+              <Fa icon={faTrash} class="text-sm xl:text-xs" />
+              <span>Delete Book</span>
+            </div>
+          {/if}
+        {/if}
+      </div>
+
+      <div class="flex">
+        {#if !selectMode}
           <div
             title="Select Storage Source"
             class="relative transform-gpu"
@@ -357,13 +371,16 @@
             >
               <div slot="icon">
                 {#key $storageIcon$}
-                  <svg
-                    class={baseIconClasses}
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox={$storageIcon$.viewBox}
-                  >
-                    <path class="fill-current" d={$storageIcon$.d} />
-                  </svg>
+                  <div class={labelIconClasses}>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox={$storageIcon$.viewBox}
+                      class="h-3.5 w-3.5 xl:h-3 xl:w-3"
+                    >
+                      <path class="fill-current" d={$storageIcon$.d} />
+                    </svg>
+                    <span>Storage Source&nbsp;▾</span>
+                  </div>
                 {/key}
               </div>
               <div class="w-28 bg-gray-700" slot="content">
@@ -410,12 +427,13 @@
               yOffset={0}
               bind:this={sortOptionsElm}
             >
-              <div slot="icon" class={baseIconClasses} title="Select Sort Options">
+              <div slot="icon" class={labelIconClasses} title="Select Sort Options">
                 {#if $booklistSortOptions$[$storageSource$].direction === SortDirection.ASC}
-                  <Fa icon={faArrowDownShortWide} />
+                  <Fa icon={faArrowDownShortWide} class="text-sm xl:text-xs" />
                 {:else}
-                  <Fa icon={faArrowDownWideShort} />
+                  <Fa icon={faArrowDownWideShort} class="text-sm xl:text-xs" />
                 {/if}
+                <span>Sort&nbsp;▾</span>
               </div>
               <div class="w-44 bg-gray-700" slot="content">
                 {#each sortMenuItems as sortMenuItem (sortMenuItem.property)}
@@ -466,35 +484,7 @@
               </div>
             </Popover>
           </div>
-          <div
-            class="relative transform-gpu"
-            in:scale={inAnimationParams}
-            out:scale={outAnimationParams}
-          >
-            <MergedHeaderIcon
-              items={isOldUrl
-                ? [
-                    mergeEntries.MANAGE,
-                    mergeEntries.DOMAIN_HINT,
-                    mergeEntries.BUG_REPORT,
-                    mergeEntries.SETTINGS
-                  ]
-                : [
-                    mergeEntries.MANAGE,
-                    mergeEntries.STATISTICS,
-                    mergeEntries.SETTINGS,
-                    mergeEntries.BUG_REPORT
-                  ]}
-              on:action={({ detail }) => {
-                if (detail === mergeEntries.BUG_REPORT.label) {
-                  dispatch('bugReportClick');
-                }
-                if (detail === mergeEntries.DOMAIN_HINT.label) {
-                  dispatch('domainHintClick');
-                }
-              }}
-            />
-          </div>
+          <div class={headerDividerClasses} />
           {#if showLoadCount}
             <button
               style:color={!!$fileCountData$ ? 'red' : null}
@@ -502,59 +492,7 @@
             >
           {/if}
         {/if}
-
-        {#if selectedCount > 0}
-          <div
-            tabindex="0"
-            role="button"
-            title="Open Export Menu"
-            class="transform-gpu {baseIconClasses}"
-            in:scale={inAnimationParams}
-            out:scale={outAnimationParams}
-            on:click={() => dispatch('replicateData')}
-            on:keyup={dummyFn}
-          >
-            <Fa icon={faCloudArrowUp} />
-          </div>
-          {#if $storageSource$ === StorageKey.BROWSER}
-            <div
-              tabindex="0"
-              role="button"
-              title="Go to Statistics"
-              class="transform-gpu {baseIconClasses}"
-              in:scale={inAnimationParams}
-              out:scale={outAnimationParams}
-              on:click={() => dispatch('selectionToStatistics')}
-              on:keyup={dummyFn}
-            >
-              <Fa icon={faChartLine} />
-            </div>
-            <div
-              tabindex="0"
-              role="button"
-              title="Delete Statistics for selected Books"
-              class="transform-gpu {baseIconClasses}"
-              in:scale={inAnimationParams}
-              out:scale={outAnimationParams}
-              on:click={() => dispatch('deleteStatistics')}
-              on:keyup={dummyFn}
-            >
-              <Fa icon={faCalendarXmark} />
-            </div>
-          {/if}
-          <div
-            tabindex="0"
-            role="button"
-            title="Delete selected Books"
-            class="transform-gpu {baseIconClasses}"
-            in:scale={inAnimationParams}
-            out:scale={outAnimationParams}
-            on:click={() => dispatch('removeClick')}
-            on:keyup={dummyFn}
-          >
-            <Fa icon={faTrash} />
-          </div>
-        {/if}
+        <HeaderNavTabs />
       </div>
     </div>
   {:else}

--- a/src/lib/components/book-reader/book-reader-header.svelte
+++ b/src/lib/components/book-reader/book-reader-header.svelte
@@ -1,28 +1,29 @@
 <script lang="ts">
-  import { browser } from '$app/environment';
   import { faBookmark as farBookmark } from '@fortawesome/free-regular-svg-icons';
   import {
     faBookmark as fasBookmark,
     faCrosshairs,
     faExpand,
     faFlag,
+    faHashtag,
+    faImages,
     faList,
-    faRotateLeft,
-    type IconDefinition
+    faRotateLeft
   } from '@fortawesome/free-solid-svg-icons';
   import { readerImageGalleryPictures$ } from '$lib/components/book-reader/book-reader-image-gallery/book-reader-image-gallery';
-  import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
-  import MergedHeaderIcon from '$lib/components/merged-header-icon/merged-header-icon.svelte';
+  import HeaderIconButton from '$lib/components/header-icon-button.svelte';
+  import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import Popover from '$lib/components/popover/popover.svelte';
   import {
     baseHeaderClasses,
-    baseIconClasses,
+    headerDividerClasses,
+    labelIconClasses,
     nTranslateXHeaderFa,
     translateXHeaderFa
   } from '$lib/css-classes';
   import { customReadingPointEnabled$, viewMode$ } from '$lib/data/store';
   import { ViewMode } from '$lib/data/view-mode';
-  import { dummyFn, isMobile$, isOnOldUrl } from '$lib/functions/utils';
+  import { dummyFn, isMobile$ } from '$lib/functions/utils';
   import { createEventDispatcher } from 'svelte';
   import Fa from 'svelte-fa';
 
@@ -47,7 +48,6 @@
     statisticsClick: void;
     readerImageGalleryClick: void;
     settingsClick: void;
-    domainHintClick: void;
     bookManagerClick: void;
   }>();
 
@@ -62,37 +62,6 @@
 
   let customReadingPointMenuElm: Popover;
 
-  let menuItems: {
-    routeId: string;
-    label: string;
-    icon: IconDefinition;
-    title: string;
-  }[] = [];
-
-  $: isOldUrl = browser && isOnOldUrl(window);
-
-  $: {
-    const items = [];
-
-    if (isOldUrl) {
-      items.push(mergeEntries.DOMAIN_HINT);
-    } else {
-      items.push(mergeEntries.STATISTICS);
-    }
-
-    if (hasText) {
-      items.push(mergeEntries.JUMP_TO_POSITION);
-    }
-
-    if ($readerImageGalleryPictures$.length) {
-      items.push(mergeEntries.READER_IMAGE_GALLERY);
-    }
-
-    items.push(mergeEntries.SETTINGS, mergeEntries.MANAGE);
-
-    menuItems = items;
-  }
-
   function dispatchCustomReadingPointAction(action: any) {
     dispatch(action);
     customReadingPointMenuElm.toggleOpen();
@@ -102,38 +71,26 @@
 <div class="flex justify-between bg-gray-700 px-4 md:px-8 {baseHeaderClasses}">
   <div class="flex transform-gpu {nTranslateXHeaderFa}">
     {#if hasChapterData}
-      <div
-        tabindex="0"
-        role="button"
+      <HeaderIconButton
+        icon={faList}
         title="Open Table of Contents"
-        class={baseIconClasses}
+        label="TOC"
         on:click={() => dispatch('tocClick')}
-        on:keyup={dummyFn}
-      >
-        <Fa icon={faList} />
-      </div>
+      />
     {/if}
-    <div
-      tabindex="0"
-      role="button"
+    <HeaderIconButton
+      icon={isBookmarkScreen ? fasBookmark : farBookmark}
       title="Create Bookmark"
-      class={baseIconClasses}
+      label="Bookmark"
       on:click={() => dispatch('bookmarkClick')}
-      on:keyup={dummyFn}
-    >
-      <Fa icon={isBookmarkScreen ? fasBookmark : farBookmark} />
-    </div>
+    />
     {#if hasBookmarkData}
-      <div
-        tabindex="0"
-        role="button"
+      <HeaderIconButton
+        icon={faRotateLeft}
         title="Return to Bookmark"
-        class={baseIconClasses}
+        label="Return to Bookmark"
         on:click={() => dispatch('scrollToBookmarkClick')}
-        on:keyup={dummyFn}
-      >
-        <Fa icon={faRotateLeft} />
-      </div>
+      />
     {/if}
     {#if $viewMode$ === ViewMode.Continuous && !$isMobile$}
       <div
@@ -143,19 +100,39 @@
         {autoScrollMultiplier}x
       </div>
     {/if}
+    <HeaderIconButton
+      icon={faFlag}
+      title="Complete Book"
+      label="Complete Book"
+      on:click={() => dispatch('completeBook')}
+    />
+    {#if showFullscreenButton}
+      <HeaderIconButton
+        icon={faExpand}
+        title="Toggle Fullscreen"
+        label="Fullscreen"
+        on:click={() => dispatch('fullscreenClick')}
+      />
+    {/if}
+    {#if hasText}
+      <HeaderIconButton
+        icon={faHashtag}
+        title="Jump to Position"
+        label="Jump"
+        on:click={() => dispatch('jumpClick')}
+      />
+    {/if}
+    {#if $readerImageGalleryPictures$.length}
+      <HeaderIconButton
+        icon={faImages}
+        title="Open Image Gallery"
+        label="Images"
+        on:click={() => dispatch('readerImageGalleryClick')}
+      />
+    {/if}
   </div>
 
   <div class="flex transform-gpu {translateXHeaderFa}">
-    <div
-      tabindex="0"
-      role="button"
-      title="Complete Book"
-      class={baseIconClasses}
-      on:click={() => dispatch('completeBook')}
-      on:keyup={dummyFn}
-    >
-      <Fa icon={faFlag} />
-    </div>
     {#if $customReadingPointEnabled$ || $viewMode$ === ViewMode.Paginated}
       <div class="flex">
         <Popover
@@ -164,8 +141,9 @@
           yOffset={0}
           bind:this={customReadingPointMenuElm}
         >
-          <div slot="icon" title="Open Custom Point Actions" class={baseIconClasses}>
-            <Fa icon={faCrosshairs} />
+          <div slot="icon" title="Open Custom Point Actions" class={labelIconClasses}>
+            <Fa icon={faCrosshairs} class="text-sm xl:text-xs" />
+            <span>Point&nbsp;▾</span>
           </div>
           <div class="w-40 bg-gray-700 md:w-32" slot="content">
             {#each customReadingPointMenuItems as actionItem (actionItem.label)}
@@ -182,36 +160,14 @@
           </div>
         </Popover>
       </div>
+      <div class={headerDividerClasses} />
     {/if}
-    {#if showFullscreenButton}
-      <div
-        tabindex="0"
-        role="button"
-        title="Toggle Fullscreen"
-        class={baseIconClasses}
-        on:click={() => dispatch('fullscreenClick')}
-        on:keyup={dummyFn}
-      >
-        <Fa icon={faExpand} />
-      </div>
-    {/if}
-    <MergedHeaderIcon
-      disableRouteNavigation
-      items={menuItems}
-      on:action={({ detail }) => {
-        if (detail === mergeEntries.STATISTICS.label) {
-          dispatch('statisticsClick');
-        } else if (detail === mergeEntries.JUMP_TO_POSITION.label) {
-          dispatch('jumpClick');
-        } else if (detail === mergeEntries.READER_IMAGE_GALLERY.label) {
-          dispatch('readerImageGalleryClick');
-        } else if (detail === mergeEntries.SETTINGS.label) {
-          dispatch('settingsClick');
-        } else if (detail === mergeEntries.DOMAIN_HINT.label) {
-          dispatch('domainHintClick');
-        } else if (detail === mergeEntries.MANAGE.label) {
-          dispatch('bookManagerClick');
-        }
+    <HeaderNavTabs
+      disableNavigation
+      on:navigate={({ detail }) => {
+        if (detail === '/statistics') dispatch('statisticsClick');
+        else if (detail === '/settings') dispatch('settingsClick');
+        else if (detail === '/manage') dispatch('bookManagerClick');
       }}
     />
   </div>

--- a/src/lib/components/header-icon-button.svelte
+++ b/src/lib/components/header-icon-button.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+  import { labelIconClasses } from '$lib/css-classes';
+  import { dummyFn } from '$lib/functions/utils';
+  import Fa from 'svelte-fa';
+
+  export let icon: IconDefinition;
+  export let title: string;
+  export let label: string | undefined = undefined;
+  export let disabled: boolean = false;
+</script>
+
+<div
+  tabindex="0"
+  role="button"
+  {title}
+  class={labelIconClasses}
+  style:cursor={disabled ? 'not-allowed' : undefined}
+  on:click
+  on:keyup={dummyFn}
+>
+  <Fa {icon} class="text-sm xl:text-xs" />
+  {#if label}<span>{label}</span>{/if}
+</div>

--- a/src/lib/components/header-nav-tabs.svelte
+++ b/src/lib/components/header-nav-tabs.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { faBookOpen, faChartLine, faCog, faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
+  import HeaderTab from '$lib/components/header-tab.svelte';
+  import { pagePath } from '$lib/data/env';
+  import { database } from '$lib/data/store';
+  import { createEventDispatcher } from 'svelte';
+  import { map, share } from 'rxjs';
+
+  export let disableNavigation = false;
+
+  const dispatch = createEventDispatcher<{ navigate: string }>();
+
+  const currentBookId$ = database.lastItem$.pipe(
+    map((item) => item?.dataId),
+    share()
+  );
+
+  const tabs = [
+    { routeId: '/statistics', label: 'Statistics', icon: faChartLine },
+    { routeId: '/settings', label: 'Settings', icon: faCog },
+    { routeId: '/manage', label: 'Manager', icon: faSignOutAlt }
+  ];
+
+  function handleClick(routeId: string, query = '') {
+    dispatch('navigate', routeId);
+
+    if (!disableNavigation) {
+      goto(`${pagePath}${routeId}${query}`);
+    }
+  }
+</script>
+
+{#if $currentBookId$}
+  <HeaderTab
+    icon={faBookOpen}
+    label="Book"
+    active={$page.route.id === '/b'}
+    on:click={() => handleClick('/b', `?id=${$currentBookId$}`)}
+  />
+{/if}
+{#each tabs as tab (tab.routeId)}
+  <HeaderTab
+    icon={tab.icon}
+    label={tab.label}
+    active={$page.route.id === tab.routeId}
+    on:click={() => handleClick(tab.routeId)}
+  />
+{/each}

--- a/src/lib/components/header-tab.svelte
+++ b/src/lib/components/header-tab.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+  import Fa from 'svelte-fa';
+
+  export let icon: IconDefinition;
+  export let label: string;
+  export let active: boolean = false;
+  export let title: string | undefined = undefined;
+</script>
+
+<button
+  {title}
+  class="flex flex-col items-center justify-center h-12 xl:h-10 px-3 text-xs cursor-pointer
+    {active ? 'bg-gray-900 hover:bg-gray-800' : 'hover:bg-gray-900'}"
+  on:click
+>
+  <Fa class="mb-0.5" {icon} />
+  {label}
+  <slot />
+</button>

--- a/src/lib/components/merged-header-icon/merged-entries.ts
+++ b/src/lib/components/merged-header-icon/merged-entries.ts
@@ -11,17 +11,14 @@ import {
   faFileArrowUp,
   faFileZipper,
   faFolderPlus,
-  faHashtag,
-  faImages,
-  faSignOutAlt,
-  faTriangleExclamation
+  faSignOutAlt
 } from '@fortawesome/free-solid-svg-icons';
 
 export const mergeEntries = {
   MANAGE: { routeId: '/manage', label: 'Manager', icon: faSignOutAlt, title: 'Go to Book Manager' },
   SETTINGS: {
     routeId: '/settings',
-    label: 'Settings',
+    label: 'Reader Settings',
     icon: faCog,
     title: 'Go to Reader Settings'
   },
@@ -31,31 +28,13 @@ export const mergeEntries = {
     icon: faChartLine,
     title: 'Go to Statistics'
   },
-  JUMP_TO_POSITION: {
-    routeId: '',
-    label: 'Jump',
-    icon: faHashtag,
-    title: 'Jump to Position'
-  },
-  READER_IMAGE_GALLERY: {
-    routeId: '',
-    label: 'Images',
-    icon: faImages,
-    title: 'Open Image Gallery'
-  },
-  DOMAIN_HINT: {
-    routeId: '',
-    label: 'Domain Hint',
-    icon: faTriangleExclamation,
-    title: 'Old Domain used'
-  },
-  BUG_REPORT: { routeId: '', label: 'Bug Report', icon: faBug, title: 'Report an Issue' },
+  BUG_REPORT: { routeId: '', label: 'Issue Report', icon: faBug, title: 'Report an Issue' },
   FOLDER_IMPORT: {
     routeId: '',
-    label: 'Import Folder(s)',
+    label: 'Import Folder',
     icon: faFolderPlus,
     title: 'Import from Folder'
   },
-  FILE_IMPORT: { routeId: '', label: 'Import File(s)', icon: faFileArrowUp, title: 'Import Files' },
+  FILE_IMPORT: { routeId: '', label: 'Import Files', icon: faFileArrowUp, title: 'Import Files' },
   BACKUP_IMPORT: { routeId: '', label: 'Import Backup', icon: faFileZipper, title: 'Import Backup' }
 };

--- a/src/lib/components/merged-header-icon/merged-header-icon.svelte
+++ b/src/lib/components/merged-header-icon/merged-header-icon.svelte
@@ -5,14 +5,13 @@
   import { page } from '$app/stores';
   import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
   import Popover from '$lib/components/popover/popover.svelte';
-  import { baseIconClasses } from '$lib/css-classes';
+  import { baseIconClasses, labelIconClasses } from '$lib/css-classes';
   import { pagePath } from '$lib/data/env';
   import { dummyFn } from '$lib/functions/utils';
 
   export let leavePageLink = '';
   export let items = [mergeEntries.MANAGE, mergeEntries.SETTINGS, mergeEntries.BUG_REPORT];
   export let mergeTo = mergeEntries.MANAGE;
-  export let disableRouteNavigation = false;
 
   const dispatch = createEventDispatcher<{ action: string }>();
 
@@ -29,12 +28,10 @@
       menuElm.toggleOpen();
     }
 
-    if (!disableRouteNavigation) {
-      const action = actionItems.find((item) => item.label === target);
+    const action = actionItems.find((item) => item.label === target);
 
-      if (action?.routeId) {
-        goto(`${pagePath}${action.routeId}`);
-      }
+    if (action?.routeId) {
+      goto(`${pagePath}${action.routeId}`);
     }
   }
 
@@ -45,8 +42,9 @@
 
 {#if leavePageLink}
   <a href={leavePageLink}>
-    <div class={baseIconClasses}>
-      <Fa icon={mergeTo.icon} />
+    <div class={labelIconClasses}>
+      <Fa icon={mergeTo.icon} class="text-sm xl:text-xs" />
+      <span>{mergeTo.label}{mergeTo.routeId ? ' ↗' : ''}</span>
     </div>
   </a>
 {:else}
@@ -56,11 +54,12 @@
         tabindex="0"
         role="button"
         title={actionItem.title}
-        class={baseIconClasses}
+        class={labelIconClasses}
         on:click={() => handleActionMenuItem(actionItem.label)}
         on:keyup={dummyFn}
       >
-        <Fa icon={actionItem.icon} />
+        <Fa icon={actionItem.icon} class="text-sm xl:text-xs" />
+        <span>{actionItem.label}{actionItem.routeId ? ' ↗' : ''}</span>
       </div>
     {/each}
   </div>

--- a/src/lib/components/settings/settings-header.svelte
+++ b/src/lib/components/settings/settings-header.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { faBookOpenReader, faClock, faDatabase } from '@fortawesome/free-solid-svg-icons';
-  import Fa from 'svelte-fa';
-  import MergedHeaderIcon from '$lib/components/merged-header-icon/merged-header-icon.svelte';
+  import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
+  import HeaderTab from '$lib/components/header-tab.svelte';
   import Ripple from '$lib/components/ripple.svelte';
   import { baseHeaderClasses, pxScreen } from '$lib/css-classes';
 
-  export let leavePageLink: string;
   export let activeSettings: string;
 
   const settingItems = [
@@ -25,21 +24,21 @@
 </script>
 
 <div class={baseHeaderClasses}>
-  <div class="{pxScreen} flex px-0 md:px-5">
-    <div class="h12 flex grow justify-evenly xl:h-10">
+  <div class="{pxScreen} flex justify-between px-0 md:px-5">
+    <div class="flex xl:h-10">
       {#each settingItems as settingItem (settingItem.label)}
-        <button
-          class="flex grow flex-col items-center justify-center text-xs"
-          class:bg-gray-900={activeSettings === settingItem.label}
-          class:hover:bg-gray-900={activeSettings !== settingItem.label}
+        <HeaderTab
+          icon={settingItem.icon}
+          label={settingItem.label}
+          active={activeSettings === settingItem.label}
           on:click={() => (activeSettings = settingItem.label)}
         >
-          <Fa class="mb-1" icon={settingItem.icon} />
-          {settingItem.label}
           <Ripple />
-        </button>
+        </HeaderTab>
       {/each}
     </div>
-    <MergedHeaderIcon {leavePageLink} />
+    <div class="flex">
+      <HeaderNavTabs />
+    </div>
   </div>
 </div>

--- a/src/lib/components/statistics/statistics-header.svelte
+++ b/src/lib/components/statistics/statistics-header.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import {
     faCalendarDays,
     faCopy,
@@ -7,8 +6,9 @@
     faMap,
     faSliders
   } from '@fortawesome/free-solid-svg-icons';
-  import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
-  import MergedHeaderIcon from '$lib/components/merged-header-icon/merged-header-icon.svelte';
+  import HeaderIconButton from '$lib/components/header-icon-button.svelte';
+  import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
+  import HeaderTab from '$lib/components/header-tab.svelte';
   import Popover from '$lib/components/popover/popover.svelte';
   import {
     StatisticsTab,
@@ -17,13 +17,15 @@
     statisticsTitleFilterIsOpen$,
     type StatisticsDataSource
   } from '$lib/components/statistics/statistics-types';
-  import { baseHeaderClasses, baseIconClasses, pxScreen } from '$lib/css-classes';
-  import { pagePath } from '$lib/data/env';
+  import {
+    baseHeaderClasses,
+    headerDividerClasses,
+    labelIconClasses,
+    pxScreen
+  } from '$lib/css-classes';
   import { lastStatisticsTab$ } from '$lib/data/store';
-  import { dummyFn } from '$lib/functions/utils';
   import Fa from 'svelte-fa';
 
-  export let currentBookId: number | undefined;
   export let showStatisticsSettings: boolean;
 
   const copyStatisticsDataItems: StatisticsDataSource[] = [
@@ -36,102 +38,75 @@
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
   <div class={baseHeaderClasses}>
-    <div class="{pxScreen} flex justify-end px-0 md:px-5">
-      <div class="relative transform-gpu">
-        <Popover
-          placement="bottom"
-          fallbackPlacements={['bottom-end', 'bottom-start']}
-          yOffset={0}
-          bind:this={copyStatisticsDataPopover}
-        >
-          <div title="Copy Data in TMW Log Format" slot="icon" class={baseIconClasses}>
-            <Fa icon={faCopy} />
-          </div>
-          <div class="flex flex-col justify-center w-36 bg-gray-700" slot="content">
-            {#each copyStatisticsDataItems as copyStatisticsDataItem (copyStatisticsDataItem.key)}
-              <button
-                class="p-2 hover:bg-white hover:text-gray-700"
-                on:click={() => {
-                  copyStatisticsData$.next(copyStatisticsDataItem.key);
-                  copyStatisticsDataPopover.toggleOpen();
-                }}
-              >
-                {copyStatisticsDataItem.label}
-              </button>
-            {/each}
-          </div>
-        </Popover>
+    <div class="{pxScreen} flex justify-between px-0 md:px-5">
+      <div class="flex">
+        <HeaderTab
+          icon={faCalendarDays}
+          label="Summary"
+          active={$lastStatisticsTab$ === StatisticsTab.SUMMARY}
+          title={$lastStatisticsTab$ === StatisticsTab.SUMMARY
+            ? 'You are already on the Summary Tab'
+            : 'Switch to Summary Tab'}
+          on:click={() => ($lastStatisticsTab$ = StatisticsTab.SUMMARY)}
+        />
+        <HeaderTab
+          icon={faMap}
+          label="Heatmap"
+          active={$lastStatisticsTab$ === StatisticsTab.OVERVIEW}
+          title={$lastStatisticsTab$ === StatisticsTab.OVERVIEW
+            ? 'You are already on the Heatmap Tab'
+            : 'Switch to Heatmap Tab'}
+          on:click={() => ($lastStatisticsTab$ = StatisticsTab.OVERVIEW)}
+        />
+        <div class={headerDividerClasses} />
+        <HeaderIconButton
+          icon={faFilter}
+          title="Open Title Filter Menu"
+          label="Filter"
+          disabled={!$statisticsTitleFilterEnabled$}
+          on:click={() => {
+            if ($statisticsTitleFilterEnabled$) {
+              $statisticsTitleFilterIsOpen$ = true;
+            }
+          }}
+        />
+        <HeaderIconButton
+          icon={faSliders}
+          title="Open Statistics Settings"
+          label="Statistics Settings"
+          on:click={() => (showStatisticsSettings = true)}
+        />
       </div>
-      <div
-        tabindex="0"
-        role="button"
-        title={$lastStatisticsTab$ === StatisticsTab.SUMMARY
-          ? 'You are already on the Summary Tab'
-          : 'Switch to Summary Tab'}
-        class={baseIconClasses}
-        class:bg-gray-900={$lastStatisticsTab$ === StatisticsTab.SUMMARY}
-        on:click={() => ($lastStatisticsTab$ = StatisticsTab.SUMMARY)}
-        on:keyup={dummyFn}
-      >
-        <Fa icon={faCalendarDays} />
+      <div class="flex">
+        <div class="relative transform-gpu">
+          <Popover
+            placement="bottom"
+            fallbackPlacements={['bottom-end', 'bottom-start']}
+            yOffset={0}
+            bind:this={copyStatisticsDataPopover}
+          >
+            <div title="Copy Data in TMW Log Format" slot="icon" class={labelIconClasses}>
+              <Fa icon={faCopy} class="text-sm xl:text-xs" />
+              <span>Copy&nbsp;▾</span>
+            </div>
+            <div class="flex flex-col justify-center w-36 bg-gray-700" slot="content">
+              {#each copyStatisticsDataItems as copyStatisticsDataItem (copyStatisticsDataItem.key)}
+                <button
+                  class="p-2 hover:bg-white hover:text-gray-700"
+                  on:click={() => {
+                    copyStatisticsData$.next(copyStatisticsDataItem.key);
+                    copyStatisticsDataPopover.toggleOpen();
+                  }}
+                >
+                  {copyStatisticsDataItem.label}
+                </button>
+              {/each}
+            </div>
+          </Popover>
+        </div>
+        <div class={headerDividerClasses} />
+        <HeaderNavTabs />
       </div>
-      <div
-        tabindex="0"
-        role="button"
-        title={$lastStatisticsTab$ === StatisticsTab.OVERVIEW
-          ? 'You are already on the Heatmap Tab'
-          : 'Switch to Heatmap Tab'}
-        class={baseIconClasses}
-        class:bg-gray-900={$lastStatisticsTab$ === StatisticsTab.OVERVIEW}
-        on:click={() => ($lastStatisticsTab$ = StatisticsTab.OVERVIEW)}
-        on:keyup={dummyFn}
-      >
-        <Fa icon={faMap} />
-      </div>
-      <div
-        tabindex="0"
-        role="button"
-        title="Open Title Filter Menu"
-        class={baseIconClasses}
-        style:cursor={$statisticsTitleFilterEnabled$ ? 'pointer' : 'not-allowed'}
-        on:click={() => {
-          if (!$statisticsTitleFilterEnabled$) {
-            return;
-          }
-
-          $statisticsTitleFilterIsOpen$ = true;
-        }}
-        on:keyup={dummyFn}
-      >
-        <Fa icon={faFilter} />
-      </div>
-      <div
-        tabindex="0"
-        role="button"
-        title="Open Statistics Settings"
-        class={baseIconClasses}
-        on:click={() => (showStatisticsSettings = true)}
-        on:keyup={dummyFn}
-      >
-        <Fa icon={faSliders} />
-      </div>
-      {#if currentBookId}
-        <svg
-          tabindex="0"
-          role="button"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          class={baseIconClasses}
-          on:click={() => goto(`${pagePath}/b?id=${currentBookId}`)}
-          on:keyup={dummyFn}
-        >
-          <path
-            class="fill-current"
-            d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5zm-3.5-8c.88 0 1.73.09 2.5.26V9.24c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99zM13 12.49v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26V11.9c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.3-4.5.83zm4.5 1.84c-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26v-1.52c-.79-.16-1.64-.24-2.5-.24z"
-          />
-        </svg>
-      {/if}
-      <MergedHeaderIcon items={[mergeEntries.SETTINGS, mergeEntries.MANAGE]} />
     </div>
   </div>
 </div>

--- a/src/lib/css-classes.ts
+++ b/src/lib/css-classes.ts
@@ -8,7 +8,6 @@ export const baseHeaderClasses = 'relative h-12 bg-gray-700 text-white xl:h-10';
 export const pHeaderMat = 'p-2.5';
 export const pxScreen = 'px-4 md:px-8 lg:max-w-4xl xl:max-w-none 2xl:max-w-6xl mx-auto';
 export const opacityHeaderIcon = 'opacity-60 hover:opacity-100 transition-opacity';
-export const pHeaderFa = 'p-4 xl:p-3';
 export const nTranslateXHeaderFa = '-translate-x-4 xl:-translate-x-3';
 export const translateXHeaderFa = 'translate-x-4 xl:translate-x-3';
 export const inputClasses =
@@ -16,3 +15,5 @@ export const inputClasses =
 export const buttonClasses =
   'inline-block no-underline font-medium rounded min-w-[32px] sm:min-w-[64px] px-4 leading-9 cursor-pointer text-cyan-900';
 export const baseIconClasses = `flex justify-center select-none items-center h-12 w-12 cursor-pointer text-xl xl:h-10 xl:w-10 xl:text-lg ${pHeaderMat} ${opacityHeaderIcon}`;
+export const labelIconClasses = `flex flex-col items-center justify-center h-12 xl:h-10 min-w-16 px-2 cursor-pointer select-none text-center text-xs xl:text-[10px] ${opacityHeaderIcon}`;
+export const headerDividerClasses = 'mx-1 h-6 w-px self-center bg-white/30';

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -1649,7 +1649,6 @@
         showReaderImageGallery = true;
       }}
       on:settingsClick={() => leaveReader(mergeEntries.SETTINGS.routeId, false)}
-      on:domainHintClick={onDomainHintClick}
       on:bookManagerClick={() => leaveReader(mergeEntries.MANAGE.routeId)}
     />
   </div>

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -7,7 +7,6 @@
   import BookExportDialog from '$lib/components/book-export/book-export-dialog.svelte';
   import ConfirmDialog from '$lib/components/confirm-dialog.svelte';
   import LogReportDialog from '$lib/components/log-report-dialog.svelte';
-  import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
   import MessageDialog from '$lib/components/message-dialog.svelte';
   import { preFilteredTitlesForStatistics$ } from '$lib/components/statistics/statistics-types';
   import { pxScreen } from '$lib/css-classes';
@@ -357,12 +356,6 @@
     });
   }
 
-  function backToCurrentBook() {
-    const currentBookId = $currentBookId$;
-    if (!currentBookId) return;
-    gotoBook(currentBookId);
-  }
-
   async function removeBooks(bookIds: number[]) {
     if (!operationAllowed()) {
       return;
@@ -650,7 +643,6 @@
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
   <BookManagerHeader
-    hasBookOpened={!!$currentBookId$}
     selectedCount={selectedBookIds.size}
     hasBooks={!!$bookCards$?.length}
     {cancelTooltip}
@@ -659,23 +651,14 @@
     {replicationProgressRemaining}
     bind:selectMode
     on:selectAllClick={onSelectAllBooks}
-    on:backToBookClick={backToCurrentBook}
     on:removeClick={() => removeBooks(Array.from(selectedBookIds))}
     on:filesChange={(ev) => onFilesChange(ev.detail)}
-    on:domainHintClick={onDomainHintClick}
     on:bugReportClick={onBugReportClick}
     on:cancelReplication={() => {
       if (!cancelSignal.aborted) {
         cancelToken.abort();
         replicationProgressRemaining = 'Canceling ...';
       }
-    }}
-    on:selectionToStatistics={() => {
-      $preFilteredTitlesForStatistics$ = new Set(
-        $bookCards$.filter((card) => selectedBookIds.has(card.id)).map((book) => book.title)
-      );
-
-      goto(`${pagePath}${mergeEntries.STATISTICS.routeId}`);
     }}
     on:deleteStatistics={onDeleteStatistics}
     on:replicateData={onReplicateData}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { tap } from 'rxjs';
-  import { afterNavigate } from '$app/navigation';
   import SettingsContent from '$lib/components/settings/settings-content.svelte';
   import SettingsHeader from '$lib/components/settings/settings-header.svelte';
   import { pxScreen } from '$lib/css-classes';
@@ -69,8 +68,6 @@
     readingGoalsMergeMode$,
     hideSpoilerImageMode$
   } from '$lib/data/store';
-  import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
-  import { pagePath } from '$lib/data/env';
   import { storage } from '$lib/data/window/navigator/storage';
   import { formatPageTitle } from '$lib/functions/format-page-title';
   import { writableSubject } from '$lib/functions/svelte/store';
@@ -85,17 +82,9 @@
     setStorageQuota();
   });
 
-  let prevPage = `${pagePath}${mergeEntries.MANAGE.routeId}`;
-
   let activeSettings = 'Reader';
 
   let storageQuota = '';
-
-  afterNavigate((navigation) => {
-    const { from } = navigation;
-    if (!from) return;
-    prevPage = `${from.url.pathname}${from.url.search}`;
-  });
 
   const setPersistentStorage$ = persistentStorage$.pipe(
     tap((value) => {
@@ -139,7 +128,7 @@
 </svelte:head>
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
-  <SettingsHeader leavePageLink={prevPage} bind:activeSettings />
+  <SettingsHeader bind:activeSettings />
 </div>
 
 <div class="{pxScreen} h-full pt-16 xl:pt-14">

--- a/src/routes/statistics/+page.svelte
+++ b/src/routes/statistics/+page.svelte
@@ -10,7 +10,6 @@
   } from '$lib/components/statistics/statistics-types';
   import { pxScreen } from '$lib/css-classes';
   import {
-    database,
     lastStartDayOfWeek$,
     lastStatisticsEndDate$,
     lastStatisticsRangeTemplate$,
@@ -24,15 +23,9 @@
     getStartHoursDate
   } from '$lib/functions/statistic-util';
   import { clickOutside } from '$lib/functions/use-click-outside';
-  import { map, share } from 'rxjs';
   import { onDestroy, tick } from 'svelte';
   import { quintInOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
-
-  const currentBookId$ = database.lastItem$.pipe(
-    map((item) => item?.dataId),
-    share()
-  );
 
   let showStatisticsSettings = false;
 
@@ -125,7 +118,7 @@
   }
 </script>
 
-<StatisticsHeader currentBookId={$currentBookId$} bind:showStatisticsSettings />
+<StatisticsHeader bind:showStatisticsSettings />
 
 <div class="{pxScreen} flex flex-col pt-16 h-full xl:pt-14">
   <StatisticsContent />


### PR DESCRIPTION
Add text labels to all header icon buttons, with glyphs to distinguish button types (▾ for dropdowns, ↗ for navigation).

Reorganize headers: action buttons on the left, dropdowns + navigation on the right, separated by dividers. Extract Jump, Images, and Issue Report from MergedHeaderIcon into standalone action buttons.

Replace MergedHeaderIcon navigation with a shared HeaderNavTabs component showing Book, Statistics, Settings, and Manager as tab-styled buttons with active/hover states.

Create shared HeaderTab and HeaderIconButton components. Add a disabled prop to HeaderIconButton for not-allowed cursor state. Migrate statistics filter button to use HeaderIconButton.

Remove unused merge entries (JUMP_TO_POSITION,
READER_IMAGE_GALLERY, DOMAIN_HINT), unused pHeaderFa CSS class, and unused disableRouteNavigation prop.

Redesign selection interface: show Select button persistently with full opacity when active, display count inline, and always show Select All.