### PR TITLE
Fix click offset in settings header tabs

### DIFF
--- a/src/lib/components/header-tab.svelte
+++ b/src/lib/components/header-tab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+  import Ripple from '$lib/components/ripple.svelte';
   import Fa from 'svelte-fa';
 
   export let icon: IconDefinition;
@@ -18,5 +19,5 @@
 >
   <Fa class="mb-0.5" {icon} />
   {label}
-  <slot />
+  <Ripple />
 </button>

--- a/src/lib/components/settings/settings-header.svelte
+++ b/src/lib/components/settings/settings-header.svelte
@@ -2,7 +2,6 @@
   import { faBookOpenReader, faClock, faDatabase } from '@fortawesome/free-solid-svg-icons';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import HeaderTab from '$lib/components/header-tab.svelte';
-  import Ripple from '$lib/components/ripple.svelte';
   import { baseHeaderClasses, pxScreen } from '$lib/css-classes';
 
   export let activeSettings: string;
@@ -32,9 +31,7 @@
           label={settingItem.label}
           active={activeSettings === settingItem.label}
           on:click={() => (activeSettings = settingItem.label)}
-        >
-          <Ripple />
-        </HeaderTab>
+        />
       {/each}
     </div>
     <div class="flex">


### PR DESCRIPTION
Svelte's string interpolation in class attributes was stripping Ripple's dynamically-added classes on active state change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)