### PR TITLE
Fix incorrect label-input associations

### DIFF
--- a/src/lib/components/book-export/book-export-selection.svelte
+++ b/src/lib/components/book-export/book-export-selection.svelte
@@ -73,7 +73,7 @@
       value="audioBook"
       bind:group={dataToReplicate}
     />
-    <label for="bookstatistic">Audiobook</label>
+    <label for="audioBook">Audiobook</label>
   </div>
   <div>
     <input
@@ -83,6 +83,6 @@
       value="subtitle"
       bind:group={dataToReplicate}
     />
-    <label for="bookstatistic">Subtitles</label>
+    <label for="subtitle">Subtitles</label>
   </div>
 </div>

--- a/src/lib/components/settings/settings-storage-source.svelte
+++ b/src/lib/components/settings/settings-storage-source.svelte
@@ -268,7 +268,7 @@
       <input id="cbx-source" type="checkbox" bind:checked={storageSourceIsSyncTarget} />
       <label for="cbx-source" class="ml-2 mr-6">Is Sync Target</label>
       <input id="cbx-manager" type="checkbox" bind:checked={storageSourceIsSourceDefault} />
-      <label for="cbx-source" class="ml-2">Is Source Default</label>
+      <label for="cbx-manager" class="ml-2">Is Source Default</label>
     </div>
     <select
       class="my-4"


### PR DESCRIPTION
Three copy-paste errors where label `for` attributes pointed at the wrong input `id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)