### PR TITLE
[codex] Migrate to the latest svelte-gestures API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "path-browserify": "1.0.1",
         "rxjs": "7.8.2",
         "svelte-fa": "4.0.4",
-        "svelte-gestures": "^5.1.4",
+        "svelte-gestures": "^5.2.2",
         "svelte-meta-tags": "^4.5.2",
         "ua-parser-js": "2.0.9"
       },
@@ -5821,9 +5821,9 @@
       }
     },
     "node_modules/svelte-gestures": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/svelte-gestures/-/svelte-gestures-5.1.4.tgz",
-      "integrity": "sha512-gfSO/GqWLu9nRMCz12jqdyA0+NTsojYcIBcRqZjwWrpQbqMXr0zWPFpZBtzfYbRHtuFxZImMZp9MrVaFCYbhDg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/svelte-gestures/-/svelte-gestures-5.2.2.tgz",
+      "integrity": "sha512-Y+chXPaSx8OsPoFppUwPk8PJzgrZ7xoDJKXeiEc7JBqyKKzXer9hlf8F9O34eFuAWB4/WQEvccACvyBplESL7A==",
       "license": "MIT"
     },
     "node_modules/svelte-meta-tags": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "path-browserify": "1.0.1",
     "rxjs": "7.8.2",
     "svelte-fa": "4.0.4",
-    "svelte-gestures": "^5.1.4",
+    "svelte-gestures": "^5.2.2",
     "svelte-meta-tags": "^4.5.2",
     "ua-parser-js": "2.0.9"
   },

--- a/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -34,7 +34,7 @@
     throttleTime
   } from 'rxjs';
   import Fa from 'svelte-fa';
-  import { swipe } from 'svelte-gestures';
+  import { useSwipe, type SwipeCustomEvent } from 'svelte-gestures';
   import type { BookmarkManager, PageManager } from '../types';
   import { BookmarkManagerPaginated } from './bookmark-manager-paginated';
   import { PageManagerPaginated } from './page-manager-paginated';
@@ -653,7 +653,7 @@
     }
   }
 
-  function onSwipe(ev: CustomEvent<{ direction: 'top' | 'right' | 'left' | 'bottom' }>) {
+  function onSwipe(ev: SwipeCustomEvent) {
     if (!concretePageManager || $skipKeyDownListener$) return;
     if (ev.detail.direction !== 'left' && ev.detail.direction !== 'right') return;
     const swipeLeft = ev.detail.direction === 'left';
@@ -750,8 +750,11 @@
   class:ttu-apply-justification={enableTextJustification}
   class:ttu-text-wrap-pretty={enableTextWrapPretty}
   class="book-content m-auto"
-  use:swipe={() => ({ timeframe: 500, minSwipeDistance: $swipeThreshold$, touchAction: 'pan-y' })}
-  onswipe={onSwipe}
+  {...useSwipe(onSwipe, () => ({
+    timeframe: 500,
+    minSwipeDistance: $swipeThreshold$,
+    touchAction: 'pan-y'
+  }))}
 >
   <div class="book-content-container" id={currentSectionId || null} bind:this={contentEl}>
     {@html displayedHtml}


### PR DESCRIPTION
## What changed

- upgraded `svelte-gestures` from `^5.1.4` to `^5.2.2`
- regenerated `package-lock.json` for the new published package
- migrated the paginated reader from the legacy `use:swipe` + `onswipe` action pattern to the current attachment-style `useSwipe(...)` API
- switched the swipe handler to the library's exported `SwipeCustomEvent` type

## Why

`svelte-gestures` 5.2.x changed its public API materially: the current library uses attachment helpers such as `useSwipe(...)` instead of the older action-style pattern that the codebase still had in place. This PR moves the one live gesture usage onto the current idiom so the dependency upgrade matches the actual runtime API.

## Impact

- swipe-based page turning in the paginated reader continues to work
- the code now matches the current `svelte-gestures` API expected by the latest package
- there were no other live `svelte-gestures` usages left to migrate

## Validation

- `npm run build`
- `npm run check:types` still reports pre-existing unrelated repo-wide TypeScript errors; no new `svelte-gestures` issues were introduced by this change
