### PR TITLE
[codex] Fix reader build a11y and SSR warnings

### DIFF
--- a/src/lib/components/book-reader/book-reader-image-gallery/book-reader-image-gallery.svelte
+++ b/src/lib/components/book-reader/book-reader-image-gallery/book-reader-image-gallery.svelte
@@ -155,32 +155,35 @@
     <div class="flex flex-col overflow-auto p-2">
       {#each $readerImageGalleryPictures$ as readerImageGalleryPicture, urlIndex (readerImageGalleryPicture.url)}
         {@const showSpoiler = $hideSpoilerImage$ && !readerImageGalleryPicture.unspoilered}
-        <button
-          class="flex justify-center my-4"
-          class:spoiler={showSpoiler}
-          data-image-index={urlIndex}
-          onclick={() => {
-            if (window.matchMedia('(min-width: 1024px)').matches) {
-              selectedImageIndex = urlIndex;
-            }
-          }}
-        >
-          <img
-            src={readerImageGalleryPicture.url}
-            alt="galleryImage"
-            class="max-h-96 lg:max-h-64"
-          />
+        <div class="relative my-4 flex justify-center" class:spoiler={showSpoiler}>
+          <button
+            class="flex justify-center"
+            data-image-index={urlIndex}
+            title="Preview image"
+            aria-label={`Preview image ${urlIndex + 1}`}
+            onclick={() => {
+              if (window.matchMedia('(min-width: 1024px)').matches) {
+                selectedImageIndex = urlIndex;
+              }
+            }}
+          >
+            <img
+              src={readerImageGalleryPicture.url}
+              alt={`Gallery image ${urlIndex + 1}`}
+              class="max-h-96 lg:max-h-64"
+            />
+          </button>
           {#if showSpoiler}
             <button
-              title="Show Image"
+              title="Show image"
+              aria-label={`Reveal gallery image ${urlIndex + 1}`}
               class="spoiler-label"
-              aria-hidden="true"
               onclick={() => toggleGalleryPictureSpoiler(readerImageGalleryPicture.url)}
             >
               ネタバレ
             </button>
           {/if}
-        </button>
+        </div>
       {/each}
     </div>
   </div>
@@ -204,9 +207,9 @@
           <img class="max-h-[94vh]" src={selectedImage.url} alt="currentImage" />
           {#if showSpoiler}
             <button
-              title="Show Image"
+              title="Show image"
               class="spoiler-label"
-              aria-hidden="true"
+              aria-label={`Reveal gallery image ${selectedImageIndex + 1}`}
               onclick={() => toggleGalleryPictureSpoiler(selectedImage.url)}
             >
               ネタバレ

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -1607,7 +1607,11 @@
 
 {$collectReaderImageGallerySpoilerToggles$ ?? ''}
 {$handleUpdateImageGalleryPictureSpoilers$ ?? ''}
-<button class="fixed inset-x-0 top-0 z-10 h-8 w-full" onclick={() => (showHeader = true)}></button>
+<button
+  class="fixed inset-x-0 top-0 z-10 h-8 w-full"
+  aria-label="Show reader header"
+  onclick={() => (showHeader = true)}
+></button>
 {#if showHeader}
   <div
     class="elevation-4 writing-horizontal-tb fixed inset-x-0 top-0 z-10 w-full"
@@ -1812,12 +1816,14 @@
 {#if $enableTapEdgeToFlip$ && isPaginated && !$skipKeyDownListener$}
   <button
     class="fixed left-0 z-10 w-5"
+    aria-label={$verticalMode$ ? 'Next page' : 'Previous page'}
     onclick={$verticalMode$ ? () => pageManager?.nextPage() : () => pageManager?.prevPage()}
     style:height={tapButtonHeight}
     style:top={tapButtonTop}
   ></button>
   <button
     class="fixed right-0 z-10 w-5"
+    aria-label={$verticalMode$ ? 'Previous page' : 'Next page'}
     onclick={$verticalMode$ ? () => pageManager?.prevPage() : () => pageManager?.nextPage()}
     style:height={tapButtonHeight}
     style:top={tapButtonTop}


### PR DESCRIPTION
## Summary
- add explicit accessible labels to the reader's invisible tap targets so Svelte no longer emits build-time a11y warnings
- restructure image gallery thumbnail spoiler controls so the reveal button is no longer nested inside the thumbnail button during SSR
- preserve the existing preview and spoiler-reveal behavior while avoiding hydration mismatch risk

## Root Cause
The build warnings came from unlabeled button tap targets in the reader page and invalid nested `<button>` markup in the image gallery, which SSR can serialize differently from the browser's repaired DOM.

## Validation
- `npm run build`

Closes #22.