### PR TITLE
[codex] Hook statistics filter labels to checkboxes

### DIFF
--- a/src/lib/components/statistics/statistics-title-filter.svelte
+++ b/src/lib/components/statistics/statistics-title-filter.svelte
@@ -254,8 +254,10 @@
         style:grid-auto-rows={`${statisticsTitleFilterBaseRowRem}rem`}
         style:row-gap={`${statisticsTitleFilterBaseRowGap}rem`}
       >
-        {#each currentTitlesToFilterRows as currentTitlesToFilterRow (currentTitlesToFilterRow.title)}
+        {#each currentTitlesToFilterRows as currentTitlesToFilterRow, rowIndex (currentTitlesToFilterRow.title)}
+          {@const checkboxId = `statistics-title-filter-${currentStatisticsTitleFilterPage}-${rowIndex}`}
           <input
+            id={checkboxId}
             type="checkbox"
             bind:checked={currentTitlesToFilterRow.isSelected}
             onchange={() => {
@@ -264,13 +266,14 @@
               }
             }}
           />
-          <div
+          <label
+            for={checkboxId}
             class="line-clamp-3"
             class:opacity-50={!titlesInStatisticsDateRange.has(currentTitlesToFilterRow.title)}
             title={currentTitlesToFilterRow.title}
           >
             {currentTitlesToFilterRow.title}
-          </div>
+          </label>
         {/each}
       </div>
     {:else}


### PR DESCRIPTION
## Summary
- connect each statistics title filter row label to its checkbox with a generated `id`/`for` pair
- keep the existing grid layout and filtering behavior unchanged while making the title text clickable
- use stable per-page row ids so the label toggles the visible checkbox reliably

## Root Cause
The statistics title filter rendered each checkbox next to a plain `div`, so the visible book title text was not associated with the checkbox control.

## Validation
- `npm run build`

Closes #21.