### PR TITLE
[codex] Stabilize type checking and validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npx eslint .
+      - name: Check
+        run: npm run check
 
-      - name: Test build
+      - name: Build
         run: npm run build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "eslint.validate": ["javascript", "svelte", "typescript"]
+  "eslint.validate": ["javascript", "svelte", "typescript"],
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "prepare": "husky && svelte-kit sync",
-    "check": "eslint --fix-dry-run .",
-    "check:pretty": "prettier --debug-check .",
+    "check": "npm run check:lint && npm run check:format && npm run check:types",
+    "check:lint": "eslint .",
+    "check:format": "prettier --check .",
     "check:types": "svelte-check --tsconfig ./tsconfig.json",
     "lint": "eslint --fix .",
     "format": "prettier --write ."

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,6 @@
 /// <reference types="@sveltejs/kit" />
+/// <reference types="wicg-file-system-access" />
+/// <reference types="webappsec-credential-management" />
 
 // See https://kit.svelte.dev/docs/types#the-app-namespace
 // for information about these interfaces

--- a/src/lib/components/book-card/book-card-list.svelte
+++ b/src/lib/components/book-card/book-card-list.svelte
@@ -22,7 +22,7 @@
     onremoveBookClick
   }: Props = $props();
 
-  let hoveringBookId: number | undefined = $state(undefined);
+  let hoveringBookId = $state<number>();
 
   function onBookCardClick(id: number) {
     onbookClick?.({ id });

--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -101,12 +101,12 @@
     { label: 'Browser', key: StorageKey.BROWSER, requiresConnectivity: false }
   ];
 
-  let fileImportElm: HTMLElement = $state(undefined!);
-  let folderImportElm: HTMLElement = $state(undefined!);
-  let backupImportElm: HTMLElement = $state(undefined!);
-  let countImportElm: HTMLInputElement = $state(undefined!);
-  let storageSourceElm: Popover = $state(undefined!);
-  let sortOptionsElm: Popover = $state(undefined!);
+  let fileImportElm = $state<HTMLElement>();
+  let folderImportElm = $state<HTMLElement>();
+  let backupImportElm = $state<HTMLElement>();
+  let countImportElm = $state<HTMLInputElement>();
+  let storageSourceElm = $state<Popover>();
+  let sortOptionsElm = $state<Popover>();
   let showLoadCount = $state(false);
 
   if (browser) {
@@ -162,15 +162,15 @@
   function triggerInput(target: string) {
     switch (target) {
       case mergeEntries.FOLDER_IMPORT.label:
-        folderImportElm.click();
+        folderImportElm?.click();
         break;
 
       case mergeEntries.BACKUP_IMPORT.label:
-        backupImportElm.click();
+        backupImportElm?.click();
         break;
 
       default:
-        fileImportElm.click();
+        fileImportElm?.click();
         break;
     }
   }
@@ -209,7 +209,7 @@
       });
     }
 
-    sortOptionsElm.toggleOpen();
+    sortOptionsElm?.toggleOpen();
   }
 </script>
 
@@ -425,7 +425,7 @@
                           storageSource$.next(sourceMenuItem.key);
                         }
 
-                        storageSourceElm.toggleOpen();
+                        storageSourceElm?.toggleOpen();
                       }}
                       onkeyup={dummyFn}
                     >
@@ -512,7 +512,7 @@
           {#if showLoadCount}
             <button
               style:color={!!$fileCountData$ ? 'red' : null}
-              onclick={() => countImportElm.click()}>C</button
+              onclick={() => countImportElm?.click()}>C</button
             >
           {/if}
         {/if}

--- a/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -139,9 +139,9 @@
 
   let allowDisplay = $state(false);
 
-  let contentEl: HTMLElement | undefined = $state();
+  let contentEl = $state<HTMLElement>();
 
-  let calculator: CharacterStatsCalculator | undefined = $state();
+  let calculator = $state<CharacterStatsCalculator>();
 
   let contentReadyEvent = $state({});
 
@@ -151,7 +151,7 @@
 
   let pageManagerConcrete: PageManagerContinuous | undefined;
 
-  let bookmarkPos: BookmarkPosData | undefined = $state();
+  let bookmarkPos = $state<BookmarkPosData>();
 
   let scrollWhenReady: boolean;
 
@@ -220,8 +220,9 @@
   // Same pattern as paginated's displayedHtml watcher.
   $effect(() => {
     if (!contentEl || !htmlContent) return;
+    const el = contentEl;
     scrollWhenReady = true;
-    untrack(() => initContent(contentEl));
+    untrack(() => initContent(el));
   });
 
   // When calculator, width, height, or loadingState change, trigger content display change

--- a/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -125,17 +125,17 @@
     ontrackerPause
   }: Props = $props();
 
-  let scrollEl: HTMLElement | undefined = $state();
+  let scrollEl = $state<HTMLElement>();
 
-  let contentEl: HTMLElement | undefined = $state();
+  let contentEl = $state<HTMLElement>();
 
-  let calculator: SectionCharacterStatsCalculator | undefined = $state();
+  let calculator = $state<SectionCharacterStatsCalculator>();
 
   let sections: Element[] = $state([]);
 
-  let concretePageManager: PageManagerPaginated | undefined = $state();
+  let concretePageManager = $state<PageManagerPaginated>();
 
-  let concreteBookmarkManager: BookmarkManagerPaginated | undefined = $state();
+  let concreteBookmarkManager = $state<BookmarkManagerPaginated>();
 
   let scrollWhenReady: boolean = $state(false);
 
@@ -151,11 +151,11 @@
 
   let isBookmarkScreen = $state(false);
 
-  let bookmarkTopAdjustment: string | undefined = $state();
+  let bookmarkTopAdjustment = $state<string>();
 
-  let bookmarkLeftAdjustment: string | undefined = $state();
+  let bookmarkLeftAdjustment = $state<string>();
 
-  let bookmarkRightAdjustment: string | undefined = $state();
+  let bookmarkRightAdjustment = $state<string>();
 
   let fontLoadingAdded = false;
 
@@ -236,14 +236,17 @@
   // Create/recreate PageManager and BookmarkManager when dependencies change
   $effect(() => {
     if (contentEl && scrollEl && sections && calculator) {
+      const content = contentEl;
+      const scroll = scrollEl;
+      const sectionCalculator = calculator;
       // Read tracked deps
       const w = width;
       const h = height;
       const vm = verticalMode;
       untrack(() => {
         concretePageManager = new PageManagerPaginated(
-          contentEl,
-          scrollEl,
+          content,
+          scroll,
           sections,
           sectionIndex$,
           virtualScrollPos$,
@@ -257,7 +260,7 @@
         onpagemanagerchange?.(concretePageManager);
 
         concreteBookmarkManager = new BookmarkManagerPaginated(
-          calculator,
+          sectionCalculator,
           concretePageManager,
           sectionReady$,
           sectionIndex$,

--- a/src/lib/components/book-reader/book-reader.svelte
+++ b/src/lib/components/book-reader/book-reader.svelte
@@ -135,7 +135,7 @@
 
   let visibilityState: DocumentVisibilityState = $state('hidden');
 
-  let containerEl: HTMLElement | undefined = $state();
+  let containerEl = $state<HTMLElement>();
 
   const mutationObserver: MutationObserver = new MutationObserver(handleMutation);
 

--- a/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte
+++ b/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte
@@ -279,7 +279,7 @@
   let currentReadingGoalStart = $state('');
   let currentReadingGoalEnd = $state('');
   let remainingTimeInReadingGoalWindow = $state('');
-  let currentReadingGoal: ReadingGoal | undefined = $state(undefined);
+  let currentReadingGoal = $state<ReadingGoal>();
   let currentTimeGoal = $state(0);
   let currentCharacterGoal = $state(0);
   let statistics = new Map<string, BooksDbStatistic>();
@@ -299,14 +299,14 @@
   );
   let bookCompletionStatistics:
     | Omit<BooksDbStatistic, 'title' | 'lastStatisticModified'>
-    | undefined = $state(undefined);
+    | undefined = $state<Omit<BooksDbStatistic, 'title' | 'lastStatisticModified'>>();
   let bookStartDate = $state(initSnapshot.todayKey);
   let timeToFinishBook = $state('N/A');
   let lastExploredCharCount = $state(initSnapshot.exploredCharCount);
   let previousLastExploredCharCount = $state(0);
   let trackingHistory: TrackingHistory[] = $state([]);
   let historyIndex = 0;
-  let autoScrollerStatistics: BooksDbStatistic | undefined = $state(undefined);
+  let autoScrollerStatistics = $state<BooksDbStatistic>();
   let autoScrollerTimer$: Observable<''> | undefined;
   let lastExploredCharCountScroller = initSnapshot.exploredCharCount;
   let statisticsToStore = $state(new Set<string>());

--- a/src/lib/components/merged-header-icon/merged-header-icon.svelte
+++ b/src/lib/components/merged-header-icon/merged-header-icon.svelte
@@ -25,7 +25,7 @@
     actionItems.length === 1 && actionItems[0].routeId ? actionItems[0].routeId : ''
   );
 
-  let menuElm: Popover = $state(undefined!);
+  let menuElm = $state<Popover>();
 
   function handleActionMenuItem(target: string) {
     onaction?.(target);
@@ -33,7 +33,7 @@
     if (
       !(target === mergeEntries.FILE_IMPORT.label || target === mergeEntries.FOLDER_IMPORT.label)
     ) {
-      menuElm.toggleOpen();
+      menuElm?.toggleOpen();
     }
 
     const action = actionItems.find((item) => item.label === target);

--- a/src/lib/components/popover/popover.svelte
+++ b/src/lib/components/popover/popover.svelte
@@ -44,9 +44,9 @@
     content: contentSnippet
   }: Props = $props();
 
-  let contentElement: HTMLElement = $state();
-  let iconElement: HTMLElement = $state();
-  let popoverElement: HTMLElement = $state();
+  let contentElement = $state<HTMLElement>();
+  let iconElement = $state<HTMLElement>();
+  let popoverElement = $state<HTMLElement>();
 
   let id: symbol;
   let instance: Instance;
@@ -76,16 +76,23 @@
     isOpen = !isOpen;
     await tick();
 
-    if (isOpen && instance) {
-      instance.state.elements.reference = getTargetElement(referenceElement);
-      instance.state.elements.popper = popoverElement;
+    const targetElement = getTargetElement(referenceElement);
+    const popperElement = popoverElement;
+
+    if (!isOpen || !targetElement || !popperElement) {
+      return;
+    }
+
+    if (instance) {
+      instance.state.elements.reference = targetElement;
+      instance.state.elements.popper = popperElement;
       await instance.update().catch(() => {
         // no-op
       });
       await tick();
       onopen?.();
-    } else if (isOpen) {
-      instance = createPopper(getTargetElement(referenceElement), popoverElement, {
+    } else {
+      instance = createPopper(targetElement, popperElement, {
         placement,
         modifiers: [
           flip,
@@ -151,8 +158,8 @@
     };
   }
 
-  function getTargetElement(referenceElement?: HTMLElement | Event) {
-    let targetElement;
+  function getTargetElement(referenceElement?: HTMLElement | Event): HTMLElement | undefined {
+    let targetElement: HTMLElement | undefined;
 
     if (referenceElement instanceof HTMLElement) {
       targetElement = referenceElement;

--- a/src/lib/components/ripple.svelte
+++ b/src/lib/components/ripple.svelte
@@ -10,7 +10,7 @@
   let hold = $state(false);
   let focus = $state(false);
 
-  let containerEl: HTMLElement | undefined = $state();
+  let containerEl = $state<HTMLElement>();
 
   let listeners: {
     el: HTMLElement;
@@ -21,30 +21,26 @@
   let target = $derived(containerEl?.parentElement);
 
   $effect(() => {
-    if (target) {
-      target.classList.add('relative', 'overflow-hidden');
-      const el = target;
-      addListener(el, 'focusin', () => queueMicrotask(() => (focus = true)));
-      addListener(el, 'focusout', () => queueMicrotask(() => (focus = false)));
-      addListener(el, 'mouseenter', () => queueMicrotask(() => (focus = true)));
-      addListener(el, 'mouseleave', () =>
-        queueMicrotask(() => {
-          hold = false;
-          focus = false;
-        })
-      );
-      addListener(el, 'mousedown', (ev) =>
-        queueMicrotask(() => createRippleFromMouseEvent(ev, el))
-      );
-      addListener(el, 'mouseup', () => queueMicrotask(() => (hold = false)));
-      addListener(el, 'touchstart', (ev) =>
-        queueMicrotask(() => createRippleFromTouchEvent(ev, el))
-      );
-      addListener(el, 'touchend', () => queueMicrotask(() => (hold = false)));
-      addListener(el, 'touchcancel', () => queueMicrotask(() => (hold = false)));
+    if (!target) return;
 
-      return () => clearEventListeners();
-    }
+    target.classList.add('relative', 'overflow-hidden');
+    const el = target;
+    addListener(el, 'focusin', () => queueMicrotask(() => (focus = true)));
+    addListener(el, 'focusout', () => queueMicrotask(() => (focus = false)));
+    addListener(el, 'mouseenter', () => queueMicrotask(() => (focus = true)));
+    addListener(el, 'mouseleave', () =>
+      queueMicrotask(() => {
+        hold = false;
+        focus = false;
+      })
+    );
+    addListener(el, 'mousedown', (ev) => queueMicrotask(() => createRippleFromMouseEvent(ev, el)));
+    addListener(el, 'mouseup', () => queueMicrotask(() => (hold = false)));
+    addListener(el, 'touchstart', (ev) => queueMicrotask(() => createRippleFromTouchEvent(ev, el)));
+    addListener(el, 'touchend', () => queueMicrotask(() => (hold = false)));
+    addListener(el, 'touchcancel', () => queueMicrotask(() => (hold = false)));
+
+    return () => clearEventListeners();
   });
 
   function addListener<K extends keyof HTMLElementEventMap>(
@@ -94,7 +90,7 @@
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  function animateRipple(node: HTMLElement, params: any) {
+  function animateRipple(node: HTMLElement, params?: any) {
     return {
       delay: 0,
       duration: 400,

--- a/src/lib/components/settings/settings-custom-theme.svelte
+++ b/src/lib/components/settings/settings-custom-theme.svelte
@@ -57,7 +57,7 @@
 
   let themeToCopy = $state(init.existingThemes[0].id);
   let themeName = $state('');
-  let themeNameElm: HTMLInputElement = $state();
+  let themeNameElm = $state<HTMLInputElement>();
 
   let themeStyle = $derived(
     `color: ${customTheme.fontColor.rgbaExpression}; background-color: ${customTheme.backgroundColor.rgbaExpression}`
@@ -143,6 +143,10 @@
   }
 
   function handleSave() {
+    if (!themeNameElm) {
+      return;
+    }
+
     themeNameElm.setCustomValidity('');
 
     if (!themeName) {

--- a/src/lib/components/settings/settings-font-selector.svelte
+++ b/src/lib/components/settings/settings-font-selector.svelte
@@ -12,7 +12,7 @@
 
   let { availableFonts = [LocalFont.NOTOSANSJP], fontValue = $bindable('') }: Props = $props();
 
-  let element: Popover = $state(undefined!);
+  let element = $state<Popover>();
 </script>
 
 <Popover bind:this={element} placement="bottom">
@@ -30,7 +30,7 @@
           class="px-4 py-2 hover:bg-gray-900"
           onclick={() => {
             fontValue = font;
-            element.toggleOpen();
+            element?.toggleOpen();
           }}
           onkeyup={dummyFn}
         >

--- a/src/lib/components/settings/settings-storage-source.svelte
+++ b/src/lib/components/settings/settings-storage-source.svelte
@@ -62,10 +62,10 @@
     encryptionDisabled: configuredEncryptionDisabled || false
   }));
 
-  let containerElm: HTMLElement = $state();
-  let nameElm: HTMLInputElement = $state();
-  let pwElm: HTMLInputElement = $state();
-  let pwConfirmElm: HTMLInputElement = $state();
+  let containerElm = $state<HTMLElement>();
+  let nameElm = $state<HTMLInputElement>();
+  let pwElm = $state<HTMLInputElement>();
+  let pwConfirmElm = $state<HTMLInputElement>();
   let error = $state('');
   const passwordManagerAvailable = 'PasswordCredential' in window;
   const storageSourceRefreshToken = init.refreshToken;
@@ -75,7 +75,7 @@
   let storageSourceType = $state(init.type);
   let storageSourceClientId = $state(init.clientId);
   let storageSourceClientSecret = $state(init.clientSecret);
-  let directoryHandle: FileSystemDirectoryHandle | undefined = $state(init.directoryHandle);
+  let directoryHandle = $state<FileSystemDirectoryHandle | undefined>(init.directoryHandle);
   let handleFsPath = $state(init.fsPath);
   let storageSourceStoredInManager = $state(init.storedInManager);
   let storageSourceEncryptionDisabled = $state(init.encryptionDisabled);
@@ -95,11 +95,15 @@
   });
 
   $effect(() => {
-    setInitialPassword(pwElm);
+    if (pwElm) {
+      setInitialPassword(pwElm);
+    }
   });
 
   $effect(() => {
-    setInitialPassword(pwConfirmElm);
+    if (pwConfirmElm) {
+      setInitialPassword(pwConfirmElm);
+    }
   });
 
   async function selectDirectory() {
@@ -129,24 +133,36 @@
   async function save() {
     resetCustomValidity();
 
+    const container = containerElm;
+    const nameInput = nameElm;
+    const passwordInput = pwElm;
+    const confirmPasswordInput = pwConfirmElm;
+
+    if (!container || !nameInput || !passwordInput || !confirmPasswordInput) {
+      return;
+    }
+
     if (
-      ![...containerElm.querySelectorAll('input')].every((elm) => {
+      ![...container.querySelectorAll('input')].every((elm) => {
         let isValid = elm.reportValidity();
 
         if (!isValid) {
           return false;
         }
 
-        if (elm === nameElm) {
+        if (elm === nameInput) {
           if (storageSourceType === StorageKey.FS && !directoryHandle) {
-            nameElm.setCustomValidity('You need to select a directory');
+            nameInput.setCustomValidity('You need to select a directory');
             isValid = false;
           } else if (isAppDefault(storageSourceName)) {
-            nameElm.setCustomValidity('Please select a different name');
+            nameInput.setCustomValidity('Please select a different name');
             isValid = false;
           }
-        } else if (elm === pwConfirmElm && pwElm.value !== pwConfirmElm.value) {
-          pwConfirmElm.setCustomValidity('Password does not match');
+        } else if (
+          elm === confirmPasswordInput &&
+          passwordInput.value !== confirmPasswordInput.value
+        ) {
+          confirmPasswordInput.setCustomValidity('Password does not match');
           isValid = false;
         }
 
@@ -172,7 +188,7 @@
             new PasswordCredential({
               id: storageSourceName,
               name: `${storageSourceName} (${storageSourceType})`,
-              password: pwConfirmElm.value
+              password: confirmPasswordInput.value
             })
           )
           .catch(({ message }: any) => {
@@ -215,7 +231,7 @@
               clientSecret: storageSourceClientSecret,
               refreshToken: invalidateToken ? '' : storageSourceRefreshToken
             }),
-            pwConfirmElm.value
+            confirmPasswordInput.value
           );
         }
       }
@@ -268,7 +284,7 @@
 
   function resetCustomValidity() {
     error = '';
-    nameElm.setCustomValidity('');
+    nameElm?.setCustomValidity('');
     pwConfirmElm?.setCustomValidity('');
   }
 
@@ -379,8 +395,13 @@
             onchange={() => {
               if (storageSourceEncryptionDisabled) {
                 storageSourceStoredInManager = false;
-                pwElm.value = '';
-                pwConfirmElm.value = '';
+                if (pwElm) {
+                  pwElm.value = '';
+                }
+
+                if (pwConfirmElm) {
+                  pwConfirmElm.value = '';
+                }
               }
             }}
           />

--- a/src/lib/components/settings/settings-user-font-add.svelte
+++ b/src/lib/components/settings/settings-user-font-add.svelte
@@ -13,9 +13,9 @@
 
   let { isLoading = $bindable(), fontCache }: Props = $props();
 
-  let fileElement: HTMLInputElement = $state(undefined!);
+  let fileElement = $state<HTMLInputElement>();
   let fontName = $state('');
-  let fontFile: File | undefined = $state();
+  let fontFile = $state<File>();
   let currentError = $state('no error');
 
   let canSave = $derived(!!fontName && !!fontFile && currentError === 'no error');
@@ -59,7 +59,10 @@
   }
 
   function resetFileElement() {
-    fileElement.value = '';
+    if (fileElement) {
+      fileElement.value = '';
+    }
+
     fontFile = undefined;
   }
 

--- a/src/lib/components/settings/settings-user-font-dialog.svelte
+++ b/src/lib/components/settings/settings-user-font-dialog.svelte
@@ -22,7 +22,7 @@
   let isLoading = $state(false);
   let cacheLoaded = $state(false);
   let currentTab = $state('Stored');
-  let fontCache: Cache | undefined = $state();
+  let fontCache = $state<Cache>();
 
   onMount(async () => {
     try {

--- a/src/lib/components/statistics/statistics-header.svelte
+++ b/src/lib/components/statistics/statistics-header.svelte
@@ -37,7 +37,7 @@
     { key: 'charactersRead', label: 'Characters Read' }
   ];
 
-  let copyStatisticsDataPopover: Popover = $state(undefined!);
+  let copyStatisticsDataPopover = $state<Popover>();
 </script>
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
@@ -102,7 +102,7 @@
                     class="p-2 hover:bg-white hover:text-gray-700"
                     onclick={() => {
                       copyStatisticsData$.next(copyStatisticsDataItem.key);
-                      copyStatisticsDataPopover.toggleOpen();
+                      copyStatisticsDataPopover?.toggleOpen();
                     }}
                   >
                     {copyStatisticsDataItem.label}

--- a/src/lib/components/statistics/statistics-summary/statistics-summary-header.svelte
+++ b/src/lib/components/statistics/statistics-summary/statistics-summary-header.svelte
@@ -41,7 +41,7 @@
   const tableHeaderClasses =
     'flex items-center py-2.5 px-0 text-sm w-full bg-transparent border-0 md:border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200 peer lg:text-base';
 
-  let summaryHeaderPopover: Popover = $state();
+  let summaryHeaderPopover = $state<Popover>();
 
   let optionKeys = $derived(
     new Set<keyof BookStatistic>((options || []).map((option) => option.key))
@@ -74,7 +74,7 @@
               onclick={(e) => {
                 e.stopPropagation();
                 onpropertyChange?.({ property: option.key, statisticsSummaryKey });
-                summaryHeaderPopover.toggleOpen();
+                summaryHeaderPopover?.toggleOpen();
               }}
             >
               {option.label}

--- a/src/lib/components/statistics/statistics-summary/statistics-summary.svelte
+++ b/src/lib/components/statistics/statistics-summary/statistics-summary.svelte
@@ -60,16 +60,16 @@
   let renderFullStatisticsSummaryTable = $state(
     window && window.matchMedia('(min-width: 768px)').matches
   );
-  let statisticsSummaryTableContainerElm: HTMLElement = $state(undefined!);
-  let statisticsSummaryPopover: Popover = $state(undefined!);
-  let statisticsSummaryButtonContainer: HTMLElement = $state(undefined!);
+  let statisticsSummaryTableContainerElm = $state<HTMLElement>();
+  let statisticsSummaryPopover = $state<Popover>();
+  let statisticsSummaryButtonContainer = $state<HTMLElement>();
   let statisticsSummaryGridRowMod = $state(0);
   let currentStatisticsSummaryPage = $state(1);
   let rowsPerStatisticsSummaryPage = $state(0);
   const statisticsSummaryPageRefs: HTMLButtonElement[] = $state([]);
-  let statisticsSummaryPagesContainer: HTMLElement = $state(undefined!);
+  let statisticsSummaryPagesContainer = $state<HTMLElement>();
   let statisticsSummaryPopoverDetails: string[] = $state([]);
-  let rowInEdit: BookStatistic | undefined = $state(undefined);
+  let rowInEdit = $state<BookStatistic>();
   let rowInEditTime = $state(0);
   let rowInEditCharacters = $state(0);
   let rowInEditResetMinMaxValues = $state(false);
@@ -238,19 +238,27 @@
 
   function updateRowsPerPage() {
     tick().then(() => {
-      rowsPerStatisticsSummaryPage = renderFullStatisticsSummaryTable
-        ? Math.max(
-            1,
-            Math.ceil(
-              (getFullHeight(window, statisticsSummaryTableContainerElm) -
-                getFullHeight(window, statisticsSummaryButtonContainer, true)) /
-                convertRemToPixels(
-                  window,
-                  statisticsSummaryBaseRowRem + statisticsSummaryBaseRowGap + 0.4
-                )
-            )
+      const tableContainer = statisticsSummaryTableContainerElm;
+      const buttonContainer = statisticsSummaryButtonContainer;
+
+      if (renderFullStatisticsSummaryTable) {
+        if (!tableContainer || !buttonContainer) {
+          return;
+        }
+
+        rowsPerStatisticsSummaryPage = Math.max(
+          1,
+          Math.ceil(
+            (getFullHeight(window, tableContainer) - getFullHeight(window, buttonContainer, true)) /
+              convertRemToPixels(
+                window,
+                statisticsSummaryBaseRowRem + statisticsSummaryBaseRowGap + 0.4
+              )
           )
-        : 1;
+        );
+      } else {
+        rowsPerStatisticsSummaryPage = 1;
+      }
 
       // Clamp page to valid range after rows-per-page changes
       const maxPages = Math.ceil(sortedData.length / rowsPerStatisticsSummaryPage);
@@ -450,7 +458,7 @@
 
             tick().then(() => {
               if (event.target instanceof HTMLElement) {
-                statisticsSummaryPopover.toggleOpen(event.target);
+                statisticsSummaryPopover?.toggleOpen(event.target);
               }
             });
           }}
@@ -486,7 +494,7 @@
 
               tick().then(() => {
                 if (event.target instanceof HTMLElement) {
-                  statisticsSummaryPopover.toggleOpen(event.target);
+                  statisticsSummaryPopover?.toggleOpen(event.target);
                 }
               });
             }}
@@ -520,7 +528,7 @@
 
               tick().then(() => {
                 if (event.target instanceof HTMLElement) {
-                  statisticsSummaryPopover.toggleOpen(event.target);
+                  statisticsSummaryPopover?.toggleOpen(event.target);
                 }
               });
             }}
@@ -547,7 +555,7 @@
 
               tick().then(() => {
                 if (event.target instanceof HTMLElement) {
-                  statisticsSummaryPopover.toggleOpen(event.target);
+                  statisticsSummaryPopover?.toggleOpen(event.target);
                 }
               });
             }}

--- a/src/lib/components/statistics/statistics-title-filter.svelte
+++ b/src/lib/components/statistics/statistics-title-filter.svelte
@@ -53,8 +53,8 @@
   const statisticsTitleFilterBaseRowRem = 4;
   const statisticsTitleFilterBaseRowGap = 2;
 
-  let statisticsTitleFilterTableContainerElm: HTMLElement = $state();
-  let statisticsTitleFilterButtonContainer: HTMLElement = $state();
+  let statisticsTitleFilterTableContainerElm = $state<HTMLElement>();
+  let statisticsTitleFilterButtonContainer = $state<HTMLElement>();
   let titleFilter = $state('');
   let titleFilterTimer: number | undefined;
   let titlesToFilter: StatisticsTitleFilterItem[] = $state([]);
@@ -140,11 +140,17 @@
 
   function updateStatisticsTitleFilterRowsPerPage(newPage?: number) {
     tick().then(() => {
+      const tableContainer = statisticsTitleFilterTableContainerElm;
+      const buttonContainer = statisticsTitleFilterButtonContainer;
+
+      if (!tableContainer || !buttonContainer) {
+        return;
+      }
+
       statisticsTitleFilterRowsPerPage = Math.max(
         1,
         Math.ceil(
-          (getFullHeight(window, statisticsTitleFilterTableContainerElm) -
-            getFullHeight(window, statisticsTitleFilterButtonContainer, true)) /
+          (getFullHeight(window, tableContainer) - getFullHeight(window, buttonContainer, true)) /
             convertRemToPixels(
               window,
               statisticsTitleFilterBaseRowRem + statisticsTitleFilterBaseRowGap + 0.4

--- a/src/lib/components/storage-unlock.svelte
+++ b/src/lib/components/storage-unlock.svelte
@@ -4,7 +4,7 @@
   import { buttonClasses } from '$lib/css-classes';
   import { decrypt, type StorageUnlockAction } from '$lib/data/storage/storage-source-manager';
   import { skipKeyDownListener$ } from '$lib/data/store';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
 
   interface Props {
     description: string;
@@ -28,13 +28,13 @@
     onclose
   }: Props = $props();
 
-  let containerElm: HTMLElement = $state();
-  let passwordElm: HTMLInputElement = $state();
+  let passwordElm = $state<HTMLInputElement>();
   let secret = $state('');
   let error = $state('');
+  let showErrorAnimation = $state(false);
 
   async function unlock() {
-    containerElm.classList.remove('error-animation');
+    showErrorAnimation = false;
     error = '';
 
     try {
@@ -47,10 +47,12 @@
         throw new Error('No data to unlock found');
       }
 
+      showErrorAnimation = false;
       closeDialog({ clientId: '', clientSecret: '' });
     } catch (err: any) {
       error = `Failed to unlock Data${err.message ? `: ${err.message}` : ''}`;
-      containerElm.classList.add('error-animation');
+      await tick();
+      showErrorAnimation = true;
     }
   }
 
@@ -72,7 +74,7 @@
 
 <DialogTemplate>
   {#snippet content()}
-    <div class="flex flex-col text-sm sm:text-base" bind:this={containerElm}>
+    <div class="flex flex-col text-sm sm:text-base" class:error-animation={showErrorAnimation}>
       <div>{description}</div>
       <div class="my-2">{action}</div>
       {#if requiresSecret}

--- a/src/lib/components/style-sheet-renderer.svelte
+++ b/src/lib/components/style-sheet-renderer.svelte
@@ -7,7 +7,7 @@
 
   let { styleSheet }: Props = $props();
 
-  let styleEl: HTMLStyleElement | undefined = $state();
+  let styleEl = $state<HTMLStyleElement>();
 
   $effect(() => {
     if (styleEl) {

--- a/src/lib/data/database/books-db/database.service.ts
+++ b/src/lib/data/database/books-db/database.service.ts
@@ -32,7 +32,7 @@ import { lastReadingGoalsModified$, readingGoal$, syncTarget$ } from '$lib/data/
 
 import type { BaseStorageHandler } from '$lib/data/storage/handler/base-handler';
 import type { BookStatistic } from '$lib/components/statistics/statistics-types';
-import type BooksDb from '$lib/data/database/books-db/versions/books-db';
+import type { BooksDb } from '$lib/data/database/books-db/versions/books-db';
 import type { IDBPDatabase } from 'idb';
 import LogReportDialog from '$lib/components/log-report-dialog.svelte';
 import { MergeMode } from '$lib/data/merge-mode';

--- a/src/lib/data/database/books-db/factory.ts
+++ b/src/lib/data/database/books-db/factory.ts
@@ -4,7 +4,7 @@
  * All rights reserved.
  */
 
-import type BooksDb from './versions/books-db';
+import type { BooksDb } from './versions/books-db';
 import { openDB } from 'idb';
 import upgradeBooksDbFromV2 from './versions/v2/upgrade';
 

--- a/src/lib/data/database/books-db/versions/books-db.ts
+++ b/src/lib/data/database/books-db/versions/books-db.ts
@@ -7,6 +7,7 @@
 import type BooksDbV6 from '$lib/data/database/books-db/versions/v6/books-db-v6';
 
 type BooksDb = BooksDbV6;
+export type { BooksDb };
 
 export type BooksDbBookData = BooksDb['data']['value'];
 export type BooksDbBookmarkData = BooksDb['bookmark']['value'];
@@ -18,5 +19,3 @@ export type BooksDbAudioBook = BooksDb['audioBook']['value'];
 export type BooksDbSubtitleData = BooksDb['subtitle']['value'];
 export type BooksDbHandle = BooksDb['handle']['value'];
 export const currentDbVersion = 6;
-
-export default BooksDb;

--- a/src/lib/data/database/books-db/versions/v2/upgrade.ts
+++ b/src/lib/data/database/books-db/versions/v2/upgrade.ts
@@ -6,8 +6,7 @@
 
 import type { IDBPDatabase, IDBPTransaction, StoreNames } from 'idb';
 
-import type BooksDb from '../books-db';
-import type { BooksDbBookData } from '../books-db';
+import type { BooksDb, BooksDbBookData } from '../books-db';
 import type BooksDbV2 from './books-db-v2';
 
 export default async function upgradeBooksDbFromV2(

--- a/src/lib/data/dialog-manager.ts
+++ b/src/lib/data/dialog-manager.ts
@@ -5,6 +5,7 @@
  */
 
 import type { StorageKey } from './storage/storage-types';
+import type { Component } from 'svelte';
 import { writableSubject } from '$lib/functions/svelte/store';
 
 export interface SyncSelection {
@@ -14,7 +15,7 @@ export interface SyncSelection {
 }
 
 export interface Dialog {
-  component: (new (...args: any[]) => any) | string;
+  component: Component<any> | string;
   props?: Record<string, any>;
   disableCloseOnClick?: boolean;
   zIndex?: string;

--- a/src/lib/data/storage/handler/base-handler.ts
+++ b/src/lib/data/storage/handler/base-handler.ts
@@ -447,11 +447,15 @@ export abstract class BaseStorageHandler {
 
     if (data instanceof Blob) {
       await zipWriter.add(name, new BlobReader(data), {
-        onprogress: (...args) => this.reportFunction(...args)
+        onprogress: async (progress, total) => {
+          this.reportFunction(progress, total);
+        }
       });
     } else if (data) {
       await zipWriter.add(name, new TextReader(data), {
-        onprogress: (...args) => this.reportFunction(...args)
+        onprogress: async (progress, total) => {
+          this.reportFunction(progress, total);
+        }
       });
     }
 
@@ -486,18 +490,19 @@ export abstract class BaseStorageHandler {
     errorForNoRead: string,
     retrievedData: Entry,
     progressBase = 1
-  ) {
+  ): Promise<Blob | string> {
     this.currentLastProgressValue = 0;
     this.currentProgressBase = progressBase;
 
-    const zipData =
-      writer instanceof BlobWriter
-        ? await retrievedData.getData?.(writer, {
-            onprogress: (...args) => this.reportFunction(...args)
-          })
-        : await retrievedData.getData?.(writer, {
-            onprogress: (...args) => this.reportFunction(...args)
-          });
+    if (retrievedData.directory) {
+      throw new Error(errorForNoRead);
+    }
+
+    const zipData = await retrievedData.getData(writer, {
+      onprogress: async (progress, total) => {
+        this.reportFunction(progress, total);
+      }
+    });
 
     if (!zipData) {
       throw new Error(errorForNoRead);
@@ -614,7 +619,7 @@ export abstract class BaseStorageHandler {
   }
 
   protected async extractAsJSON(entry: Entry, errorMessage: string, progressBase = 0.9) {
-    if (!entry) {
+    if (!entry || entry.directory) {
       return undefined;
     }
 

--- a/src/lib/data/storage/storage-oauth-manager.ts
+++ b/src/lib/data/storage/storage-oauth-manager.ts
@@ -346,13 +346,13 @@ export class StorageOAuthManager {
     return token;
   }
 
-  private base64Url(buffer: ArrayBuffer) {
+  private base64Url(buffer: Uint8Array) {
     if (!this.parentWindow) {
       throw new Error('Parent window not defined');
     }
 
     return this.parentWindow
-      .btoa(String.fromCharCode(...new Uint8Array(buffer)))
+      .btoa(String.fromCharCode(...buffer))
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=+$/, '');
@@ -417,9 +417,11 @@ export class StorageOAuthManager {
 
         event.ports[0].postMessage({
           result: this.base64Url(
-            await this.parentWindow.crypto.subtle.digest(
-              'SHA-256',
-              new TextEncoder().encode(this.codeVerifier)
+            new Uint8Array(
+              await this.parentWindow.crypto.subtle.digest(
+                'SHA-256',
+                new TextEncoder().encode(this.codeVerifier)
+              )
             )
           )
         });

--- a/src/lib/data/storage/storage-source-manager.ts
+++ b/src/lib/data/storage/storage-source-manager.ts
@@ -20,7 +20,7 @@ import { storageSource$ } from '$lib/data/storage/storage-view';
 const saltByteLength = 16;
 const ivByteLength = 12;
 
-async function generateKey(window: Window, salt: Uint8Array, secret: string) {
+async function generateKey(window: Window, salt: Uint8Array<ArrayBuffer>, secret: string) {
   return window.crypto.subtle.deriveKey(
     {
       name: 'PBKDF2',
@@ -130,7 +130,7 @@ export async function unlockStorageData(
   if (storageSource && storageSource.type !== StorageKey.FS) {
     if (storageSource.storedInManager && storageSource.data instanceof ArrayBuffer) {
       const passwordCredential: PasswordCredential | undefined = await navigator.credentials
-        .get({ password: true })
+        .get({ password: true } as CredentialRequestOptions)
         .then((credentials) =>
           credentials instanceof PasswordCredential ? credentials : undefined
         )

--- a/src/lib/functions/file-loaders/epub/extract-epub.ts
+++ b/src/lib/functions/file-loaders/epub/extract-epub.ts
@@ -7,7 +7,7 @@
 import { BlobReader, BlobWriter, TextWriter, ZipReader } from '@zip.js/zip.js';
 import { isOPFType, type EpubContent, type EpubOPFContent } from './types';
 
-import type { Entry } from '@zip.js/zip.js';
+import type { Entry, FileEntry } from '@zip.js/zip.js';
 import { XMLParser } from 'fast-xml-parser';
 import initZipSettings from '../utils/init-zip-settings';
 import path from 'path-browserify';
@@ -28,7 +28,10 @@ export default async function extractEpub(blob: Blob) {
       return acc;
     }, {});
 
-    const containerXml = await fileMap['META-INF/container.xml'].getData!(new TextWriter());
+    const containerXml = await getFileEntry(
+      fileMap['META-INF/container.xml'],
+      'META-INF/container.xml'
+    ).getData(new TextWriter());
     const parser = new XMLParser({
       ignoreAttributes: false
     });
@@ -38,7 +41,9 @@ export default async function extractEpub(blob: Blob) {
 
     const contentOpfFilename = rootFile['@_full-path'];
 
-    const contentsXml = await fileMap[contentOpfFilename].getData!(new TextWriter());
+    const contentsXml = await getFileEntry(fileMap[contentOpfFilename], contentOpfFilename).getData(
+      new TextWriter()
+    );
     result[contentOpfFilename] = contentsXml;
 
     contentsDirectory = path.dirname(contentOpfFilename);
@@ -57,16 +62,15 @@ export default async function extractEpub(blob: Blob) {
           throw new Error(`item ${fileRelativePath} not found`);
         }
 
-        if (entry.getData && !entry.directory) {
-          let value: string | Blob;
-          const mediaType: string = item['@_media-type'];
-          if (mediaType.startsWith('image/')) {
-            value = await entry.getData(new BlobWriter(mediaType));
-          } else {
-            value = await entry.getData(new TextWriter());
-          }
-          result[fileRelativePath] = value;
+        const fileEntry = getFileEntry(entry, fileRelativePath);
+        let value: string | Blob;
+        const mediaType: string = item['@_media-type'];
+        if (mediaType.startsWith('image/')) {
+          value = await fileEntry.getData(new BlobWriter(mediaType));
+        } else {
+          value = await fileEntry.getData(new TextWriter());
         }
+        result[fileRelativePath] = value;
       })
     );
   }
@@ -77,4 +81,12 @@ export default async function extractEpub(blob: Blob) {
     contents,
     result
   };
+}
+
+function getFileEntry(entry: Entry | undefined, filename: string): FileEntry {
+  if (!entry || entry.directory) {
+    throw new Error(`${filename} not found`);
+  }
+
+  return entry;
 }

--- a/src/lib/functions/file-loaders/htmlz/extract-htmlz.ts
+++ b/src/lib/functions/file-loaders/htmlz/extract-htmlz.ts
@@ -23,20 +23,22 @@ export default async function extract(blob: Blob) {
   if (entries.length) {
     await Promise.all(
       entries.map(async (entry) => {
-        if (entry.getData && !entry.directory) {
-          let value: string | Blob;
-          switch (entry.filename) {
-            case 'index.html':
-            case 'metadata.opf':
-            case 'style.css':
-              value = await entry.getData(new TextWriter());
-              break;
-            default: {
-              value = await entry.getData(new BlobWriter(getMimeTypeFromName(entry.filename)));
-            }
-          }
-          result[entry.filename] = value;
+        if (entry.directory) {
+          return;
         }
+
+        let value: string | Blob;
+        switch (entry.filename) {
+          case 'index.html':
+          case 'metadata.opf':
+          case 'style.css':
+            value = await entry.getData(new TextWriter());
+            break;
+          default: {
+            value = await entry.getData(new BlobWriter(getMimeTypeFromName(entry.filename)));
+          }
+        }
+        result[entry.filename] = value;
       })
     );
   }

--- a/src/lib/types/fake-indexeddb-auto.d.ts
+++ b/src/lib/types/fake-indexeddb-auto.d.ts
@@ -1,0 +1,1 @@
+declare module 'fake-indexeddb/auto';

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -186,9 +186,9 @@
   let showFooter = $state(true);
   let exploredCharCount = $state(0);
   let bookCharCount = $state(0);
-  let autoScroller: AutoScroller | undefined = $state();
-  let bookmarkManager: BookmarkManager | undefined = $state();
-  let pageManager: PageManager | undefined = $state();
+  let autoScroller = $state<AutoScroller>();
+  let bookmarkManager = $state<BookmarkManager>();
+  let pageManager = $state<PageManager>();
   let bookmarkData: Promise<BooksDbBookmarkData | undefined> = $state(Promise.resolve(undefined));
   let customReadingPointTop = $state(-2);
   let customReadingPointLeft = $state(-2);
@@ -196,15 +196,15 @@
     $verticalMode$ ? $verticalCustomReadingPosition$ : $horizontalCustomReadingPosition$
   );
   let customReadingPointScrollOffset = $state(0);
-  let customReadingPointRange: Range | undefined = $state();
-  let lastSelectedRange: Range | undefined = $state();
+  let customReadingPointRange = $state<Range>();
+  let lastSelectedRange = $state<Range>();
   let lastSelectedRangeWasEmpty = $state(true);
   let isSelectingCustomReadingPoint = $state(false);
   let showCustomReadingPoint = $state(false);
   let localStorageHandler: BrowserStorageHandler;
   let dataToReplicate: StorageDataType[] = $state([]);
   let dataToReplicateQueue: StorageDataType[] = [];
-  let externalStorageHandler: BaseStorageHandler | undefined = $state();
+  let externalStorageHandler = $state<BaseStorageHandler>();
   let externalStorageErrors = $state(0);
   let isReplicating = $state(false);
   let storedExploredCharacter = 0;


### PR DESCRIPTION
## Summary

This PR stabilizes the repo's TypeScript and Svelte typing so the current codebase passes `svelte-check` cleanly and the same validation is enforced in CI and editors.

## What changed

- add a real aggregate `npm run check` script and update CI to run `check` and `build` separately
- replace ad hoc ambient DOM declarations with the installed web platform type packages, keeping only the local browser augmentations in `src/app.d.ts`
- normalize Svelte rune state declarations to the current `$state<Type>()` style for optional refs and similar state
- remove presentation-only DOM mutation in `storage-unlock` in favor of state-driven class bindings
- fix component and browser API typing across storage, dialog, database, reader, statistics, and settings code paths
- narrow zip entries before reading them so EPUB/HTMLZ loaders satisfy the newer zip.js type surface without relying on unchecked `getData!` calls
- add workspace VS Code settings so the editor uses the repo's TypeScript version for IntelliSense
- add fake-indexeddb ambient declarations needed by the current codebase

## Why

The branch started as a repo-wide typecheck cleanup, but it also tightened the developer workflow around those checks. Before this, editor and CI behavior could drift from `svelte-check`, and several areas of the codebase were relying on outdated or overly-loose typings.

## Validation

- `npm run check`
- `npm run build`

Closes #24