### PR TITLE
[codex] Break storage handler replication cycle

### DIFF
--- a/src/lib/data/storage/handler/base-handler.ts
+++ b/src/lib/data/storage/handler/base-handler.ts
@@ -18,7 +18,7 @@ import type { Section } from '$lib/data/database/books-db/versions/v4/books-db-v
 import { storageRootName } from '$lib/data/env';
 import { MergeMode } from '$lib/data/merge-mode';
 import { InternalStorageSources, type StorageKey } from '$lib/data/storage/storage-types';
-import { exporterVersion } from '$lib/functions/replication/replicator';
+import { exporterVersion } from '$lib/functions/replication/exporter-version';
 import { throwIfAborted } from '$lib/functions/replication/replication-error';
 import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
 import {

--- a/src/lib/functions/replication/exporter-version.ts
+++ b/src/lib/functions/replication/exporter-version.ts
@@ -1,0 +1,7 @@
+/**
+ * @license BSD-3-Clause
+ * Copyright (c) 2026, ッツ Reader Authors
+ * All rights reserved.
+ */
+
+export const exporterVersion = 1;

--- a/src/lib/functions/replication/replicator.ts
+++ b/src/lib/functions/replication/replicator.ts
@@ -21,8 +21,6 @@ import {
 } from '$lib/functions/replication/replication-progress';
 import pLimit from 'p-limit';
 
-export const exporterVersion = 1;
-
 export async function importData(
   document: Document,
   targetHandler: BaseStorageHandler,


### PR DESCRIPTION
## Summary

Break the runtime import cycle between storage handlers and the replication module.

## Root cause

`BaseStorageHandler` imported `exporterVersion` from `replicator.ts`, while `replicator.ts` imported `BackupStorageHandler`, which extends `BaseStorageHandler`.

That created this cycle:

- `base-handler -> replicator -> backup-handler -> base-handler`

During SSR evaluation, that could leave `BaseStorageHandler` undefined while `BackupStorageHandler` was being defined, causing requests such as `GET /manage` to fail with:

`Class extends value undefined is not a constructor or null`

## Fix

- move `exporterVersion` into a standalone `exporter-version.ts` module
- import that constant from `base-handler.ts`
- keep `replicator.ts` out of the storage-handler initialization path

## Validation

- `npm run check`
- `npm run build`
- verified a live dev-server request to `/manage` returns `200 OK`
