### PR TITLE
[codex] Fix heatmap month label layout

### DIFF
--- a/src/lib/components/statistics/statistics-heatmap/statistics-heatmap.svelte
+++ b/src/lib/components/statistics/statistics-heatmap/statistics-heatmap.svelte
@@ -1146,26 +1146,24 @@
     class="grid items-center overflow-x-auto py-1"
     style:grid-auto-columns={`${dayElementSize}px`}
     style:grid-auto-rows={`${dayElementSize}px`}
+    style:grid-template-rows={`${dayElementSize + 4}px repeat(7, ${dayElementSize}px)`}
     style:gap={`${heatmapGridGapValue}px`}
     style:margin={`0 ${heatmapDayMargins}px`}
     bind:this={heatmapElement}
   >
     {#each monthLabels as label (label.monthLabel)}
       <div
-        class="text-xs md:text-sm"
-        style:grid-row={'1/1'}
+        class="flex h-full items-end text-xs leading-none md:text-sm"
+        style:grid-row={'1/2'}
         style:grid-column={`${label.heatmapColumn}`}
-        style:height={`${dayElementSize}px`}
-        style:margin-bottom={`${dayElementSize}px`}
       >
         {label.monthLabel}
       </div>
     {/each}
     <div
       class="sticky left-0"
-      style:grid-row={'1/1'}
+      style:grid-row={'1/2'}
       style:grid-column={`1/3`}
-      style:height={`${dayElementSize * 2}px`}
       style:background-color={'var(--background-color)'}
     ></div>
     {#each dayLabels as dayLabel, index (dayLabel)}


### PR DESCRIPTION
## Summary
- reserve a slightly taller first grid row for the heatmap month labels
- keep the month labels confined to that top row and aligned to the bottom
- avoid overlapping or clipping the labels against the heatmap cells

## Why
The month labels at the top of the statistics heatmap were being clipped because they were rendered inside a row that was too short for the label text. Earlier layout attempts could also make the labels disappear or render behind the heatmap cells.

## Impact
The month labels such as `Jan`, `Feb`, and `Mar` now remain visible and fully readable without affecting the heatmap layout.

## Root Cause
The first grid row reused the same height as the day cells, which was not enough vertical space for the label text metrics.

## Validation
- `npm run check`
