### PR TITLE
[codex] simplify header popover menus

### DIFF
--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -2,6 +2,7 @@
   import { browser } from '$app/environment';
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
   import HeaderButton from '$lib/components/header-button.svelte';
+  import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import Popover from '$lib/components/popover/popover.svelte';
   import { baseHeaderClasses, headerDividerClasses, pxScreen } from '$lib/css-classes';
@@ -102,8 +103,6 @@
   let folderImportElm = $state<HTMLElement>();
   let backupImportElm = $state<HTMLElement>();
   let countImportElm = $state<HTMLInputElement>();
-  let storageSourceElm = $state<Popover>();
-  let sortOptionsElm = $state<Popover>();
   let showLoadCount = $state(false);
 
   if (browser) {
@@ -140,6 +139,13 @@
     );
   }
 
+  let storageSourceMenuOptions = $derived(
+    storageSourceMenuItems.map((sourceMenuItem) => ({
+      ...sourceMenuItem,
+      disabled: sourceMenuItem.requiresConnectivity && !$isOnline$
+    }))
+  );
+
   let sortMenuItems = $derived([
     ...($storageSource$ === StorageKey.BROWSER ? [{ property: 'id', label: 'Added (id)' }] : []),
     { property: 'title', label: 'Title' },
@@ -164,27 +170,6 @@
     } catch ({ message }: any) {
       console.error(`failed to read file: ${message}`);
     }
-  }
-
-  function changeSortOptions(clickedProperty: string, newDirection: SortDirection) {
-    const { property, direction } = $booklistSortOptions$[$storageSource$];
-
-    if (property !== clickedProperty || direction !== newDirection) {
-      booklistSortOptions$.next({
-        ...$booklistSortOptions$,
-        ...{
-          [$storageSource$]: {
-            property: clickedProperty as Exclude<
-              keyof BookCardProps,
-              'imagePath' | 'isPlaceholder'
-            >,
-            direction: newDirection
-          }
-        }
-      });
-    }
-
-    sortOptionsElm?.toggleOpen();
   }
 </script>
 
@@ -324,123 +309,112 @@
             in:scale={inAnimationParams}
             out:scale={outAnimationParams}
           >
-            <Popover
-              placement="bottom"
-              fallbackPlacements={['bottom-end', 'bottom-start']}
-              yOffset={0}
-              bind:this={storageSourceElm}
+            <HeaderMenuButton
+              title="Select storage source"
+              label="Storage Source"
+              items={storageSourceMenuOptions}
+              onselect={async (sourceMenuItem) => {
+                if (sourceMenuItem.key !== $storageSource$) {
+                  if (!$cacheStorageData$) {
+                    getStorageHandler(window, sourceMenuItem.key).clearData();
+                  }
+
+                  storageSource$.next(sourceMenuItem.key);
+                }
+              }}
             >
               {#snippet icon()}
                 {#key $storageIcon$}
-                  <HeaderButton title="Select storage source" label="Storage Source ▾">
-                    {#snippet icon()}
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox={$storageIcon$.viewBox}
-                        class="h-3.5 w-3.5 xl:h-3 xl:w-3"
-                      >
-                        <path class="fill-current" d={$storageIcon$.d} />
-                      </svg>
-                    {/snippet}
-                  </HeaderButton>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox={$storageIcon$.viewBox}
+                    class="h-3.5 w-3.5 xl:h-3 xl:w-3"
+                  >
+                    <path class="fill-current" d={$storageIcon$.d} />
+                  </svg>
                 {/key}
               {/snippet}
-              {#snippet content()}
-                <div class="w-28 bg-gray-700">
-                  {#each storageSourceMenuItems as sourceMenuItem (sourceMenuItem.key)}
-                    <button
-                      type="button"
-                      class="block w-full px-4 py-2 text-left text-sm hover:bg-white hover:text-gray-700"
-                      class:hover:bg-white={!sourceMenuItem.requiresConnectivity || $isOnline$}
-                      class:hover:text-gray-700={!sourceMenuItem.requiresConnectivity || $isOnline$}
-                      class:cursor-not-allowed={sourceMenuItem.requiresConnectivity && !$isOnline$}
-                      class:text-gray-500={sourceMenuItem.requiresConnectivity && !$isOnline$}
-                      disabled={sourceMenuItem.requiresConnectivity && !$isOnline$}
-                      onclick={async () => {
-                        if (sourceMenuItem.key !== $storageSource$) {
-                          if (!$cacheStorageData$) {
-                            getStorageHandler(window, sourceMenuItem.key).clearData();
-                          }
-
-                          storageSource$.next(sourceMenuItem.key);
-                        }
-
-                        storageSourceElm?.toggleOpen();
-                      }}
-                    >
-                      {sourceMenuItem.label}
-                    </button>
-                  {/each}
-                </div>
-              {/snippet}
-            </Popover>
+            </HeaderMenuButton>
           </div>
           <div
             class="relative transform-gpu"
             in:scale={inAnimationParams}
             out:scale={outAnimationParams}
           >
-            <Popover
-              placement="bottom"
-              fallbackPlacements={['bottom-end', 'bottom-start']}
-              yOffset={0}
-              bind:this={sortOptionsElm}
+            <HeaderMenuButton
+              title="Select sort options"
+              label="Sort"
+              faIcon={$booklistSortOptions$[$storageSource$].direction === SortDirection.ASC
+                ? faArrowDownShortWide
+                : faArrowDownWideShort}
+              items={sortMenuItems}
             >
-              {#snippet icon()}
-                <HeaderButton
-                  title="Select sort options"
-                  label="Sort ▾"
-                  faIcon={$booklistSortOptions$[$storageSource$].direction === SortDirection.ASC
-                    ? faArrowDownShortWide
-                    : faArrowDownWideShort}
-                />
-              {/snippet}
-              {#snippet content()}
-                <div class="w-44 bg-gray-700">
-                  {#each sortMenuItems as sortMenuItem (sortMenuItem.property)}
-                    {@const isCurrentSort =
-                      $booklistSortOptions$[$storageSource$].property === sortMenuItem.property}
-                    {@const isCurrentSortAsc =
-                      isCurrentSort &&
-                      $booklistSortOptions$[$storageSource$].direction === SortDirection.ASC}
-                    <div
-                      class="grid cursor-default grid-cols-[auto_auto_auto] text-sm hover:bg-white hover:text-gray-700"
-                      class:bg-white={isCurrentSort}
-                      class:text-gray-700={isCurrentSort}
-                      class:hover:opacity-70={isCurrentSort}
-                    >
-                      <button
-                        type="button"
-                        class="self-center justify-self-start"
-                        class:text-red-500={isCurrentSortAsc}
-                        class:hover:text-gray-700={isCurrentSortAsc}
-                        class:hover:text-red-500={!isCurrentSortAsc}
-                        onclick={() => {
-                          changeSortOptions(sortMenuItem.property, SortDirection.ASC);
-                        }}
-                      >
-                        <Fa icon={faSortUp} class="px-4" />
-                      </button>
-                      <div class="py-2">
-                        {sortMenuItem.label}
-                      </div>
-                      <button
-                        type="button"
-                        class="justify-self-end hover:text-red-500"
-                        class:text-red-500={isCurrentSort && !isCurrentSortAsc}
-                        class:hover:text-gray-700={isCurrentSort && !isCurrentSortAsc}
-                        class:hover:text-red-500={!isCurrentSort || isCurrentSortAsc}
-                        onclick={() => {
-                          changeSortOptions(sortMenuItem.property, SortDirection.DESC);
-                        }}
-                      >
-                        <Fa icon={faSortDown} class="mt-1 px-4" />
-                      </button>
-                    </div>
-                  {/each}
+              {#snippet item(sortMenuItem, close)}
+                {@const isCurrentSort =
+                  $booklistSortOptions$[$storageSource$].property === sortMenuItem.property}
+                {@const isCurrentSortAsc =
+                  isCurrentSort &&
+                  $booklistSortOptions$[$storageSource$].direction === SortDirection.ASC}
+                <div
+                  class="grid cursor-default grid-cols-[auto_auto_auto] text-sm hover:bg-white hover:text-gray-700"
+                  class:bg-white={isCurrentSort}
+                  class:text-gray-700={isCurrentSort}
+                  class:hover:opacity-70={isCurrentSort}
+                >
+                  <button
+                    type="button"
+                    class="self-center justify-self-start"
+                    class:text-red-500={isCurrentSortAsc}
+                    class:hover:text-gray-700={isCurrentSortAsc}
+                    class:hover:text-red-500={!isCurrentSortAsc}
+                    onclick={() => {
+                      booklistSortOptions$.next({
+                        ...$booklistSortOptions$,
+                        ...{
+                          [$storageSource$]: {
+                            property: sortMenuItem.property as Exclude<
+                              keyof BookCardProps,
+                              'imagePath' | 'isPlaceholder'
+                            >,
+                            direction: SortDirection.ASC
+                          }
+                        }
+                      });
+                      close();
+                    }}
+                  >
+                    <Fa icon={faSortUp} class="px-4" />
+                  </button>
+                  <div class="py-2">
+                    {sortMenuItem.label}
+                  </div>
+                  <button
+                    type="button"
+                    class="justify-self-end hover:text-red-500"
+                    class:text-red-500={isCurrentSort && !isCurrentSortAsc}
+                    class:hover:text-gray-700={isCurrentSort && !isCurrentSortAsc}
+                    class:hover:text-red-500={!isCurrentSort || isCurrentSortAsc}
+                    onclick={() => {
+                      booklistSortOptions$.next({
+                        ...$booklistSortOptions$,
+                        ...{
+                          [$storageSource$]: {
+                            property: sortMenuItem.property as Exclude<
+                              keyof BookCardProps,
+                              'imagePath' | 'isPlaceholder'
+                            >,
+                            direction: SortDirection.DESC
+                          }
+                        }
+                      });
+                      close();
+                    }}
+                  >
+                    <Fa icon={faSortDown} class="mt-1 px-4" />
+                  </button>
                 </div>
               {/snippet}
-            </Popover>
+            </HeaderMenuButton>
           </div>
           <div class={headerDividerClasses}></div>
           {#if showLoadCount}

--- a/src/lib/components/book-reader/book-reader-header.svelte
+++ b/src/lib/components/book-reader/book-reader-header.svelte
@@ -12,8 +12,8 @@
   } from '@fortawesome/free-solid-svg-icons';
   import { readerImageGalleryPictures$ } from '$lib/components/book-reader/book-reader-image-gallery/book-reader-image-gallery';
   import HeaderButton from '$lib/components/header-button.svelte';
+  import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
-  import Popover from '$lib/components/popover/popover.svelte';
   import {
     baseHeaderClasses,
     headerDividerClasses,
@@ -75,13 +75,6 @@
     { label: 'Set Point', action: onsetCustomReadingPoint },
     ...(hasCustomReadingPoint ? [{ label: 'Reset Point', action: onresetCustomReadingPoint }] : [])
   ]);
-
-  let customReadingPointMenuElm: Popover = $state(undefined as any);
-
-  function dispatchCustomReadingPointAction(action: (() => void) | undefined) {
-    action?.();
-    customReadingPointMenuElm.toggleOpen();
-  }
 </script>
 
 <div class="flex justify-between px-4 md:px-8 {baseHeaderClasses}">
@@ -150,29 +143,13 @@
 
   <div class="flex transform-gpu {translateXHeaderFa}">
     {#if $customReadingPointEnabled$ || $viewMode$ === ViewMode.Paginated}
-      <Popover
-        placement="bottom"
-        fallbackPlacements={['bottom-end', 'bottom-start']}
-        yOffset={0}
-        bind:this={customReadingPointMenuElm}
-      >
-        {#snippet icon()}
-          <HeaderButton faIcon={faCrosshairs} title="Open custom point actions" label="Point ▾" />
-        {/snippet}
-        {#snippet content()}
-          <div class="w-40 bg-gray-700 md:w-32">
-            {#each customReadingPointMenuItems as actionItem (actionItem.label)}
-              <button
-                type="button"
-                class="block w-full px-4 py-2 text-left text-sm hover:bg-white hover:text-gray-700"
-                onclick={() => dispatchCustomReadingPointAction(actionItem.action)}
-              >
-                {actionItem.label}
-              </button>
-            {/each}
-          </div>
-        {/snippet}
-      </Popover>
+      <HeaderMenuButton
+        faIcon={faCrosshairs}
+        title="Open custom point actions"
+        label="Point"
+        items={customReadingPointMenuItems}
+        onselect={(actionItem) => actionItem.action?.()}
+      />
       <div class={headerDividerClasses}></div>
     {/if}
     <HeaderNavTabs

--- a/src/lib/components/header-menu-button.svelte
+++ b/src/lib/components/header-menu-button.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+  import HeaderButton from '$lib/components/header-button.svelte';
+  import Popover from '$lib/components/popover/popover.svelte';
+  import type { Snippet } from 'svelte';
+
+  interface Props<T> {
+    faIcon?: IconDefinition;
+    label: string;
+    title?: string;
+    items?: T[];
+    onselect?: (item: T) => void | Promise<void>;
+    icon?: Snippet;
+    item?: Snippet<[T, () => void]>;
+  }
+
+  let {
+    faIcon,
+    label,
+    title,
+    items = [],
+    onselect,
+    icon: iconSnippet,
+    item
+  }: Props<any> = $props();
+
+  let popover = $state<Popover>();
+
+  function closeMenu() {
+    popover?.toggleOpen();
+  }
+
+  async function handleSelect(itemToSelect: any) {
+    if (itemToSelect.disabled) {
+      return;
+    }
+
+    await onselect?.(itemToSelect);
+    closeMenu();
+  }
+</script>
+
+<Popover
+  placement="bottom"
+  fallbackPlacements={['bottom-end', 'bottom-start']}
+  yOffset={0}
+  bind:this={popover}
+>
+  {#snippet icon()}
+    <HeaderButton {faIcon} {title} label={`${label} ▾`} icon={iconSnippet} />
+  {/snippet}
+  {#snippet content()}
+    <div class="inline-flex flex-col bg-gray-700">
+      {#each items as menuItem}
+        {#if item}
+          {@render item(menuItem, closeMenu)}
+        {:else}
+          <button
+            type="button"
+            class="w-full px-4 py-2 text-left text-sm whitespace-nowrap hover:bg-white hover:text-gray-700"
+            class:cursor-not-allowed={menuItem.disabled}
+            class:text-gray-500={menuItem.disabled}
+            class:hover:bg-white={!menuItem.disabled}
+            class:hover:text-gray-700={!menuItem.disabled}
+            disabled={menuItem.disabled}
+            title={menuItem.title}
+            onclick={() => handleSelect(menuItem)}
+          >
+            {menuItem.label}
+          </button>
+        {/if}
+      {/each}
+    </div>
+  {/snippet}
+</Popover>

--- a/src/lib/components/statistics/statistics-header.svelte
+++ b/src/lib/components/statistics/statistics-header.svelte
@@ -7,8 +7,8 @@
     faSliders
   } from '@fortawesome/free-solid-svg-icons';
   import HeaderButton from '$lib/components/header-button.svelte';
+  import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
-  import Popover from '$lib/components/popover/popover.svelte';
   import {
     StatisticsTab,
     copyStatisticsData$,
@@ -29,8 +29,6 @@
     { key: 'readingTime', label: 'Reading Time' },
     { key: 'charactersRead', label: 'Characters Read' }
   ];
-
-  let copyStatisticsDataPopover = $state<Popover>();
 </script>
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
@@ -77,32 +75,14 @@
         />
       </div>
       <div class="flex">
-        <Popover
-          placement="bottom"
-          fallbackPlacements={['bottom-end', 'bottom-start']}
-          yOffset={0}
-          bind:this={copyStatisticsDataPopover}
-        >
-          {#snippet icon()}
-            <HeaderButton faIcon={faCopy} title="Copy data in TMW log format" label="Copy ▾" />
-          {/snippet}
-          {#snippet content()}
-            <div class="flex w-36 flex-col justify-center bg-gray-700">
-              {#each copyStatisticsDataItems as copyStatisticsDataItem (copyStatisticsDataItem.key)}
-                <button
-                  type="button"
-                  class="p-2 hover:bg-white hover:text-gray-700"
-                  onclick={() => {
-                    copyStatisticsData$.next(copyStatisticsDataItem.key);
-                    copyStatisticsDataPopover?.toggleOpen();
-                  }}
-                >
-                  {copyStatisticsDataItem.label}
-                </button>
-              {/each}
-            </div>
-          {/snippet}
-        </Popover>
+        <HeaderMenuButton
+          faIcon={faCopy}
+          title="Copy data in TMW log format"
+          label="Copy"
+          items={copyStatisticsDataItems}
+          onselect={(copyStatisticsDataItem) =>
+            copyStatisticsData$.next(copyStatisticsDataItem.key)}
+        />
         <div class={headerDividerClasses}></div>
         <HeaderNavTabs />
       </div>


### PR DESCRIPTION
## Summary

This refactors the remaining header popover menus around a shared `HeaderMenuButton` wrapper built on top of `Popover` and `HeaderButton`.

It simplifies the top-bar call sites for the reader point menu, statistics copy menu, and manager storage menu, while keeping the sort menu as the one intentional custom case.

## What Changed

- add `HeaderMenuButton` as the shared header popover trigger and menu wrapper
- move the reader `Point` menu onto the shared path
- move the statistics `Copy` menu onto the shared path
- move the manager `Storage Source` and `Sort` menus onto the shared path
- make the default menu body infer its width from its contents instead of per-caller width classes
- support disabled default menu items so storage source can use the simple `items + onselect` path
- keep the sort menu on a custom item snippet because its grid row layout is genuinely different

## Why

The previous `Popover` call sites still had too many moving parts:

- repeated trigger snippets
- repeated menu wrapper markup
- repeated close-on-select plumbing
- repeated row button styling

This keeps `Popover` as the low-level primitive, but gives header menus a higher-level API that matches how they are actually used in the app.

## Validation

- `npm run check:types`
