### PR TITLE
Overhaul statistics book filter dialog

### DIFF
--- a/src/lib/components/statistics/statistics-content.svelte
+++ b/src/lib/components/statistics/statistics-content.svelte
@@ -19,7 +19,6 @@
     copyStatisticsData$,
     statisticsTitleFilterEnabled$,
     statisticsTitleFilterIsOpen$,
-    type StatisticsTitleFilterItem,
     preFilteredTitlesForStatistics$,
     statisticsDataAggregrationModes,
     exportStatisticsData$,
@@ -259,7 +258,8 @@
 
   let isLoading = $state(true);
   let todayKey = $state(getDateString(getStartHoursDate($startDayHoursForTracker$)));
-  let statisticsTitleFilters = $state(new Map<string, boolean>());
+  let titleFilterSelections: [string, boolean][] = $state([]);
+  let statisticsTitleFilters = $derived(new Map(titleFilterSelections));
   let titlesInStatisticsDateRange = $state(new Set<string>());
   let statisticsData: BookStatistic[] = $state([]);
   let statisticsForSelection: BookStatistic[] = $state([]);
@@ -272,6 +272,7 @@
 
   $effect(() => {
     if (
+      statisticsTitleFilters &&
       $lastPrimaryReadingDataAggregationMode$ &&
       $lastStatisticsStartDate$ &&
       $lastStatisticsEndDate$
@@ -399,44 +400,25 @@
         return true;
       });
 
-      const preFilteredTitlesForStatistics = [...$preFilteredTitlesForStatistics$];
+      const filteredEntries = [...filterMap.entries()];
+      const titleFilters = [...notDeletedMap.entries()];
+      const newStatisticsTitleFilterData = new Map<string, boolean>();
 
-      for (let index = 0, { length } = preFilteredTitlesForStatistics; index < length; index += 1) {
-        const preFilteredTitleForStatistics = preFilteredTitlesForStatistics[index];
+      for (let index = 0, { length } = filteredEntries; index < length; index += 1) {
+        const [title, hasData] = filteredEntries[index];
 
-        if (
-          filterMap.has(preFilteredTitleForStatistics) &&
-          !filterMap.get(preFilteredTitleForStatistics)
-        ) {
-          statisticsTitleFilters.delete(preFilteredTitleForStatistics);
-          $preFilteredTitlesForStatistics$.delete(preFilteredTitleForStatistics);
+        if (hasData) {
+          newStatisticsTitleFilterData.set(title, true);
         }
       }
 
-      if ($preFilteredTitlesForStatistics$.size) {
-        statisticsTitleFilters = statisticsTitleFilters;
-        $preFilteredTitlesForStatistics$ = $preFilteredTitlesForStatistics$;
-      } else {
-        const filteredEntries = [...filterMap.entries()];
-        const titleFilters = [...notDeletedMap.entries()];
-        const newStatisticsTitleFilterData = new Map<string, boolean>();
+      for (let index = 0, { length } = titleFilters; index < length; index += 1) {
+        const [title, isDisplayed] = titleFilters[index];
 
-        for (let index = 0, { length } = filteredEntries; index < length; index += 1) {
-          const [title, hasData] = filteredEntries[index];
-
-          if (hasData) {
-            newStatisticsTitleFilterData.set(title, true);
-          }
-        }
-
-        for (let index = 0, { length } = titleFilters; index < length; index += 1) {
-          const [title, isDisplayed] = titleFilters[index];
-
-          newStatisticsTitleFilterData.set(title, isDisplayed);
-        }
-
-        statisticsTitleFilters = newStatisticsTitleFilterData;
+        newStatisticsTitleFilterData.set(title, isDisplayed);
       }
+
+      titleFilterSelections = [...newStatisticsTitleFilterData.entries()];
 
       updateStatisticsData();
       $statisticsActionInProgress$ = false;
@@ -517,40 +499,6 @@
     }
   }
 
-  function updateTitleFilter(newStatisticsTitleFilters: StatisticsTitleFilterItem[]) {
-    const newStatisticsTitleFilterData = new Map<string, boolean>();
-
-    for (let index = 0, { length } = newStatisticsTitleFilters; index < length; index += 1) {
-      const newStatisticsTitleFilter = newStatisticsTitleFilters[index];
-
-      newStatisticsTitleFilterData.set(
-        newStatisticsTitleFilter.title,
-        newStatisticsTitleFilter.isSelected
-      );
-    }
-
-    statisticsTitleFilters = newStatisticsTitleFilterData;
-
-    updateStatisticsData();
-  }
-
-  function clearPrefilter() {
-    const newStatisticsTitleFilterData = new Map<string, boolean>();
-
-    for (let index = 0, { length } = statisticsData; index < length; index += 1) {
-      const statistic = statisticsData[index];
-
-      if (statistic.readingTime) {
-        newStatisticsTitleFilterData.set(statistic.title, true);
-      }
-    }
-
-    statisticsTitleFilters = newStatisticsTitleFilterData;
-    $preFilteredTitlesForStatistics$ = new Set();
-
-    updateStatisticsData();
-  }
-
   function toggleStatisticsRangeTemplate() {
     let nextIndex =
       statisticsRangeTemplates.findIndex(
@@ -581,19 +529,19 @@
     try {
       const db = await database.db;
       const hasPrefilteredTitlesForStatistics = !!$preFilteredTitlesForStatistics$.size;
-      const initialStatisticsTitleFilters = new Map<string, boolean>();
+      const initialTitleFilterSelections = new Map<string, boolean>();
 
       [statisticsData, readingGoals] = await Promise.all([
         db.getAllFromIndex('statistic', 'dateKey'),
         database.getReadingGoals()
       ]).then(([statistics, readingGoalData]) => [
         statistics.map((statistic) => {
-          if (
-            statistic.readingTime &&
-            (!hasPrefilteredTitlesForStatistics ||
-              $preFilteredTitlesForStatistics$.has(statistic.title))
-          ) {
-            initialStatisticsTitleFilters.set(statistic.title, true);
+          if (statistic.readingTime) {
+            initialTitleFilterSelections.set(
+              statistic.title,
+              !hasPrefilteredTitlesForStatistics ||
+                $preFilteredTitlesForStatistics$.has(statistic.title)
+            );
           }
 
           return {
@@ -612,7 +560,7 @@
         readingGoalData
       ]);
 
-      statisticsTitleFilters = initialStatisticsTitleFilters;
+      titleFilterSelections = [...initialTitleFilterSelections.entries()];
       updateStatisticsData();
     } catch ({ message }: any) {
       messageDialog({ title: 'Error', message: `Error getting data: ${message}` });
@@ -794,12 +742,7 @@
   side="right"
   class="overflow-hidden bg-gray-700 text-white"
 >
-  <StatisticsTitleFilter
-    {statisticsTitleFilters}
-    {titlesInStatisticsDateRange}
-    onapplyFilter={updateTitleFilter}
-    onclearPrefilter={clearPrefilter}
-  />
+  <StatisticsTitleFilter bind:titleFilterSelections {titlesInStatisticsDateRange} />
 </SidebarOverlay>
 {#if $statisticsActionInProgress$}
   <div class="tap-highlight-transparent fixed inset-0 bg-black/20 z-70"></div>

--- a/src/lib/components/statistics/statistics-title-filter.svelte
+++ b/src/lib/components/statistics/statistics-title-filter.svelte
@@ -1,297 +1,98 @@
 <script lang="ts">
-  import { browser } from '$app/environment';
-  import {
-    faCalendar,
-    faCalendarXmark,
-    faChevronLeft,
-    faChevronRight,
-    faCircleCheck,
-    faEye,
-    faEyeSlash,
-    faList,
-    faListCheck,
-    faTrash
-  } from '@fortawesome/free-solid-svg-icons';
   import DialogFormButton from '$lib/components/dialog-form-button.svelte';
-  import {
-    preFilteredTitlesForStatistics$,
-    type StatisticsTitleFilterItem
-  } from '$lib/components/statistics/statistics-types';
-  import {
-    lastStatisticsFilterDateRangeOnly$,
-    lastStatisticsFilterShowSelectedTitlesOnly$
-  } from '$lib/data/store';
-  import { convertRemToPixels, getFullHeight, limitToRange } from '$lib/functions/utils';
-  import { onDestroy, tick } from 'svelte';
-  import Fa from 'svelte-fa';
+  import ToggleSwitch from '$lib/components/toggle-switch.svelte';
+  import { lastStatisticsFilterDateRangeOnly$ } from '$lib/data/store';
 
   interface Props {
-    statisticsTitleFilters: Map<string, boolean>;
+    titleFilterSelections: [string, boolean][];
     titlesInStatisticsDateRange: Set<string>;
-    onapplyFilter?: (data: StatisticsTitleFilterItem[]) => void;
-    onclearPrefilter?: () => void;
   }
 
-  let {
-    statisticsTitleFilters,
-    titlesInStatisticsDateRange,
-    onapplyFilter,
-    onclearPrefilter
-  }: Props = $props();
+  let { titleFilterSelections = $bindable(), titlesInStatisticsDateRange }: Props = $props();
 
-  const statisticsTitleFilterBaseRowRem = 4;
-  const statisticsTitleFilterBaseRowGap = 2;
-
-  let statisticsTitleFilterTableContainerElm = $state<HTMLElement>();
-  let statisticsTitleFilterButtonContainer = $state<HTMLElement>();
   let titleFilter = $state('');
-  let titleFilterTimer: number | undefined;
-  let titlesToFilter: StatisticsTitleFilterItem[] = $state([]);
-  let filteredTitles: StatisticsTitleFilterItem[] = $state([]);
-  let currentTitlesToFilterRows: StatisticsTitleFilterItem[] = $state([]);
-  let statisticsTitleFilterMaxPages = $state(0);
-  let currentStatisticsTitleFilterPage = $state(1);
-  let statisticsTitleFilterRowsPerPage = $state(0);
-  let statisticsTitleFilterPageLabel = $derived(
-    `PAGE ${currentStatisticsTitleFilterPage} / ${statisticsTitleFilterMaxPages}`
+  let headerCheckbox = $state<HTMLInputElement>();
+
+  let filteredSelections = $derived(
+    titleFilterSelections.filter(
+      ([title]) =>
+        (!titleFilter || title.includes(titleFilter)) &&
+        (!$lastStatisticsFilterDateRangeOnly$ || titlesInStatisticsDateRange.has(title))
+    )
   );
 
-  $effect(() => {
-    setTitlesToFilter(statisticsTitleFilters);
-  });
+  let allSelected = $derived(
+    filteredSelections.length > 0 && filteredSelections.every(([, isSelected]) => isSelected)
+  );
+  let noneSelected = $derived(filteredSelections.every(([, isSelected]) => !isSelected));
 
   $effect(() => {
-    applyTitleFilters(
-      $lastStatisticsFilterDateRangeOnly$,
-      $lastStatisticsFilterShowSelectedTitlesOnly$
-    );
+    if (headerCheckbox) {
+      headerCheckbox.indeterminate = !allSelected && !noneSelected;
+    }
   });
 
-  $effect(() => {
-    updateStatisticsTitleFilterTableData(currentStatisticsTitleFilterPage);
-  });
+  function handleToggleAll() {
+    const valueToSet = !allSelected;
 
-  let resizeObserver: ResizeObserver | undefined;
-
-  $effect(() => {
-    if (!browser) {
-      return;
+    for (const item of filteredSelections) {
+      item[1] = valueToSet;
     }
-
-    const tableContainer = statisticsTitleFilterTableContainerElm;
-
-    if (!tableContainer) {
-      return;
-    }
-
-    resizeObserver?.disconnect();
-    resizeObserver = new ResizeObserver(() => updateStatisticsTitleFilterRowsPerPage());
-    resizeObserver.observe(tableContainer);
-  });
-
-  onDestroy(() => resizeObserver?.disconnect());
-
-  function handleTitleFilterChange() {
-    clearTimeout(titleFilterTimer);
-    titleFilterTimer = window.setTimeout(() => {
-      applyTitleFilters();
-    }, 500);
-  }
-
-  function handleSelectAll(valueToSet: boolean) {
-    for (let index = 0, { length } = titlesToFilter; index < length; index += 1) {
-      titlesToFilter[index].isSelected = valueToSet;
-    }
-
-    if ($lastStatisticsFilterShowSelectedTitlesOnly$) {
-      applyTitleFilters();
-    } else {
-      updateStatisticsTitleFilterTableData(currentStatisticsTitleFilterPage);
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  function setTitlesToFilter(_: any) {
-    const entries = [...statisticsTitleFilters.entries()];
-
-    titlesToFilter = entries.map(([title, isSelected]) => ({ title, isSelected }));
-
-    applyTitleFilters();
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  function applyTitleFilters(..._: any) {
-    tick().then(() => {
-      filteredTitles = titlesToFilter.filter(
-        (filterItem) =>
-          (!titleFilter || filterItem.title.includes(titleFilter)) &&
-          (!$lastStatisticsFilterDateRangeOnly$ ||
-            titlesInStatisticsDateRange.has(filterItem.title)) &&
-          (!$lastStatisticsFilterShowSelectedTitlesOnly$ || filterItem.isSelected)
-      );
-
-      updateStatisticsTitleFilterRowsPerPage(currentStatisticsTitleFilterPage);
-    });
-  }
-
-  function updateStatisticsTitleFilterRowsPerPage(newPage?: number) {
-    tick().then(() => {
-      const tableContainer = statisticsTitleFilterTableContainerElm;
-      const buttonContainer = statisticsTitleFilterButtonContainer;
-
-      if (!tableContainer || !buttonContainer) {
-        return;
-      }
-
-      statisticsTitleFilterRowsPerPage = Math.max(
-        1,
-        Math.ceil(
-          (getFullHeight(window, tableContainer) - getFullHeight(window, buttonContainer, true)) /
-            convertRemToPixels(
-              window,
-              statisticsTitleFilterBaseRowRem + statisticsTitleFilterBaseRowGap + 0.4
-            )
-        )
-      );
-
-      updateStatisticsTitleFilterPageData(newPage);
-    });
-  }
-
-  function updateStatisticsTitleFilterPageData(newPage?: number) {
-    statisticsTitleFilterMaxPages = Math.ceil(
-      filteredTitles.length / statisticsTitleFilterRowsPerPage
-    );
-
-    currentStatisticsTitleFilterPage = newPage
-      ? limitToRange(1, statisticsTitleFilterMaxPages, newPage)
-      : limitToRange(1, statisticsTitleFilterMaxPages, currentStatisticsTitleFilterPage);
-
-    updateStatisticsTitleFilterTableData(currentStatisticsTitleFilterPage);
-  }
-
-  function updateStatisticsTitleFilterTableData(pageNumber: number) {
-    if (!pageNumber) {
-      return;
-    }
-
-    const currenPageStart = (pageNumber - 1) * statisticsTitleFilterRowsPerPage;
-
-    currentTitlesToFilterRows = filteredTitles.slice(
-      currenPageStart,
-      currenPageStart + statisticsTitleFilterRowsPerPage
-    );
   }
 </script>
 
 <div class="flex items-center p-4">
-  <DialogFormButton title="Close title filter" />
+  <DialogFormButton title="Close book filter" />
 </div>
-<div class="flex flex-col flex-1 px-4">
-  <input
-    type="search"
-    placeholder="Filter Title"
-    class="w-full text-black"
-    bind:value={titleFilter}
-    oninput={handleTitleFilterChange}
-  />
-  <div class="flex justify-between mt-6 text-2xl">
-    <DialogFormButton
-      title="Apply filter"
-      icon={faCircleCheck}
-      class="hover:text-red-500"
-      onsubmit={() => onapplyFilter?.(titlesToFilter)}
+<div class="flex flex-col flex-1 px-4 min-h-0">
+  <div class="flex items-center gap-4">
+    <input
+      type="search"
+      placeholder="Filter book list"
+      class="flex-1 text-black"
+      bind:value={titleFilter}
     />
-    <button title="Select all" class="hover:text-red-500" onclick={() => handleSelectAll(true)}>
-      <Fa icon={faListCheck} />
-    </button>
-    <button title="Remove all" class="hover:text-red-500" onclick={() => handleSelectAll(false)}>
-      <Fa icon={faList} />
-    </button>
-    <button
-      title={$lastStatisticsFilterDateRangeOnly$
-        ? 'Display Titles across all Time'
-        : 'Display Titles in selected Date Range only'}
-      class="hover:text-red-500"
-      onclick={() => ($lastStatisticsFilterDateRangeOnly$ = !$lastStatisticsFilterDateRangeOnly$)}
-    >
-      <Fa icon={$lastStatisticsFilterDateRangeOnly$ ? faCalendarXmark : faCalendar} />
-    </button>
-    <button
-      title={$lastStatisticsFilterShowSelectedTitlesOnly$
-        ? 'Display all Titles'
-        : 'Display selected Titles only'}
-      class="hover:text-red-500"
-      onclick={() =>
-        ($lastStatisticsFilterShowSelectedTitlesOnly$ =
-          !$lastStatisticsFilterShowSelectedTitlesOnly$)}
-    >
-      <Fa icon={$lastStatisticsFilterShowSelectedTitlesOnly$ ? faEyeSlash : faEye} />
-    </button>
-    {#if $preFilteredTitlesForStatistics$.size}
-      <button
-        title="Remove prefilter"
-        class="hover:text-red-500"
-        onclick={() => onclearPrefilter?.()}
-      >
-        <Fa icon={faTrash} />
-      </button>
-    {/if}
   </div>
-  <div class="grow mt-8 pl-1 overflow-auto" bind:this={statisticsTitleFilterTableContainerElm}>
-    {#if filteredTitles.length}
-      <div
-        class="grid grid-cols-[max-content_auto] gap-x-8 items-center"
-        style:grid-auto-rows={`${statisticsTitleFilterBaseRowRem}rem`}
-        style:row-gap={`${statisticsTitleFilterBaseRowGap}rem`}
-      >
-        {#each currentTitlesToFilterRows as currentTitlesToFilterRow, rowIndex (currentTitlesToFilterRow.title)}
-          {@const checkboxId = `statistics-title-filter-${currentStatisticsTitleFilterPage}-${rowIndex}`}
-          <input
-            id={checkboxId}
-            type="checkbox"
-            bind:checked={currentTitlesToFilterRow.isSelected}
-            onchange={() => {
-              if ($lastStatisticsFilterShowSelectedTitlesOnly$) {
-                applyTitleFilters();
-              }
-            }}
-          />
-          <label
-            for={checkboxId}
-            class="line-clamp-3"
-            class:opacity-50={!titlesInStatisticsDateRange.has(currentTitlesToFilterRow.title)}
-            title={currentTitlesToFilterRow.title}
-          >
-            {currentTitlesToFilterRow.title}
-          </label>
-        {/each}
-      </div>
+  <ToggleSwitch
+    bind:checked={$lastStatisticsFilterDateRangeOnly$}
+    label="Only show books with statistics in the target date range"
+    class="mt-4"
+  />
+  <div class="grow mt-4 pl-1 overflow-auto">
+    {#if filteredSelections.length}
+      <table class="w-full">
+        <thead class="sticky top-0 z-10 bg-gray-700 shadow-[0_1px_0_theme(colors.gray.500)]">
+          <tr>
+            <th class="w-0 py-2 pr-4">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                onchange={handleToggleAll}
+                title={allSelected ? 'Deselect all' : 'Select all'}
+                bind:this={headerCheckbox}
+              />
+            </th>
+            <th class="py-2 text-left font-semibold">Book title</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each filteredSelections as item (item[0])}
+            <tr>
+              <td class="py-2 pr-4">
+                <input type="checkbox" bind:checked={item[1]} />
+              </td>
+              <td
+                class="py-2 line-clamp-3"
+                class:opacity-50={!titlesInStatisticsDateRange.has(item[0])}
+              >
+                {item[0]}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
     {:else}
-      <div class="mt-6 text-2xl text-center">No Titles to filter</div>
+      <div class="mt-6 text-2xl text-center">No books to filter</div>
     {/if}
-  </div>
-  <div
-    class="my-6 flex justify-between"
-    class:invisible={statisticsTitleFilterMaxPages < 2}
-    bind:this={statisticsTitleFilterButtonContainer}
-  >
-    <button
-      disabled={currentStatisticsTitleFilterPage === 1}
-      class:opacity-25={currentStatisticsTitleFilterPage === 1}
-      class:cursor-not-allowed={currentStatisticsTitleFilterPage === 1}
-      onclick={() => (currentStatisticsTitleFilterPage -= 1)}
-    >
-      <Fa icon={faChevronLeft} />
-    </button>
-    <div class="mx-6">{statisticsTitleFilterPageLabel}</div>
-    <button
-      disabled={currentStatisticsTitleFilterPage === statisticsTitleFilterMaxPages}
-      class:opacity-25={currentStatisticsTitleFilterPage === statisticsTitleFilterMaxPages}
-      class:cursor-not-allowed={currentStatisticsTitleFilterPage === statisticsTitleFilterMaxPages}
-      onclick={() => (currentStatisticsTitleFilterPage += 1)}
-    >
-      <Fa icon={faChevronRight} />
-    </button>
   </div>
 </div>

--- a/src/lib/components/statistics/statistics-types.ts
+++ b/src/lib/components/statistics/statistics-types.ts
@@ -13,11 +13,6 @@ export interface StatisticsDataSource {
   label: string;
 }
 
-export interface StatisticsTitleFilterItem {
-  title: string;
-  isSelected: boolean;
-}
-
 export interface BookStatistic extends BooksDbStatistic {
   id: string;
   averageReadingTime: number;

--- a/src/lib/components/toggle-switch.svelte
+++ b/src/lib/components/toggle-switch.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  interface Props {
+    checked: boolean;
+    label: string;
+    class?: string;
+  }
+
+  let { checked = $bindable(), label, class: className = '' }: Props = $props();
+</script>
+
+<label class="flex items-center gap-3 cursor-pointer select-none {className}">
+  <span
+    class="relative inline-block w-10 h-6 rounded-full transition-colors"
+    class:bg-blue-500={checked}
+    class:bg-gray-500={!checked}
+  >
+    <input type="checkbox" class="sr-only" bind:checked />
+    <span
+      class="absolute top-1 left-1 w-4 h-4 rounded-full bg-white transition-transform"
+      class:translate-x-4={checked}
+    ></span>
+  </span>
+  <span>{label}</span>
+</label>

--- a/src/lib/data/store.ts
+++ b/src/lib/data/store.ts
@@ -394,11 +394,6 @@ export const lastStatisticsFilterDateRangeOnly$ = writableBooleanLocalStorageSub
   false
 );
 
-export const lastStatisticsFilterShowSelectedTitlesOnly$ = writableBooleanLocalStorageSubject()(
-  'lastStatisticsFilterShowSelectedTitlesOnly',
-  false
-);
-
 export const lastReadingDataHeatmapAggregationMode$ =
   writableStringLocalStorageSubject<HeatmapDataAggregration>()(
     'lastReadingDataHeatmapAggregationMode',


### PR DESCRIPTION
## Summary
- Replace the paginated grid with a scrollable table with a select-all/none/indeterminate header checkbox
- Apply filter changes in real time instead of requiring an explicit "Apply filter" button
- Replace cryptic calendar icon with a labeled toggle switch for the date range filter
- Remove the useless "display selected titles only" control
- Show all books when pre-filtering (from book detail pages) instead of hiding unselected ones, eliminating the need for the "remove prefilter" trash button
- Simplify parent-child data flow using a bindable `[string, boolean][]` array as the single source of truth, replacing the callback-based Map round-trip
- Extract a reusable `ToggleSwitch` component

## Test plan
- [x] Open statistics, open the book filter sidebar
- [x] Verify all books are listed in a scrollable table
- [x] Check/uncheck individual books and verify statistics update immediately
- [x] Use the header checkbox to select all / deselect all, verify indeterminate state with partial selection
- [x] Toggle "Only show books with statistics in the target date range" and verify filtering
- [x] Type in the search box and verify the book list filters
- [x] Navigate to statistics from a book detail page and verify the pre-filtered book is checked while all others are visible but unchecked
- [x] Verify the sticky table header stays visible and opaque when scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)