### PR TITLE
chore: remove unused isOnOldUrl function

### DIFF
--- a/src/lib/functions/utils.ts
+++ b/src/lib/functions/utils.ts
@@ -29,10 +29,6 @@ export function isMobile(window: Window) {
   return userAgentRegex.test(UA);
 }
 
-export function isOnOldUrl(window: Window) {
-  return window.location.href.startsWith('https://ttu-ebook.web.app');
-}
-
 export function dummyFn() {}
 
 export const isMobile$ = writableSubject<boolean>(false);


### PR DESCRIPTION
## Summary

- Remove the unused `isOnOldUrl` function from `src/lib/functions/utils.ts`, which checked for the legacy `ttu-ebook.web.app` domain

Part of #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)