### PR TITLE
docs: add privacy policy page at /privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@ This project is a revival fork of the original [ッツ Ebook Reader](https://git
 
 Hosted on <https://reader.miwake.app/>.
 
-## Privacy policy
-
-Miwake Reader runs entirely in your browser. No personal data is collected, stored, or transmitted to any server operated by Miwake Reader.
-
-If you choose to connect a Google Drive or OneDrive account, the app accesses only files it creates in a dedicated folder (`miwake-reader-data`). OAuth tokens are stored locally in your browser and are never sent to any third party. The app requests the minimum necessary scope (`drive.file` for Google Drive, `files.readwrite` for OneDrive).
-
-No analytics, tracking, or telemetry of any kind is used.
-
 ## Development
 
 1. Have [Node.js](https://nodejs.org/) installed.

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,0 +1,17 @@
+<div class="mx-auto max-w-2xl p-8">
+  <h1 class="mb-6 text-2xl font-bold">Privacy Policy</h1>
+
+  <p class="mb-4">
+    Miwake Reader runs entirely in your browser. No personal data is collected, stored, or
+    transmitted to any server operated by Miwake Reader.
+  </p>
+
+  <p class="mb-4">
+    If you choose to connect a Google Drive or OneDrive account, the app accesses only files it
+    creates in a dedicated folder (<code>miwake-reader-data</code>). OAuth tokens are stored locally
+    in your browser and are never sent to any third party. The app requests the minimum necessary
+    scope (<code>drive.file</code> for Google Drive, <code>files.readwrite</code> for OneDrive).
+  </p>
+
+  <p>No analytics, tracking, or telemetry of any kind is used.</p>
+</div>


### PR DESCRIPTION
## Summary

- Add a `/privacy` route with the privacy policy content
- Google requires the privacy policy URL to be on the app's own domain for the OAuth consent screen

URL: `https://reader.miwake.app/privacy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)