### PR TITLE
fix: overhaul OAuth to fix COOP popup issues, add OneDrive AppFolder

### DIFF
--- a/src/lib/data/env.ts
+++ b/src/lib/data/env.ts
@@ -2,7 +2,7 @@ export const basePath = import.meta.env.VITE_BASE_PATH || 'https://reader.miwake
 export const pagePath = import.meta.env.VITE_PAGE_PATH || '';
 export const appName = import.meta.env.VITE_APP_NAME || 'Miwake Reader';
 export const clearConsoleOnReload = !!import.meta.env.VITE_CLEAR_ON_RELOAD || false;
-export const storageRootName = import.meta.env.VITE_STORAGE_ROOT_NAME || 'miwake-reader-data';
+export const storageRootName = import.meta.env.VITE_STORAGE_ROOT_NAME || appName;
 export const gDriveAuthEndpoint =
   import.meta.env.VITE_GDRIVE_AUTH_ENDPOINT || 'https://accounts.google.com/o/oauth2/v2/auth';
 export const gDriveTokenEndpoint =
@@ -24,6 +24,5 @@ export const oneDriveTokenEndpoint =
 export const oneDriveDiscoveryEndpoint =
   import.meta.env.VITE_ONEDRIVE_DISCOVERY ||
   'https://login.microsoftonline.com/consumers/v2.0/.well-known/openid-configuration';
-export const oneDriveScope = import.meta.env.VITE_ONEDRIVE_SCOPE || 'files.readwrite';
+export const oneDriveScope = import.meta.env.VITE_ONEDRIVE_SCOPE || 'files.readwrite.appfolder';
 export const oneDriveClientId = import.meta.env.VITE_ONEDRIVE_CLIENT_ID || '';
-export const oneDriveClientSecret = import.meta.env.VITE_ONEDRIVE_CLIENT_SECRET || '';

--- a/src/lib/data/storage/handler/onedrive-handler.ts
+++ b/src/lib/data/storage/handler/onedrive-handler.ts
@@ -47,6 +47,8 @@ interface ExternalThumbnailData {
 export class OneDriveStorageHandler extends ApiStorageHandler {
   private baseEndpoint = 'https://graph.microsoft.com/v1.0/me/drive/items';
 
+  private appRootEndpoint = 'https://graph.microsoft.com/v1.0/me/drive/special/approot';
+
   constructor(window: Window) {
     super(StorageKey.ONEDRIVE, window, oneDriveTokenEndpoint);
   }
@@ -167,10 +169,15 @@ export class OneDriveStorageHandler extends ApiStorageHandler {
 
   protected async ensureTitle(
     name = BaseStorageHandler.rootName,
-    parent = 'root',
+    _parent = 'root',
     readOnly = false
   ) {
-    if (name === BaseStorageHandler.rootName && this.rootId) {
+    if (name === BaseStorageHandler.rootName) {
+      if (!this.rootId) {
+        // AppFolder is auto-created by Microsoft on first access
+        const response = await this.request(`${this.appRootEndpoint}?$select=id`);
+        this.rootId = response.id;
+      }
       return this.rootId;
     }
 
@@ -180,40 +187,32 @@ export class OneDriveStorageHandler extends ApiStorageHandler {
       return externalId;
     }
 
-    const sanitizedName = BaseStorageHandler.sanitizeForFilename(name);
-    const params = new URLSearchParams();
-
-    params.append('select', `id,name`);
-    params.append('filter', `name eq '${sanitizedName}'`);
-
-    let titleId = '';
-
-    if (name === BaseStorageHandler.rootName) {
-      titleId = (await this.request(`${this.baseEndpoint}/${parent}/children?${params.toString()}`))
-        ?.value?.[0]?.id;
-    } else if (this.rootId) {
-      // One Drive Bug (?) - with non latin characters it will return no filter result so we need to refetch all folders
-      const remoteFolders = await this.list(this.rootId);
-
-      for (let index = 0, { length } = remoteFolders; index < length; index += 1) {
-        const remoteFolder = remoteFolders[index];
-        const title = BaseStorageHandler.desanitizeFilename(remoteFolder.name);
-
-        this.titleToId.set(title, remoteFolder.id);
-
-        if (title === name) {
-          titleId = remoteFolder.id;
-        }
-      }
-    } else {
+    if (!this.rootId) {
       throw new Error('RootId required for search');
     }
 
+    // OneDrive bug: non-latin characters return no filter results, so refetch all folders
+    const remoteFolders = await this.list(this.rootId);
+    let titleId = '';
+
+    for (let index = 0, { length } = remoteFolders; index < length; index += 1) {
+      const remoteFolder = remoteFolders[index];
+      const title = BaseStorageHandler.desanitizeFilename(remoteFolder.name);
+
+      this.titleToId.set(title, remoteFolder.id);
+
+      if (title === name) {
+        titleId = remoteFolder.id;
+      }
+    }
+
     if (!titleId && !readOnly) {
-      params.delete('filter');
+      const sanitizedName = BaseStorageHandler.sanitizeForFilename(name);
+      const params = new URLSearchParams();
+      params.append('select', 'id,name');
 
       const response = await this.request(
-        `${this.baseEndpoint}/${parent}/children?${params.toString()}`,
+        `${this.baseEndpoint}/${this.rootId}/children?${params.toString()}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -230,14 +229,6 @@ export class OneDriveStorageHandler extends ApiStorageHandler {
 
     if (titleId) {
       this.titleToId.set(name, titleId);
-    }
-
-    if (titleId && name === BaseStorageHandler.rootName) {
-      this.rootId = titleId;
-    }
-
-    if (!titleId && name === BaseStorageHandler.rootName) {
-      throw new Error('Root folder not found');
     }
 
     return titleId;

--- a/src/lib/data/storage/storage-oauth-manager.ts
+++ b/src/lib/data/storage/storage-oauth-manager.ts
@@ -4,6 +4,7 @@ import { dialogManager } from '$lib/data/dialog-manager';
 import {
   gDriveAuthEndpoint,
   gDriveClientId,
+  gDriveClientSecret,
   gDriveScope,
   gDriveTokenEndpoint,
   oneDriveAuthEndpoint,
@@ -15,7 +16,6 @@ import {
 import { logger } from '$lib/data/logger';
 import {
   encrypt,
-  isAppDefault,
   unlockStorageData,
   type RemoteContext,
   type StorageUnlockAction
@@ -49,17 +49,17 @@ export class StorageOAuthManager {
 
   private codeVerifier = '';
 
+  private static AUTH_CHANNEL = 'miwake-auth';
+
+  private static AUTH_STORAGE_KEY = 'miwake-auth-data';
+
   private authResolver: ((value: OAuthTokenData | PromiseLike<OAuthTokenData>) => void) | undefined;
 
   private authRejector: ((error: Error) => void) | undefined;
 
-  private rebindedWinHandler: ((event: MessageEvent) => void) | undefined;
+  private broadcastChannel: BroadcastChannel | undefined;
 
-  private authCloseIntervalTime = 500;
-
-  private authCloseInterval: number | undefined;
-
-  private authTimeout = 45000;
+  private authTimeout = 120000;
 
   private authTimeoutTimer: number | undefined;
 
@@ -99,7 +99,7 @@ export class StorageOAuthManager {
     if (storageSourceName === StorageSourceDefault.GDRIVE_DEFAULT) {
       this.remoteData = {
         clientId: gDriveClientId,
-        clientSecret: ''
+        clientSecret: gDriveClientSecret
       };
     } else if (storageSourceName === StorageSourceDefault.ONEDRIVE_DEFAULT) {
       this.remoteData = {
@@ -149,6 +149,10 @@ export class StorageOAuthManager {
     }
 
     this.parentWindow = window;
+
+    logger.warn(`Opening auth window for ${storageSourceName} (${this.storageType})`);
+
+    await this.stashAuthData();
 
     if (authWindow) {
       this.authWindow = authWindow;
@@ -288,6 +292,13 @@ export class StorageOAuthManager {
         this.remoteData.refreshToken
       )
     ) {
+      logger.warn(
+        `Cannot refresh token for ${this.storageSourceName} (${this.storageType}): ` +
+          `refreshEndpoint=${!!this.refreshEndpoint}, ` +
+          `clientId=${!!this.remoteData?.clientId}, ` +
+          `clientSecret=${!!this.remoteData?.clientSecret}, ` +
+          `refreshToken=${!!this.remoteData?.refreshToken}`
+      );
       return undefined;
     }
 
@@ -340,16 +351,43 @@ export class StorageOAuthManager {
     return token;
   }
 
-  private base64Url(buffer: Uint8Array) {
-    if (!this.parentWindow) {
-      throw new Error('Parent window not defined');
-    }
-
-    return this.parentWindow
-      .btoa(String.fromCharCode(...buffer))
+  private static base64Url(buffer: Uint8Array) {
+    return btoa(String.fromCharCode(...buffer))
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=+$/, '');
+  }
+
+  private async stashAuthData() {
+    if (!this.parentWindow || !this.remoteData) {
+      return;
+    }
+
+    if (!this.codeVerifier) {
+      const arr = new Uint8Array(32);
+      this.parentWindow.crypto.getRandomValues(arr);
+      this.codeVerifier = StorageOAuthManager.base64Url(arr);
+    }
+
+    const codeChallenge = StorageOAuthManager.base64Url(
+      new Uint8Array(
+        await this.parentWindow.crypto.subtle.digest(
+          'SHA-256',
+          new TextEncoder().encode(this.codeVerifier)
+        )
+      )
+    );
+
+    const authData = {
+      ...this.remoteData,
+      ...StorageOAuthManager.getAuthVariables(this.storageType),
+      sendSecret: this.storageType === StorageKey.GDRIVE,
+      needsRefreshToken: !this.remoteData.refreshToken,
+      codeVerifier: this.codeVerifier,
+      codeChallenge
+    };
+
+    sessionStorage.setItem(StorageOAuthManager.AUTH_STORAGE_KEY, JSON.stringify(authData));
   }
 
   private waitForAuth(window: Window): Promise<OAuthTokenData> {
@@ -361,99 +399,48 @@ export class StorageOAuthManager {
 
       this.authResolver = resolve;
       this.authRejector = reject;
-      this.rebindedWinHandler = this.winHandler.bind(this);
-      this.parentWindow.addEventListener('message', this.rebindedWinHandler, false);
 
-      this.authCloseInterval = window.setInterval(() => {
-        if (this.authWindow?.closed) {
-          reject(new Error('Window was closed before login'));
+      this.broadcastChannel = new BroadcastChannel(StorageOAuthManager.AUTH_CHANNEL);
+      this.broadcastChannel.onmessage = (event: MessageEvent) => {
+        if (!this.authResolver || !this.authRejector) {
+          return;
         }
-      }, this.authCloseIntervalTime);
+
+        switch (event.data.type) {
+          case 'auth':
+            this.authResolver(event.data.payload);
+            break;
+          case 'failure':
+            logger.error(event.data.payload.detail);
+            this.authRejector(new Error(event.data.payload.message));
+            break;
+          default:
+            break;
+        }
+      };
 
       this.authTimeoutTimer = window.setTimeout(() => {
-        reject(new Error('Login timeout'));
+        reject(
+          new Error(
+            `Login timeout for ${this.storageSourceName} (${this.storageType}) after ${this.authTimeout / 1000}s`
+          )
+        );
       }, this.authTimeout);
     });
   }
 
-  private async winHandler(event: MessageEvent) {
-    if (
-      !this.parentWindow ||
-      !this.remoteData ||
-      event.source !== this.authWindow ||
-      !this.authResolver ||
-      !this.authRejector
-    ) {
-      return;
-    }
-
-    switch (event.data.type) {
-      case 'getAuthVariables':
-        event.ports[0].postMessage({
-          result: {
-            ...this.remoteData,
-            ...StorageOAuthManager.getAuthVariables(this.storageType),
-            sendSecret:
-              this.storageType === StorageKey.GDRIVE && !isAppDefault(this.storageSourceName)
-          }
-        });
-        break;
-      case 'auth':
-        this.authResolver(event.data.payload);
-        break;
-      case 'getCodeChallenge':
-        if (!this.codeVerifier) {
-          const arr = new Uint8Array(32);
-
-          this.parentWindow.crypto.getRandomValues(arr);
-          this.codeVerifier = this.base64Url(arr);
-        }
-
-        event.ports[0].postMessage({
-          result: this.base64Url(
-            new Uint8Array(
-              await this.parentWindow.crypto.subtle.digest(
-                'SHA-256',
-                new TextEncoder().encode(this.codeVerifier)
-              )
-            )
-          )
-        });
-        break;
-      case 'getCodeVerifier':
-        event.ports[0].postMessage({
-          result: this.codeVerifier
-        });
-        break;
-      case 'failure':
-        logger.error(event.data.payload.detail);
-        this.authRejector(new Error(event.data.payload.message));
-        break;
-
-      default:
-        break;
-    }
-  }
-
   private clearAuthData() {
     clearTimeout(this.authTimeoutTimer);
-    clearInterval(this.authCloseInterval);
 
-    if (this.parentWindow && this.rebindedWinHandler) {
-      this.parentWindow.removeEventListener('message', this.rebindedWinHandler, false);
+    if (this.broadcastChannel) {
+      this.broadcastChannel.close();
+      this.broadcastChannel = undefined;
     }
 
-    try {
-      if (!this.authWindow?.closed) {
-        this.authWindow?.close();
-      }
-    } catch (_) {
-      // no-op
-    }
+    sessionStorage.removeItem(StorageOAuthManager.AUTH_STORAGE_KEY);
 
     this.authResolver = undefined;
     this.authRejector = undefined;
-    this.rebindedWinHandler = undefined;
     this.parentWindow = undefined;
     this.authWindow = null;
     this.codeVerifier = '';

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -4,6 +4,9 @@
   import { convertAuthErrorResponse } from '$lib/functions/replication/error-handler';
   import Fa from 'svelte-fa';
 
+  const AUTH_CHANNEL = 'miwake-auth';
+  const AUTH_STORAGE_KEY = 'miwake-auth-data';
+
   $effect(() => {
     if (browser) {
       handleAuthRequest();
@@ -12,25 +15,34 @@
 
   async function handleAuthRequest() {
     const url = new URL(window.location.href);
-    const hashParams = new URLSearchParams(url.hash.substring(1));
-    const hashError = hashParams.has('error_description') || hashParams.has('error');
     const redirectUri = `${url.origin}${url.pathname}`;
 
-    if (hashError) {
-      reportError(
-        url.origin,
-        'Authorization failed',
-        hashParams.get('error_description') || hashParams.get('error') || 'Unknown error'
-      );
-    } else if (url.searchParams.has('code')) {
-      const params = new URLSearchParams();
-      const { clientId, clientSecret, sendSecret, tokenEndpoint } = await getDataFromOpener(
-        url.origin,
-        {
-          type: 'getAuthVariables'
+    if (url.searchParams.has('error')) {
+      sendMessage({
+        type: 'failure',
+        payload: {
+          message: 'Authorization failed',
+          detail: `Authorization failed\n${url.searchParams.get('error_description') || url.searchParams.get('error') || 'Unknown error'}`
         }
-      );
+      });
+    } else if (url.searchParams.has('code')) {
+      const stored = sessionStorage.getItem(AUTH_STORAGE_KEY);
 
+      if (!stored) {
+        sendMessage({
+          type: 'failure',
+          payload: {
+            message: 'Auth session data not found',
+            detail: 'Auth session data was not found in sessionStorage after redirect'
+          }
+        });
+        return;
+      }
+
+      const { clientId, clientSecret, sendSecret, tokenEndpoint, codeVerifier, needsRefreshToken } =
+        JSON.parse(stored);
+
+      const params = new URLSearchParams();
       params.append('grant_type', 'authorization_code');
       params.append('redirect_uri', redirectUri);
       params.append('client_id', clientId);
@@ -40,10 +52,7 @@
       }
 
       params.append('code', url.searchParams.get('code') || '');
-      params.append(
-        'code_verifier',
-        await getDataFromOpener(url.origin, { type: 'getCodeVerifier' })
-      );
+      params.append('code_verifier', codeVerifier);
 
       fetch(tokenEndpoint, {
         method: 'POST',
@@ -58,130 +67,106 @@
           return response.json();
         })
         .then((tokenData) => {
-          checkAuthResponse(
-            url.origin,
-            tokenData.access_token,
-            tokenData.expires_in,
-            tokenData.scope,
-            tokenData.refresh_token
-          );
+          const {
+            access_token: accessToken,
+            expires_in: expiration,
+            scope,
+            refresh_token: refreshToken
+          } = tokenData;
+
+          if (!accessToken || !expiration || !scope || (needsRefreshToken && !refreshToken)) {
+            sendMessage({
+              type: 'failure',
+              payload: {
+                message: 'A required authentication property was not found',
+                detail: `Had Token: ${!!accessToken}\nHad Expiration: ${!!expiration}\nHad Scope: ${!!scope}\nNeeded Refresh Token: ${needsRefreshToken}\nHad Refresh Token: ${!!refreshToken}`
+              }
+            });
+            return;
+          }
+
+          sendMessage({
+            type: 'auth',
+            payload: {
+              accessToken,
+              scope,
+              expiration: Date.now() + (Number.parseInt(expiration, 10) - 600) * 1000,
+              refreshToken
+            }
+          });
         })
         .catch((error) => {
-          reportError(url.origin, 'Code authorization request failed', error.message);
+          sendMessage({
+            type: 'failure',
+            payload: {
+              message: 'Code authorization request failed',
+              detail: `Code authorization request failed\n${error.message}`
+            }
+          });
+        })
+        .finally(() => {
+          sessionStorage.removeItem(AUTH_STORAGE_KEY);
         });
     } else if (url.searchParams.has('miwake-init-auth')) {
-      const params = new URLSearchParams();
+      const stored = sessionStorage.getItem(AUTH_STORAGE_KEY);
 
-      const { clientId, authEndpoint, scope } = await getDataFromOpener(url.origin, {
-        type: 'getAuthVariables'
-      });
-
-      if (!clientId || !scope || !authEndpoint) {
-        return reportError(
-          url.origin,
-          'A required authentication input was not found',
-          `ClientId: ${!!clientId}\nScope: ${!!scope}\nAuthEndpoint: ${!!authEndpoint}`
-        );
+      if (!stored) {
+        sendMessage({
+          type: 'failure',
+          payload: {
+            message: 'Auth session data not found',
+            detail: 'Auth session data was not found in sessionStorage during init'
+          }
+        });
+        return;
       }
 
+      const { clientId, authEndpoint, scope, codeChallenge, needsRefreshToken } =
+        JSON.parse(stored);
+
+      if (!clientId || !scope || !authEndpoint) {
+        sendMessage({
+          type: 'failure',
+          payload: {
+            message: 'A required authentication input was not found',
+            detail: `ClientId: ${!!clientId}\nScope: ${!!scope}\nAuthEndpoint: ${!!authEndpoint}`
+          }
+        });
+        return;
+      }
+
+      const params = new URLSearchParams();
       params.append('client_id', clientId);
       params.append('redirect_uri', redirectUri);
       params.append('scope', scope);
-
       params.append('response_type', 'code');
-      params.append('access_type', 'offline');
       params.append('code_challenge_method', 'S256');
-      params.append(
-        'code_challenge',
-        await getDataFromOpener(url.origin, { type: 'getCodeChallenge' })
-      );
-      params.append('prompt', 'consent');
+      params.append('code_challenge', codeChallenge);
+
+      if (needsRefreshToken) {
+        params.append('access_type', 'offline');
+        params.append('prompt', 'consent');
+      }
 
       window.location.assign(`${authEndpoint}?${params.toString()}`);
     } else if (url.searchParams.has('miwake-init-wait')) {
       // idle until location reassign for iOS workaround of blocking popups in async context
     } else {
-      reportError(
-        url.origin,
-        'Unexpected authentication context',
-        `Url: ${url.href}\nHash: ${url.hash || '-'}`
-      );
-    }
-
-    return undefined;
-  }
-
-  function reportError(origin: string, baseError: string, detail: string) {
-    if (!window.opener) {
-      return;
-    }
-
-    window.opener.postMessage(
-      {
+      sendMessage({
         type: 'failure',
         payload: {
-          message: baseError,
-          detail: `${baseError}\n${detail}`
+          message: 'Unexpected authentication context',
+          detail: `Unexpected authentication context\nUrl: ${url.href}\nHash: ${url.hash || '-'}`
         }
-      },
-      origin
-    );
+      });
+    }
   }
 
-  function checkAuthResponse(
-    origin: string,
-    accessToken: string | null,
-    expiration: string | null,
-    scope: string | null,
-    refreshToken?: string | null
-  ) {
-    if (!window.opener) {
-      return;
-    }
-
-    if (!accessToken || !expiration || !scope || !refreshToken) {
-      reportError(
-        origin,
-        'A required authentication property was not found',
-        `Had Token: ${!!accessToken}\nHad Expiration: ${!!expiration}\nHad Scope: ${!!scope}\nHad Refresh Token: ${!!refreshToken}`
-      );
-      return;
-    }
-
-    window.opener.postMessage(
-      {
-        type: 'auth',
-        payload: {
-          accessToken,
-          scope,
-          expiration: Date.now() + (Number.parseInt(expiration, 10) - 600) * 1000,
-          refreshToken
-        }
-      },
-      origin
-    );
-  }
-
-  function getDataFromOpener(origin: string, payload: any): Promise<any> {
-    return new Promise((resolve, reject) => {
-      if (!window.opener) {
-        return;
-      }
-
-      const channel = new MessageChannel();
-
-      channel.port1.onmessage = ({ data }) => {
-        channel.port1.close();
-
-        if (data.error) {
-          reject(new Error(data.error));
-        } else {
-          resolve(data.result);
-        }
-      };
-
-      window.opener.postMessage(payload, origin, [channel.port2]);
-    });
+  function sendMessage(data: any) {
+    const channel = new BroadcastChannel(AUTH_CHANNEL);
+    channel.postMessage(data);
+    channel.close();
+    window.close();
   }
 </script>
 


### PR DESCRIPTION
## Summary

- **Replace `window.opener` with `BroadcastChannel` + `sessionStorage`** for auth popup communication. Google's COOP headers sever the `window.opener` relationship after cross-origin redirect, causing the auth flow to silently hang. The parent now stashes auth data in `sessionStorage` before opening the popup; the popup reads it and posts results back via `BroadcastChannel`.
- **Fix GDrive default source client secret**: was hardcoded to `''` so the secret was never sent during code exchange, even though the env var was set. Now uses `gDriveClientSecret` from env.
- **Only force consent when needed**: `prompt=consent` + `access_type=offline` are now only sent when a refresh token is needed (first auth), not on every auth.
- **Switch OneDrive to AppFolder scope** (`files.readwrite.appfolder`): narrower permissions, uses `/me/drive/special/approot` endpoint, simpler root folder handling (auto-created by Microsoft).
- **Use `appName` as GDrive root folder name** instead of `miwake-reader-data`.
- Popup closes itself via `window.close()` (no COOP errors from parent-side close).
- Remove unused `oneDriveClientSecret` env var.
- Remove dead implicit-flow hash error handling from auth page.
- Improve auth error logging with provider names and timeout details.

## Test plan

- [ ] GDrive auth flow completes successfully (first time: consent screen, gets refresh token)
- [ ] GDrive subsequent loads use refresh token silently (no popup)
- [ ] OneDrive auth flow completes successfully
- [ ] OneDrive creates files under the app-specific folder (not a manually-named folder)
- [ ] No COOP console errors during auth
- [ ] Auth timeout shows which provider timed out
- [ ] Popup closes itself after auth completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)