### PR TITLE
chore: remove unfinished audiobook and subtitle scaffolding

### DIFF
--- a/src/lib/components/book-export/book-export-selection.svelte
+++ b/src/lib/components/book-export/book-export-selection.svelte
@@ -71,24 +71,4 @@
     />
     <label for="bookstatistic">Statistics</label>
   </div>
-  <div>
-    <input
-      type="checkbox"
-      id="audioBook"
-      name="audioBook"
-      value="audioBook"
-      bind:group={dataToReplicate}
-    />
-    <label for="audioBook">Audiobook</label>
-  </div>
-  <div>
-    <input
-      type="checkbox"
-      id="subtitle"
-      name="subtitle"
-      value="subtitle"
-      bind:group={dataToReplicate}
-    />
-    <label for="subtitle">Subtitles</label>
-  </div>
 </div>

--- a/src/lib/data/database/books-db/database.service.ts
+++ b/src/lib/data/database/books-db/database.service.ts
@@ -1,11 +1,9 @@
 import type {
-  BooksDbAudioBook,
   BooksDbBookData,
   BooksDbBookmarkData,
   BooksDbReadingGoal,
   BooksDbStatistic,
-  BooksDbStorageSource,
-  BooksDbSubtitleData
+  BooksDbStorageSource
 } from '$lib/data/database/books-db/versions/books-db';
 import { Observable, Subject, from } from 'rxjs';
 import { StorageDataType, StorageKey } from '$lib/data/storage/storage-types';
@@ -325,18 +323,6 @@ export class DatabaseService {
     return db.put('bookmark', bookmarkData);
   }
 
-  async putAudioBook(audioBook: BooksDbAudioBook) {
-    const db = await this.db;
-
-    return db.put('audioBook', audioBook);
-  }
-
-  async putSubtitleData(subtitleData: BooksDbSubtitleData) {
-    const db = await this.db;
-
-    return db.put('subtitle', subtitleData);
-  }
-
   async putLastItem(dataId: number) {
     const db = await this.db;
     const result = await db.put('lastItem', { dataId }, LAST_ITEM_KEY);
@@ -363,10 +349,8 @@ export class DatabaseService {
       | 'statistic'
       | 'lastItem'
       | 'lastModified'
-      | 'audioBook'
-      | 'subtitle'
       | 'handle'
-    )[] = ['data', 'audioBook', 'subtitle', 'handle'];
+    )[] = ['data', 'handle'];
     const shouldDeleteLastItem = cachedData.lastItem === dataId;
     const shouldDeleteBookmark = cachedData.bookmarkIds.has(dataId);
 
@@ -406,8 +390,6 @@ export class DatabaseService {
       }
 
       if (bookTitle) {
-        await tx.objectStore('audioBook').delete(bookTitle);
-        await tx.objectStore('subtitle').delete(bookTitle);
         await tx.objectStore('handle').delete(IDBKeyRange.bound([bookTitle], [bookTitle, []]));
       }
 
@@ -1039,17 +1021,5 @@ export class DatabaseService {
     }
 
     lastReadingGoalsModified$.next(Date.now());
-  }
-
-  async getAudioBook(title: string) {
-    const db = await this.db;
-
-    return db.get('audioBook', title);
-  }
-
-  async getSubtitleData(title: string) {
-    const db = await this.db;
-
-    return db.get('subtitle', title);
   }
 }

--- a/src/lib/data/database/books-db/versions/books-db.ts
+++ b/src/lib/data/database/books-db/versions/books-db.ts
@@ -9,7 +9,5 @@ export type BooksDbStorageSource = BooksDb['storageSource']['value'];
 export type BooksDbStatistic = BooksDb['statistic']['value'];
 export type BooksDbReadingGoal = BooksDb['readingGoal']['value'];
 export type BooksDbLastModified = BooksDb['lastModified']['value'];
-export type BooksDbAudioBook = BooksDb['audioBook']['value'];
-export type BooksDbSubtitleData = BooksDb['subtitle']['value'];
 export type BooksDbHandle = BooksDb['handle']['value'];
 export const currentDbVersion = 6;

--- a/src/lib/data/storage/handler/api-handler.ts
+++ b/src/lib/data/storage/handler/api-handler.ts
@@ -1,19 +1,13 @@
 import type {
-  BooksDbAudioBook,
   BooksDbBookData,
   BooksDbBookmarkData,
   BooksDbReadingGoal,
-  BooksDbStatistic,
-  BooksDbSubtitleData
+  BooksDbStatistic
 } from '$lib/data/database/books-db/versions/books-db';
 import { logger } from '$lib/data/logger';
 import { MergeMode } from '$lib/data/merge-mode';
 import { mergeReadingGoals, readingGoalSortFunction } from '$lib/data/reading-goal';
-import {
-  BaseStorageHandler,
-  FilePrefix,
-  type ExternalFile
-} from '$lib/data/storage/handler/base-handler';
+import { BaseStorageHandler, type ExternalFile } from '$lib/data/storage/handler/base-handler';
 import { getStorageHandler } from '$lib/data/storage/storage-handler-factory';
 import { StorageOAuthManager } from '$lib/data/storage/storage-oauth-manager';
 import { StorageKey } from '$lib/data/storage/storage-types';
@@ -270,40 +264,6 @@ export abstract class ApiStorageHandler extends BaseStorageHandler {
     );
   }
 
-  async isAudioBookPresentAndUpToDate(referenceFilename: string | undefined) {
-    if (!referenceFilename) {
-      BaseStorageHandler.reportProgress();
-
-      return false;
-    }
-
-    const { file } = await this.getExternalFile(FilePrefix.AUDIO_BOOK);
-
-    return BaseStorageHandler.checkIsPresentAndUpToDate<BooksDbAudioBook>(
-      BaseStorageHandler.getAudioBookMetadata,
-      'lastAudioBookModified',
-      referenceFilename,
-      file?.name
-    );
-  }
-
-  async isSubtitleDataPresentAndUpToDate(referenceFilename: string | undefined) {
-    if (!referenceFilename) {
-      BaseStorageHandler.reportProgress();
-
-      return false;
-    }
-
-    const { file } = await this.getExternalFile(FilePrefix.SUBTITLE);
-
-    return BaseStorageHandler.checkIsPresentAndUpToDate<BooksDbSubtitleData>(
-      BaseStorageHandler.getSubtitleDataMetadata,
-      'lastSubtitleDataModified',
-      referenceFilename,
-      file?.name
-    );
-  }
-
   async getBook() {
     const { file, data } = await this.getExternalFile(
       'bookdata_',
@@ -372,30 +332,6 @@ export abstract class ApiStorageHandler extends BaseStorageHandler {
       readingGoals: data,
       lastGoalModified: BaseStorageHandler.getReadingGoalsMetadata(file.name).lastGoalModified
     };
-  }
-
-  async getAudioBook() {
-    const { file, data } = await this.getExternalFile(FilePrefix.AUDIO_BOOK, 'json');
-
-    if (!file) {
-      return undefined;
-    }
-
-    return this.isForBrowser
-      ? data
-      : new File([new Blob([JSON.stringify(data)])], file.name, { type: 'application/json' });
-  }
-
-  async getSubtitleData() {
-    const { file, data } = await this.getExternalFile(FilePrefix.SUBTITLE, 'json');
-
-    if (!file) {
-      return undefined;
-    }
-
-    return this.isForBrowser
-      ? data
-      : new File([new Blob([JSON.stringify(data)])], file.name, { type: 'application/json' });
   }
 
   async saveBook(data: Omit<BooksDbBookData, 'id'> | File, skipTimestampFallback = true) {
@@ -529,32 +465,6 @@ export abstract class ApiStorageHandler extends BaseStorageHandler {
       JSON.stringify(readingGoalsToStore),
       BaseStorageHandler.readingGoalsFilePrefix
     );
-  }
-
-  async saveAudioBook(data: BooksDbAudioBook | File) {
-    const filename = BaseStorageHandler.getAudioBookFileName(data);
-    const audioBookData = data instanceof File ? data : JSON.stringify(data);
-    const { titleId, files, file } = await this.getExternalFile(
-      FilePrefix.AUDIO_BOOK,
-      '',
-      0.2,
-      false
-    );
-
-    await this.upload(titleId, filename, files, file, audioBookData);
-  }
-
-  async saveSubtitleData(data: BooksDbSubtitleData | File) {
-    const filename = BaseStorageHandler.getSubtitleDataFileName(data);
-    const subtitleData = data instanceof File ? data : JSON.stringify(data);
-    const { titleId, files, file } = await this.getExternalFile(
-      FilePrefix.SUBTITLE,
-      '',
-      0.2,
-      false
-    );
-
-    await this.upload(titleId, filename, files, file, subtitleData);
   }
 
   async deleteBookData(booksToDelete: string[], cancelSignal: AbortSignal) {

--- a/src/lib/data/storage/handler/backup-handler.ts
+++ b/src/lib/data/storage/handler/backup-handler.ts
@@ -1,14 +1,12 @@
 import type {
-  BooksDbAudioBook,
   BooksDbBookData,
   BooksDbBookmarkData,
   BooksDbReadingGoal,
-  BooksDbStatistic,
-  BooksDbSubtitleData
+  BooksDbStatistic
 } from '$lib/data/database/books-db/versions/books-db';
 import type { MergeMode } from '$lib/data/merge-mode';
 import { readingGoalSortFunction } from '$lib/data/reading-goal';
-import { BaseStorageHandler, FilePrefix } from '$lib/data/storage/handler/base-handler';
+import { BaseStorageHandler } from '$lib/data/storage/handler/base-handler';
 import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
 import type { ReplicationContext } from '$lib/functions/replication/replication-progress';
 import { BlobReader, BlobWriter, ZipReader, type Entry, type ZipWriter } from '@zip.js/zip.js';
@@ -48,16 +46,6 @@ export class BackupStorageHandler extends BaseStorageHandler {
   }
 
   areReadingGoalsPresentAndUpToDate() {
-    BaseStorageHandler.reportProgress();
-    return Promise.resolve(false);
-  }
-
-  isAudioBookPresentAndUpToDate() {
-    BaseStorageHandler.reportProgress();
-    return Promise.resolve(false);
-  }
-
-  isSubtitleDataPresentAndUpToDate() {
     BaseStorageHandler.reportProgress();
     return Promise.resolve(false);
   }
@@ -225,48 +213,6 @@ export class BackupStorageHandler extends BaseStorageHandler {
     };
   }
 
-  async getAudioBook() {
-    const { zipEntry, filename } = this.findEntry(FilePrefix.AUDIO_BOOK);
-
-    if (!zipEntry) {
-      return undefined;
-    }
-
-    if (this.isForBrowser) {
-      return this.extractAsJSON(zipEntry, 'Unable to read audioBook data');
-    }
-
-    const audioBookBlob = await this.readFromZip(
-      new BlobWriter(),
-      'Unable to read audioBook data',
-      zipEntry,
-      0.9
-    );
-
-    return new File([audioBookBlob], filename, { type: 'application/json' });
-  }
-
-  async getSubtitleData() {
-    const { zipEntry, filename } = this.findEntry(FilePrefix.SUBTITLE);
-
-    if (!zipEntry) {
-      return undefined;
-    }
-
-    if (this.isForBrowser) {
-      return this.extractAsJSON(zipEntry, 'Unable to read subtitles data');
-    }
-
-    const subtitleDataBlob = await this.readFromZip(
-      new BlobWriter(),
-      'Unable to read subtitles data',
-      zipEntry,
-      0.9
-    );
-
-    return new File([subtitleDataBlob], filename, { type: 'application/json' });
-  }
-
   async saveBook(data: Omit<BooksDbBookData, 'id'> | File) {
     const filename = `${this.sanitizedTitle}/${BaseStorageHandler.getBookFileName(data)}`;
 
@@ -337,34 +283,6 @@ export class BackupStorageHandler extends BaseStorageHandler {
       JSON.stringify(data),
       this.exportZipWriter
     );
-  }
-
-  async saveAudioBook(data: BooksDbAudioBook | File) {
-    const filename = `${this.sanitizedTitle}/${BaseStorageHandler.getAudioBookFileName(data)}`;
-
-    if (data instanceof File) {
-      this.exportZipWriter = await this.addDataToZip(filename, data, this.exportZipWriter);
-    } else {
-      this.exportZipWriter = await this.addDataToZip(
-        filename,
-        JSON.stringify(data),
-        this.exportZipWriter
-      );
-    }
-  }
-
-  async saveSubtitleData(data: BooksDbSubtitleData | File) {
-    const filename = `${this.sanitizedTitle}/${BaseStorageHandler.getSubtitleDataFileName(data)}`;
-
-    if (data instanceof File) {
-      this.exportZipWriter = await this.addDataToZip(filename, data, this.exportZipWriter);
-    } else {
-      this.exportZipWriter = await this.addDataToZip(
-        filename,
-        JSON.stringify(data),
-        this.exportZipWriter
-      );
-    }
   }
 
   async createExportZip(document: Document, resetOnly: boolean) {

--- a/src/lib/data/storage/handler/base-handler.ts
+++ b/src/lib/data/storage/handler/base-handler.ts
@@ -4,9 +4,7 @@ import {
   type BooksDbBookData,
   type BooksDbBookmarkData,
   type BooksDbStatistic,
-  type BooksDbReadingGoal,
-  type BooksDbAudioBook,
-  type BooksDbSubtitleData
+  type BooksDbReadingGoal
 } from '$lib/data/database/books-db/versions/books-db';
 import type { Section } from '$lib/data/database/books-db/versions/v4/books-db-v4';
 import { storageRootName } from '$lib/data/env';
@@ -30,11 +28,6 @@ import {
   ZipWriter,
   type Entry
 } from '@zip.js/zip.js';
-
-export enum FilePrefix {
-  AUDIO_BOOK = 'audioBook_',
-  SUBTITLE = 'subtitles_'
-}
 
 export interface ExternalFile {
   id: string;
@@ -73,12 +66,6 @@ export abstract class BaseStorageHandler {
     referenceFilename: string | undefined
   ): Promise<boolean>;
 
-  abstract isAudioBookPresentAndUpToDate(referenceFilename: string | undefined): Promise<boolean>;
-
-  abstract isSubtitleDataPresentAndUpToDate(
-    referenceFilename: string | undefined
-  ): Promise<boolean>;
-
   abstract getBook(): Promise<Omit<BooksDbBookData, 'id'> | File | undefined>;
 
   abstract getProgress(): Promise<BooksDbBookmarkData | File | undefined>;
@@ -95,10 +82,6 @@ export abstract class BaseStorageHandler {
     lastGoalModified: number;
   }>;
 
-  abstract getAudioBook(): Promise<BooksDbAudioBook | File | undefined>;
-
-  abstract getSubtitleData(): Promise<BooksDbSubtitleData | File | undefined>;
-
   abstract saveBook(
     data: Omit<BooksDbBookData, 'id'> | File,
     skipTimestampFallback?: boolean,
@@ -112,10 +95,6 @@ export abstract class BaseStorageHandler {
   abstract saveCover(data: Blob | undefined): Promise<void>;
 
   abstract saveReadingGoals(data: BooksDbReadingGoal[], lastGoalModified: number): Promise<void>;
-
-  abstract saveAudioBook(data: BooksDbAudioBook | File): Promise<void>;
-
-  abstract saveSubtitleData(data: BooksDbSubtitleData | File): Promise<void>;
 
   abstract deleteBookData(
     booksToDelete: string[],
@@ -687,18 +666,6 @@ export abstract class BaseStorageHandler {
         }.json`;
   }
 
-  protected static getAudioBookFileName(audioBook: BooksDbAudioBook | File) {
-    return audioBook instanceof File
-      ? audioBook.name
-      : `${FilePrefix.AUDIO_BOOK}${exporterVersion}_${currentDbVersion}_${audioBook.lastAudioBookModified}_${audioBook.playbackPosition}.json`;
-  }
-
-  protected static getSubtitleDataFileName(data: BooksDbSubtitleData | File) {
-    return data instanceof File
-      ? data.name
-      : `${FilePrefix.SUBTITLE}${exporterVersion}_${currentDbVersion}_${data.lastSubtitleDataModified}_${data.subtitleData.subtitles.length}.json`;
-  }
-
   protected static async getCoverFileName(cover: Blob) {
     const type = (await BaseStorageHandler.determineImageExtension(cover)) || 'jpeg';
 
@@ -735,28 +702,6 @@ export abstract class BaseStorageHandler {
       exporterVersion: +parts[1],
       dbVersion: +parts[2],
       lastGoalModified: +parts[3]
-    };
-  }
-
-  protected static getAudioBookMetadata(filename: string) {
-    const parts = filename.split('_').map((part) => part.replace(/\.json$/, ''));
-
-    return {
-      exporterVersion: +parts[1],
-      dbVersion: +parts[2],
-      lastAudioBookModified: +parts[3],
-      playbackPosition: +parts[4]
-    };
-  }
-
-  protected static getSubtitleDataMetadata(filename: string) {
-    const parts = filename.split('_').map((part) => part.replace(/\.json$/, ''));
-
-    return {
-      exporterVersion: +parts[1],
-      dbVersion: +parts[2],
-      lastSubtitleDataModified: +parts[3],
-      subtitleCount: +parts[4]
     };
   }
 

--- a/src/lib/data/storage/handler/browser-handler.ts
+++ b/src/lib/data/storage/handler/browser-handler.ts
@@ -1,11 +1,9 @@
-import { BaseStorageHandler, FilePrefix } from '$lib/data/storage/handler/base-handler';
+import { BaseStorageHandler } from '$lib/data/storage/handler/base-handler';
 import type {
-  BooksDbAudioBook,
   BooksDbBookData,
   BooksDbBookmarkData,
   BooksDbReadingGoal,
-  BooksDbStatistic,
-  BooksDbSubtitleData
+  BooksDbStatistic
 } from '$lib/data/database/books-db/versions/books-db';
 import { database, lastReadingGoalsModified$ } from '$lib/data/store';
 
@@ -135,16 +133,6 @@ export class BrowserStorageHandler extends BaseStorageHandler {
       fileName = lastGoalModified
         ? BaseStorageHandler.getReadingGoalsFileName(lastGoalModified)
         : undefined;
-    } else if (fileIdentifier === FilePrefix.AUDIO_BOOK) {
-      const audioBook = await this.getAudioBook();
-
-      fileName = audioBook ? BaseStorageHandler.getAudioBookFileName(audioBook) : undefined;
-    } else if (fileIdentifier === FilePrefix.SUBTITLE) {
-      const subtitleData = await this.getSubtitleData();
-
-      fileName = subtitleData
-        ? BaseStorageHandler.getSubtitleDataFileName(subtitleData)
-        : undefined;
     }
 
     BrowserStorageHandler.reportProgress(0.5);
@@ -223,44 +211,6 @@ export class BrowserStorageHandler extends BaseStorageHandler {
     );
   }
 
-  async isAudioBookPresentAndUpToDate(referenceFilename: string | undefined) {
-    if (!referenceFilename) {
-      BaseStorageHandler.reportProgress();
-
-      return false;
-    }
-
-    const audioBook = await this.getAudioBook();
-    const fileName = audioBook ? BaseStorageHandler.getAudioBookFileName(audioBook) : undefined;
-
-    return BaseStorageHandler.checkIsPresentAndUpToDate<BooksDbAudioBook>(
-      BaseStorageHandler.getAudioBookMetadata,
-      'lastAudioBookModified',
-      referenceFilename,
-      fileName
-    );
-  }
-
-  async isSubtitleDataPresentAndUpToDate(referenceFilename: string | undefined) {
-    if (!referenceFilename) {
-      BaseStorageHandler.reportProgress();
-
-      return false;
-    }
-
-    const subtitleData = await this.getSubtitleData();
-    const fileName = subtitleData
-      ? BaseStorageHandler.getSubtitleDataFileName(subtitleData)
-      : undefined;
-
-    return BaseStorageHandler.checkIsPresentAndUpToDate<BooksDbSubtitleData>(
-      BaseStorageHandler.getSubtitleDataMetadata,
-      'lastSubtitleDataModified',
-      referenceFilename,
-      fileName
-    );
-  }
-
   async getBook() {
     const book = this.currentContext.id
       ? await database.getData(this.currentContext.id)
@@ -306,22 +256,6 @@ export class BrowserStorageHandler extends BaseStorageHandler {
     BaseStorageHandler.reportProgress();
 
     return cover;
-  }
-
-  async getAudioBook() {
-    const audioBook = await database.getAudioBook(this.currentContext.title);
-
-    BaseStorageHandler.reportProgress();
-
-    return audioBook;
-  }
-
-  async getSubtitleData() {
-    const subtitleData = await database.getSubtitleData(this.currentContext.title);
-
-    BaseStorageHandler.reportProgress();
-
-    return subtitleData;
   }
 
   async saveBook(
@@ -444,26 +378,6 @@ export class BrowserStorageHandler extends BaseStorageHandler {
     }
 
     return { readingGoals, lastGoalModified };
-  }
-
-  async saveAudioBook(data: BooksDbAudioBook | File) {
-    if (data instanceof File) {
-      BaseStorageHandler.reportProgress();
-
-      return;
-    }
-
-    await database.putAudioBook(data);
-  }
-
-  async saveSubtitleData(data: BooksDbSubtitleData | File) {
-    if (data instanceof File) {
-      BaseStorageHandler.reportProgress();
-
-      return;
-    }
-
-    await database.putSubtitleData(data);
   }
 
   async deleteBookData(

--- a/src/lib/data/storage/handler/filesystem-handler.ts
+++ b/src/lib/data/storage/handler/filesystem-handler.ts
@@ -1,16 +1,14 @@
 import type {
-  BooksDbAudioBook,
   BooksDbBookData,
   BooksDbBookmarkData,
   BooksDbReadingGoal,
-  BooksDbStatistic,
-  BooksDbSubtitleData
+  BooksDbStatistic
 } from '$lib/data/database/books-db/versions/books-db';
 import { database, fsStorageSource$ } from '$lib/data/store';
 import { mergeReadingGoals, readingGoalSortFunction } from '$lib/data/reading-goal';
 import { mergeStatistics, updateStatisticToStore } from '$lib/functions/statistic-util';
 
-import { BaseStorageHandler, FilePrefix } from '$lib/data/storage/handler/base-handler';
+import { BaseStorageHandler } from '$lib/data/storage/handler/base-handler';
 import type { BookCardProps } from '$lib/components/book-card/book-card-props';
 import { MergeMode } from '$lib/data/merge-mode';
 import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
@@ -248,38 +246,6 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
     );
   }
 
-  async isAudioBookPresentAndUpToDate(referenceFilename: string | undefined) {
-    if (!referenceFilename) {
-      BaseStorageHandler.reportProgress();
-      return false;
-    }
-
-    const { file } = await this.getExternalFile(FilePrefix.AUDIO_BOOK, 1);
-
-    return BaseStorageHandler.checkIsPresentAndUpToDate<BooksDbAudioBook>(
-      BaseStorageHandler.getAudioBookMetadata,
-      'lastAudioBookModified',
-      referenceFilename,
-      file?.name
-    );
-  }
-
-  async isSubtitleDataPresentAndUpToDate(referenceFilename: string | undefined) {
-    if (!referenceFilename) {
-      BaseStorageHandler.reportProgress();
-      return false;
-    }
-
-    const { file } = await this.getExternalFile(FilePrefix.SUBTITLE, 1);
-
-    return BaseStorageHandler.checkIsPresentAndUpToDate<BooksDbSubtitleData>(
-      BaseStorageHandler.getSubtitleDataMetadata,
-      'lastSubtitleDataModified',
-      referenceFilename,
-      file?.name
-    );
-  }
-
   async getBook() {
     const { file } = await this.getExternalFile('bookdata_', this.isForBrowser ? 0.4 : 0.8);
 
@@ -366,49 +332,6 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
       readingGoals,
       lastGoalModified: BaseStorageHandler.getReadingGoalsMetadata(file.name).lastGoalModified
     };
-  }
-
-  async getAudioBook() {
-    const { file } = await this.getExternalFile(
-      FilePrefix.AUDIO_BOOK,
-      this.isForBrowser ? 0.6 : 0.8
-    );
-
-    if (!file) {
-      return undefined;
-    }
-
-    const audioBookFile = await file.getFile();
-
-    if (this.isForBrowser) {
-      const audioBook = JSON.parse(await FilesystemStorageHandler.readFileObject(audioBookFile));
-
-      BaseStorageHandler.reportProgress(0.4);
-      return audioBook;
-    }
-
-    return audioBookFile;
-  }
-
-  async getSubtitleData() {
-    const { file } = await this.getExternalFile(FilePrefix.SUBTITLE, this.isForBrowser ? 0.6 : 0.8);
-
-    if (!file) {
-      return undefined;
-    }
-
-    const subtitleDataFile = await file.getFile();
-
-    if (this.isForBrowser) {
-      const subtitleData = JSON.parse(
-        await FilesystemStorageHandler.readFileObject(subtitleDataFile)
-      );
-
-      BaseStorageHandler.reportProgress(0.4);
-      return subtitleData;
-    }
-
-    return subtitleDataFile;
   }
 
   async saveBook(data: Omit<BooksDbBookData, 'id'> | File, skipTimestampFallback = true) {
@@ -571,34 +494,6 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
       file,
       0.6,
       BaseStorageHandler.readingGoalsFilePrefix
-    );
-  }
-
-  async saveAudioBook(data: BooksDbAudioBook | File) {
-    const filename = BaseStorageHandler.getAudioBookFileName(data);
-    const { file, files, rootDirectory } = await this.getExternalFile(FilePrefix.AUDIO_BOOK);
-
-    await this.writeFile(
-      rootDirectory,
-      filename,
-      data instanceof File ? data : JSON.stringify(data),
-      files,
-      file,
-      0.6
-    );
-  }
-
-  async saveSubtitleData(data: BooksDbSubtitleData | File) {
-    const filename = BaseStorageHandler.getSubtitleDataFileName(data);
-    const { file, files, rootDirectory } = await this.getExternalFile(FilePrefix.SUBTITLE);
-
-    await this.writeFile(
-      rootDirectory,
-      filename,
-      data instanceof File ? data : JSON.stringify(data),
-      files,
-      file,
-      0.6
     );
   }
 

--- a/src/lib/data/storage/storage-types.ts
+++ b/src/lib/data/storage/storage-types.ts
@@ -10,9 +10,7 @@ export enum StorageDataType {
   DATA = 'data',
   PROGRESS = 'bookmark',
   STATISTICS = 'statistic',
-  READING_GOALS = 'readingGoal',
-  AUDIOBOOK = 'audioBook',
-  SUBTITLE = 'subtitle'
+  READING_GOALS = 'readingGoal'
 }
 
 export enum StorageSourceDefault {

--- a/src/lib/functions/replication/replicator.ts
+++ b/src/lib/functions/replication/replicator.ts
@@ -1,5 +1,5 @@
 import { BackupStorageHandler } from '$lib/data/storage/handler/backup-handler';
-import { BaseStorageHandler, FilePrefix } from '$lib/data/storage/handler/base-handler';
+import { BaseStorageHandler } from '$lib/data/storage/handler/base-handler';
 import { storage } from '$lib/data/window/navigator/storage';
 import { StorageDataType, StorageKey } from '$lib/data/storage/storage-types';
 import { database, requestPersistentStorage$ } from '$lib/data/store';
@@ -144,9 +144,7 @@ export async function importBackup(
       StorageDataType.DATA,
       StorageDataType.PROGRESS,
       StorageDataType.STATISTICS,
-      StorageDataType.READING_GOALS,
-      StorageDataType.AUDIOBOOK,
-      StorageDataType.SUBTITLE
+      StorageDataType.READING_GOALS
     ],
     cancelSignal
   );
@@ -173,8 +171,6 @@ export async function replicateData(
   const processProgressData = dataToReplicate.includes(StorageDataType.PROGRESS);
   const processStatistics = dataToReplicate.includes(StorageDataType.STATISTICS);
   const processReadingGoals = dataToReplicate.includes(StorageDataType.READING_GOALS);
-  const processAudioBook = dataToReplicate.includes(StorageDataType.AUDIOBOOK);
-  const processSubtitleData = dataToReplicate.includes(StorageDataType.SUBTITLE);
   const replicationLimiter = pLimit(1);
   const replicationTasks: Promise<void>[] = [];
 
@@ -267,52 +263,6 @@ export async function replicateData(
               }
 
               checkCancelAndProgress(cancelSignal, !dataProcessed, !statistics);
-            }
-          }
-
-          if (processAudioBook) {
-            if (
-              await targetHandler.isAudioBookPresentAndUpToDate(
-                await sourceHandler.getFilenameForRecentCheck(FilePrefix.AUDIO_BOOK)
-              )
-            ) {
-              checkCancelAndProgress(cancelSignal, !dataProcessed, true);
-              checkCancelAndProgress(cancelSignal, !dataProcessed, true);
-            } else {
-              const audioBook = await sourceHandler.getAudioBook();
-
-              checkCancelAndProgress(cancelSignal, !dataProcessed);
-
-              if (audioBook) {
-                await targetHandler.saveAudioBook(audioBook);
-
-                dataProcessed = true;
-              }
-
-              checkCancelAndProgress(cancelSignal, !dataProcessed, !audioBook);
-            }
-          }
-
-          if (processSubtitleData) {
-            if (
-              await targetHandler.isSubtitleDataPresentAndUpToDate(
-                await sourceHandler.getFilenameForRecentCheck(FilePrefix.SUBTITLE)
-              )
-            ) {
-              checkCancelAndProgress(cancelSignal, !dataProcessed, true);
-              checkCancelAndProgress(cancelSignal, !dataProcessed, true);
-            } else {
-              const subtitleData = await sourceHandler.getSubtitleData();
-
-              checkCancelAndProgress(cancelSignal, !dataProcessed);
-
-              if (subtitleData) {
-                await targetHandler.saveSubtitleData(subtitleData);
-
-                dataProcessed = true;
-              }
-
-              checkCancelAndProgress(cancelSignal, !dataProcessed, !subtitleData);
             }
           }
 

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -605,12 +605,6 @@
       syncedPromise.finally(() => document.dispatchEvent(new CustomEvent(SYNCED)));
     } else if (detail.type === 'skipKeyDownListener') {
       skipKeyDownListener$.next(detail.params.value);
-    } else if (
-      detail.type === 'sync' &&
-      (detail.syncType === StorageDataType.AUDIOBOOK ||
-        detail.syncType === StorageDataType.SUBTITLE)
-    ) {
-      scheduleReplication(detail.syncType);
     }
   }
   /** Experimental Code - May be removed any time without warning */
@@ -1065,13 +1059,7 @@
         localStorageHandler,
         false,
         [context],
-        [
-          StorageDataType.PROGRESS,
-          StorageDataType.STATISTICS,
-          StorageDataType.READING_GOALS,
-          StorageDataType.AUDIOBOOK,
-          StorageDataType.SUBTITLE
-        ]
+        [StorageDataType.PROGRESS, StorageDataType.STATISTICS, StorageDataType.READING_GOALS]
       );
 
       if (error) {
@@ -1287,17 +1275,13 @@
       }
 
       if (dataToReplicateQueue.length) {
-        const isAudioBookOnly =
-          dataToReplicate.length === 1 && dataToReplicate[0] === StorageDataType.AUDIOBOOK;
         dataToReplicate = JSON.parse(JSON.stringify(dataToReplicateQueue));
         dataToReplicateQueue = [];
 
-        if (isSilent || isAudioBookOnly) {
+        if (isSilent) {
           executeReplicate$.next();
-        } else if (!isAudioBookOnly) {
-          await executeReplication(false);
         } else {
-          dataToReplicate = [];
+          await executeReplication(false);
         }
       } else {
         dataToReplicate = [];


### PR DESCRIPTION
## Summary

Remove all plumbing for audiobook and subtitle features that were never completed in the upstream project. No UI for playback or display ever existed — just dead code in storage handlers, database operations, replicator logic, and export UI.

- Remove `AUDIOBOOK` and `SUBTITLE` from `StorageDataType` enum
- Remove abstract + concrete methods across all 4 storage handlers and backup handler (`isAudioBookPresentAndUpToDate`, `isSubtitleDataPresentAndUpToDate`, `getAudioBook`, `getSubtitleData`, `saveAudioBook`, `saveSubtitleData`)
- Remove `FilePrefix.AUDIO_BOOK` and `FilePrefix.SUBTITLE`
- Remove audiobook/subtitle processing from the replicator
- Remove audiobook/subtitle checkboxes from the export selection UI
- Remove `isAudioBookOnly` special-casing from the book reader page
- Remove `putAudioBook`, `putSubtitleData`, `getAudioBook`, `getSubtitleData` from database service
- Remove `BooksDbAudioBook` and `BooksDbSubtitleData` type exports

IndexedDB object stores and schema types in v6 are left in place to avoid needing a database migration.

**-555 lines across 11 files.**

## Test plan

- [x] App builds and runs
- [x] Book import still works
- [x] Export dialog no longer shows audiobook/subtitle checkboxes
- [x] Sync between storage sources still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)