### PR TITLE
fix: persist refresh tokens for default sources and simplify OAuth manager

### DIFF
--- a/src/lib/data/storage/storage-oauth-manager.ts
+++ b/src/lib/data/storage/storage-oauth-manager.ts
@@ -16,6 +16,7 @@ import {
 import { logger } from '$lib/data/logger';
 import {
   encrypt,
+  isAppDefault,
   unlockStorageData,
   type RemoteContext,
   type StorageUnlockAction
@@ -37,7 +38,7 @@ export const storageOAuthTokens = new Map<string, OAuthTokenData>();
 export class StorageOAuthManager {
   private storageType: StorageKey;
 
-  private refreshEndpoint;
+  private readonly refreshEndpoint;
 
   private parentWindow: Window | undefined;
 
@@ -84,27 +85,31 @@ export class StorageOAuthManager {
       this.storageSourceName = storageSourceName;
     }
 
+    // 1. Try the in-memory cached token
     let token = await this.verifyToken(oldToken);
 
     if (token) {
       return token.accessToken;
     }
 
+    // 2. Load credentials (and any stored refresh token)
     this.remoteData = undefined;
 
     let secret: string | undefined;
     let unlockResult = oldUnlockResult;
     let storageSource = oldStorageSource;
+    const defaultSource = isAppDefault(storageSourceName);
 
-    if (storageSourceName === StorageSourceDefault.GDRIVE_DEFAULT) {
+    if (defaultSource) {
+      const db = await database.db;
+      const stored = await db.get('storageSource', storageSourceName);
+      const storedData = stored?.data as RemoteContext | undefined;
+
+      const isGDrive = storageSourceName === StorageSourceDefault.GDRIVE_DEFAULT;
       this.remoteData = {
-        clientId: gDriveClientId,
-        clientSecret: gDriveClientSecret
-      };
-    } else if (storageSourceName === StorageSourceDefault.ONEDRIVE_DEFAULT) {
-      this.remoteData = {
-        clientId: oneDriveClientId,
-        clientSecret: ''
+        clientId: isGDrive ? gDriveClientId : oneDriveClientId,
+        clientSecret: isGDrive ? gDriveClientSecret : '',
+        refreshToken: storedData?.refreshToken
       };
     } else {
       if (!unlockResult) {
@@ -139,15 +144,18 @@ export class StorageOAuthManager {
         refreshToken: unlockResult.refreshToken
       };
 
-      token = await this.verifyToken(token);
-
-      if (token) {
-        return token.accessToken;
-      }
-
       secret = unlockResult.secret;
     }
 
+    // 3. Try refreshing with stored refresh token
+    token = await this.verifyToken(undefined);
+
+    if (token) {
+      storageOAuthTokens.set(storageSourceName, token);
+      return token.accessToken;
+    }
+
+    // 4. No valid token — need interactive auth
     this.parentWindow = window;
 
     logger.warn(`Opening auth window for ${storageSourceName} (${this.storageType})`);
@@ -206,45 +214,39 @@ export class StorageOAuthManager {
       throw new Error('Unable to open login window. Please check your popup settings');
     }
 
+    // 5. Wait for popup auth result and persist refresh token
     let errorMessage = '';
 
     try {
-      const existingStorageSourceData = storageSource || {
-        storedInManager: false,
-        encryptionDisabled: false
-      };
-
       token = await this.waitForAuth(window);
 
       storageOAuthTokens.set(storageSourceName, token);
 
-      if (
-        this.parentWindow &&
-        this.remoteData.clientId &&
-        (this.storageType !== StorageKey.GDRIVE || this.remoteData.clientSecret) &&
-        token.refreshToken &&
-        token.refreshToken !== this.remoteData.refreshToken &&
-        (secret || existingStorageSourceData.encryptionDisabled)
-      ) {
+      if (token.refreshToken && token.refreshToken !== this.remoteData.refreshToken) {
         this.remoteData.refreshToken = token.refreshToken;
 
         try {
           const db = await database.db;
-          const newData = existingStorageSourceData.encryptionDisabled
-            ? {
-                clientId: this.remoteData.clientId,
-                clientSecret: this.remoteData.clientSecret,
-                refreshToken: token.refreshToken
-              }
-            : await encrypt(
-                this.parentWindow,
-                JSON.stringify({
+          const existingStorageSourceData = storageSource || {
+            storedInManager: false,
+            encryptionDisabled: false
+          };
+          const newData =
+            defaultSource || existingStorageSourceData.encryptionDisabled
+              ? {
                   clientId: this.remoteData.clientId,
                   clientSecret: this.remoteData.clientSecret,
                   refreshToken: token.refreshToken
-                }),
-                secret!
-              );
+                }
+              : await encrypt(
+                  this.parentWindow,
+                  JSON.stringify({
+                    clientId: this.remoteData.clientId,
+                    clientSecret: this.remoteData.clientSecret,
+                    refreshToken: token.refreshToken
+                  }),
+                  secret!
+                );
 
           await db.put('storageSource', {
             ...existingStorageSourceData,
@@ -288,17 +290,9 @@ export class StorageOAuthManager {
         this.refreshEndpoint &&
         this.storageSourceName &&
         this.remoteData?.clientId &&
-        (this.storageType !== StorageKey.GDRIVE || this.remoteData.clientSecret) &&
         this.remoteData.refreshToken
       )
     ) {
-      logger.warn(
-        `Cannot refresh token for ${this.storageSourceName} (${this.storageType}): ` +
-          `refreshEndpoint=${!!this.refreshEndpoint}, ` +
-          `clientId=${!!this.remoteData?.clientId}, ` +
-          `clientSecret=${!!this.remoteData?.clientSecret}, ` +
-          `refreshToken=${!!this.remoteData?.refreshToken}`
-      );
       return undefined;
     }
 
@@ -359,29 +353,25 @@ export class StorageOAuthManager {
   }
 
   private async stashAuthData() {
-    if (!this.parentWindow || !this.remoteData) {
+    if (!this.remoteData) {
       return;
     }
 
     if (!this.codeVerifier) {
       const arr = new Uint8Array(32);
-      this.parentWindow.crypto.getRandomValues(arr);
+      crypto.getRandomValues(arr);
       this.codeVerifier = StorageOAuthManager.base64Url(arr);
     }
 
     const codeChallenge = StorageOAuthManager.base64Url(
       new Uint8Array(
-        await this.parentWindow.crypto.subtle.digest(
-          'SHA-256',
-          new TextEncoder().encode(this.codeVerifier)
-        )
+        await crypto.subtle.digest('SHA-256', new TextEncoder().encode(this.codeVerifier))
       )
     );
 
     const authData = {
       ...this.remoteData,
       ...StorageOAuthManager.getAuthVariables(this.storageType),
-      sendSecret: this.storageType === StorageKey.GDRIVE,
       needsRefreshToken: !this.remoteData.refreshToken,
       codeVerifier: this.codeVerifier,
       codeChallenge

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -39,7 +39,7 @@
         return;
       }
 
-      const { clientId, clientSecret, sendSecret, tokenEndpoint, codeVerifier, needsRefreshToken } =
+      const { clientId, clientSecret, tokenEndpoint, codeVerifier, needsRefreshToken } =
         JSON.parse(stored);
 
       const params = new URLSearchParams();
@@ -47,7 +47,7 @@
       params.append('redirect_uri', redirectUri);
       params.append('client_id', clientId);
 
-      if (sendSecret && clientSecret) {
+      if (clientSecret) {
         params.append('client_secret', clientSecret);
       }
 


### PR DESCRIPTION
## Summary

- **Fix refresh token persistence for default sources**: Default GDrive/OneDrive sources never persisted refresh tokens to IndexedDB — the persistence path required encryption credentials that only custom sources have. This caused a fresh auth popup on every page load. Now stores tokens as plain `RemoteContext` for default sources and reads them back on init.
- **Unified default source init**: Merged duplicate GDrive/OneDrive blocks into one
- **All sources try token refresh before popup**: Previously only custom sources attempted `verifyToken` → `refreshToken()` before opening the auth popup; default sources always went straight to the popup
- **Removed `sendSecret` flag**: Auth page now just checks `if (clientSecret)` — simpler and equivalent since OneDrive's secret is already empty
- **Removed noisy `refreshToken()` warning**: It fired on every first load before any auth had happened
- **Use global `crypto`** instead of `parentWindow.crypto`
- **Made `refreshEndpoint` readonly**
- **Simplified refresh precondition check**: Removed the `(storageType !== GDRIVE || clientSecret)` guard that was a vestige of the old "default sources have no secret" assumption

## Test plan

- [ ] First GDrive auth: consent screen, gets refresh token, persists to IndexedDB
- [ ] Reload page: no popup, silent token refresh
- [ ] First OneDrive auth: same flow, persists refresh token
- [ ] Reload: no popup
- [ ] Custom sources with encryption still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)