### PR TITLE
chore: replace StorageUnlock with messageDialog for iOS popup workaround

### DIFF
--- a/src/lib/components/message-dialog-content.svelte
+++ b/src/lib/components/message-dialog-content.svelte
@@ -13,5 +13,5 @@
 <h2 class={dialogTitleClasses}>{title}</h2>
 <p class="max-h-[60vh] overflow-auto whitespace-pre-line">{message}</p>
 <form method="dialog" class={dialogActionsClasses}>
-  <button use:ripple class={buttonClasses} value="close" type="submit">Close</button>
+  <button use:ripple class={buttonClasses} value="close" type="submit">OK</button>
 </form>

--- a/src/lib/data/simple-dialogs.ts
+++ b/src/lib/data/simple-dialogs.ts
@@ -47,7 +47,7 @@ export function confirmDialog({ title, message }: { title: string; message: stri
 }
 
 export function messageDialog({ title, message }: { title: string; message: string }) {
-  showDialog(
+  return showDialog(
     MessageDialogContent,
     { title, message },
     {

--- a/src/lib/data/storage/storage-oauth-manager.ts
+++ b/src/lib/data/storage/storage-oauth-manager.ts
@@ -1,6 +1,4 @@
-import StorageUnlock from '$lib/components/storage-unlock.svelte';
 import type { BooksDbStorageSource } from '$lib/data/database/books-db/versions/books-db';
-import { dialogManager } from '$lib/data/dialog-manager';
 import {
   gDriveAuthEndpoint,
   gDriveClientId,
@@ -23,6 +21,7 @@ import {
 } from '$lib/data/storage/storage-source-manager';
 import { StorageSourceDefault, StorageKey } from '$lib/data/storage/storage-types';
 import { database } from '$lib/data/store';
+import { messageDialog } from '$lib/data/simple-dialogs';
 import { convertAuthErrorResponse } from '$lib/functions/replication/error-handler';
 import { isMobile } from '$lib/functions/utils';
 
@@ -179,20 +178,9 @@ export class StorageOAuthManager {
 
     if (!this.authWindow) {
       if (shallUnlock) {
-        await new Promise<undefined>((resolver) => {
-          dialogManager.dialogs$.next([
-            {
-              component: StorageUnlock,
-              props: {
-                description: 'You are trying to access external data',
-                action: 'Login to your account when prompted',
-                requiresSecret: false,
-                encryptedData: undefined,
-                resolver
-              },
-              disableCloseOnClick: true
-            }
-          ]);
+        await messageDialog({
+          title: 'Login Required',
+          message: 'Log in to your cloud storage account when prompted.'
         });
 
         return this.getToken(


### PR DESCRIPTION
## Summary

- Replace the `StorageUnlock` component (used with `requiresSecret: false`, no encrypted data) with a simple `await messageDialog()` in the iOS popup workaround path
- Make `messageDialog` return its promise so callers can await it
- Removes `StorageUnlock` and `dialogManager` imports from the OAuth manager

## Test plan

- [ ] On iOS Safari (or with popup blocker): auth flow shows a simple message dialog, then opens the popup after user clicks OK
- [ ] Desktop auth flow (popup not blocked) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)