### PR TITLE
Improve book card progress bar colors and shape

### DIFF
--- a/src/lib/components/book-card/book-card.svelte
+++ b/src/lib/components/book-card/book-card.svelte
@@ -100,7 +100,9 @@
       </div>
       <div class="h-2.5 bg-gray-400/80">
         <div
-          class="h-full rounded-sm bg-linear-to-b from-red-600 to-red-900"
+          class="h-full bg-linear-to-b {progress >= 1
+            ? 'from-emerald-500 to-emerald-600'
+            : 'rounded-r-sm from-blue-500 to-blue-700'}"
           style:width="{progress * 100}%"
         ></div>
       </div>


### PR DESCRIPTION
## Summary
- Change progress bar color from red to **blue** for in-progress books (red looked like an error)
- Use **green** for 100% completed books to signal completion
- Only round the right edge of the bar at <100%; use flat edges at 100% so it fills the container cleanly

## Test plan
- [x] Verify in-progress books show a blue progress bar
- [x] Verify completed books show a green progress bar that fills the container edge-to-edge
- [x] Verify the right edge of the bar is slightly rounded at <100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)