### PR TITLE
fix: clear blocking dialog before opening tracker on book completion

### DIFF
--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -824,6 +824,7 @@
       }
 
       if ($statisticsEnabled$ && $openTrackerOnCompletion$) {
+        dialogManager.dialogs$.next([]);
         confettiWidthModifier = 36;
         confettiMaxRuns = 0;
         bookCompleted = window.matchMedia('(min-width: 900px)').matches;


### PR DESCRIPTION
## Summary
- When "open tracker on completion" is enabled, completing a book left a `bg-black/32` overlay blocking all interaction after closing the tracker
- The `completeBook()` function pushes a dummy dialog to block interaction during async completion work, but the "open tracker" branch never cleared it (unlike the else branch which calls `dialogManager.dialogs$.next([])`)
- Added the missing `dialogs$.next([])` call before opening the tracker

## Test plan
- [x] Complete a book with "open tracker on completion" enabled
- [x] Close the tracker and verify no overlay remains
- [x] Complete a book with the setting disabled and verify confetti still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)