### PR TITLE
Add completed flag to bookmarks for reliable book completion

### DIFF
--- a/src/lib/components/book-card/book-card-props.ts
+++ b/src/lib/components/book-card/book-card-props.ts
@@ -6,6 +6,7 @@ export interface BookCardProps {
   lastBookModified: number;
   lastBookOpen: number;
   progress: number;
+  completed: boolean;
   lastBookmarkModified: number;
   isPlaceholder: boolean;
 }

--- a/src/lib/components/book-card/book-card.svelte
+++ b/src/lib/components/book-card/book-card.svelte
@@ -8,11 +8,12 @@
     imagePath: string | Blob;
     title: string;
     progress: number;
+    completed: boolean;
     onclick?: MouseEventHandler<HTMLDivElement>;
     onkeyup?: KeyboardEventHandler<HTMLDivElement>;
   }
 
-  let { imagePath, title, progress, onclick, onkeyup }: Props = $props();
+  let { imagePath, title, progress, completed, onclick, onkeyup }: Props = $props();
 
   let objectUrl = '';
 
@@ -100,10 +101,10 @@
       </div>
       <div class="h-2.5 bg-gray-400/80">
         <div
-          class="h-full bg-linear-to-b {progress >= 1
+          class="h-full bg-linear-to-b {completed
             ? 'from-emerald-500 to-emerald-600'
             : 'rounded-r-sm from-blue-500 to-blue-700'}"
-          style:width="{progress * 100}%"
+          style:width="{completed ? 100 : progress * 100}%"
         ></div>
       </div>
     </div>

--- a/src/lib/components/book-reader/book-reader-header.svelte
+++ b/src/lib/components/book-reader/book-reader-header.svelte
@@ -36,7 +36,9 @@
     onbookmarkClick?: () => void;
     onscrollToBookmarkClick?: () => void;
     onjumpClick?: () => void;
+    isBookCompleted: boolean;
     oncompleteBook?: () => void;
+    onuncompleteBook?: () => void;
     onfullscreenClick?: () => void;
     onshowCustomReadingPoint?: () => void;
     onsetCustomReadingPoint?: () => void;
@@ -59,7 +61,9 @@
     onbookmarkClick,
     onscrollToBookmarkClick,
     onjumpClick,
+    isBookCompleted,
     oncompleteBook,
+    onuncompleteBook,
     onfullscreenClick,
     onshowCustomReadingPoint,
     onsetCustomReadingPoint,
@@ -111,9 +115,9 @@
     {/if}
     <HeaderButton
       faIcon={faFlag}
-      title="Complete book"
-      label="Complete Book"
-      onclick={() => oncompleteBook?.()}
+      title={isBookCompleted ? 'Mark book as not completed' : 'Mark book as completed'}
+      label={isBookCompleted ? 'Undo Complete' : 'Complete Book'}
+      onclick={() => (isBookCompleted ? onuncompleteBook?.() : oncompleteBook?.())}
     />
     {#if showFullscreenButton}
       <HeaderButton

--- a/src/lib/data/database/books-db/database.service.ts
+++ b/src/lib/data/database/books-db/database.service.ts
@@ -319,8 +319,9 @@ export class DatabaseService {
 
   async putBookmark(bookmarkData: BooksDbBookmarkData) {
     const db = await this.db;
-
-    return db.put('bookmark', bookmarkData);
+    const result = await db.put('bookmark', bookmarkData);
+    this.bookmarksChanged$.next();
+    return result;
   }
 
   async putLastItem(dataId: number) {

--- a/src/lib/data/database/books-db/versions/v6/books-db-v6.ts
+++ b/src/lib/data/database/books-db/versions/v6/books-db-v6.ts
@@ -47,6 +47,7 @@ interface BooksDbV6BookmarkData {
   scrollY?: number;
   exploredCharCount?: number;
   progress: number | string | undefined;
+  completed?: boolean;
   lastBookmarkModified: number;
 }
 

--- a/src/lib/data/storage/handler/base-handler.ts
+++ b/src/lib/data/storage/handler/base-handler.ts
@@ -325,6 +325,7 @@ export abstract class BaseStorageHandler {
         lastBookModified: 0,
         lastBookOpen: 0,
         progress: 0,
+        completed: false,
         lastBookmarkModified: 0,
         isPlaceholder: false
       }),

--- a/src/lib/data/storage/handler/filesystem-handler.ts
+++ b/src/lib/data/storage/handler/filesystem-handler.ts
@@ -627,6 +627,7 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
               lastBookModified: 0,
               lastBookOpen: 0,
               progress: 0,
+              completed: false,
               lastBookmarkModified: 0,
               isPlaceholder: false
             };

--- a/src/lib/data/storage/handler/gdrive-handler.ts
+++ b/src/lib/data/storage/handler/gdrive-handler.ts
@@ -335,6 +335,7 @@ export class GDriveStorageHandler extends ApiStorageHandler {
         lastBookModified: 0,
         lastBookOpen: 0,
         progress: 0,
+        completed: false,
         lastBookmarkModified: 0,
         isPlaceholder: false
       };

--- a/src/lib/data/storage/handler/onedrive-handler.ts
+++ b/src/lib/data/storage/handler/onedrive-handler.ts
@@ -431,6 +431,7 @@ export class OneDriveStorageHandler extends ApiStorageHandler {
       lastBookModified: 0,
       lastBookOpen: 0,
       progress: 0,
+      completed: false,
       lastBookmarkModified: 0,
       isPlaceholder: false
     };

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -216,6 +216,7 @@
   let frozenPosition = $state(-1);
   let skipFirstFreezeChange = $state(false);
   let bookCompleted = $state(false);
+  let isBookCompleted = $state(false);
   let confettiWidthModifier = $state(36);
   let confettiMaxRuns = $state(0);
   let showReaderImageGallery = $state(false);
@@ -581,6 +582,7 @@
     bookmarkData.then((data) => {
       hasBookmarkData = !!data;
       storedExploredCharacter = data?.exploredCharCount || 0;
+      isBookCompleted = !!data?.completed;
     });
   });
 
@@ -812,8 +814,7 @@
       if (bookmarkManager) {
         const data = {
           ...bookmarkManager.formatBookmarkData($rawBookData$.id, customReadingPointScrollOffset),
-          exploredCharCount: Math.max(0, bookCharCount - 1),
-          progress: 1
+          completed: true
         };
 
         await database.putBookmark(data);
@@ -844,6 +845,22 @@
     } catch ({ message }: any) {
       messageDialog({ title: 'Error', message: `Error completing book: ${message}` });
     }
+  }
+
+  async function uncompleteBook() {
+    const bookId = getBookIdSync();
+    if (!bookId || !bookmarkManager) return;
+
+    const data = {
+      ...bookmarkManager.formatBookmarkData(bookId, customReadingPointScrollOffset),
+      completed: false
+    };
+
+    await database.putBookmark(data);
+
+    bookmarkData = Promise.resolve(data);
+
+    scheduleReplication(StorageDataType.PROGRESS);
   }
 
   function getCurrentChapterProgress(sectionData: SectionWithProgress[]) {
@@ -1133,6 +1150,11 @@
       }
     } else {
       data = bookmarkManager.formatBookmarkData(bookId, customReadingPointScrollOffset);
+    }
+
+    const existingData = await bookmarkData;
+    if (existingData?.completed) {
+      data.completed = true;
     }
 
     await database.putBookmark(data);
@@ -1558,7 +1580,9 @@
         tocIsOpen$.set(true);
       }}
       onjumpClick={handleJump}
+      {isBookCompleted}
       oncompleteBook={completeBook}
+      onuncompleteBook={uncompleteBook}
       onsetCustomReadingPoint={handleSetCustomReadingPoint}
       onshowCustomReadingPoint={() => {
         showHeader = false;

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -117,9 +117,10 @@
     return b?.progress
       ? {
           progress: typeof b.progress === 'string' ? +b.progress.slice(0, -1) : b.progress,
+          completed: !!b.completed,
           lastBookmarkModified: b.lastBookmarkModified || 0
         }
-      : { progress: 0, lastBookmarkModified: 0 };
+      : { progress: 0, completed: false, lastBookmarkModified: 0 };
   }
 
   function sortBookCards(


### PR DESCRIPTION
## Summary
- Add a `completed` boolean to bookmark data, separate from `progress`, so auto-bookmark can't regress completion status
- Add "Undo Complete" toggle in the reader header to mark a book as not completed
- Book card progress bar shows green/100% based on `completed` flag instead of `progress >= 1`
- Fix `putBookmark` to notify `bookmarksChanged$` so the manage view reflects updates

## Test plan
- [x] Complete a book, verify green 100% bar in manage view
- [x] Re-open completed book, scroll around -- should stay green/completed
- [x] Press "Undo Complete", verify bar returns to blue with actual progress
- [x] Verify auto-bookmark still works normally for non-completed books

🤖 Generated with [Claude Code](https://claude.com/claude-code)