### PR TITLE
feat: convert log report dialog to native dialog

### DIFF
--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -257,8 +257,8 @@
           />
           <HeaderButton
             faIcon={faBug}
-            title="Report an issue"
-            label="Issue Report"
+            title="Report a bug"
+            label="Bug Report"
             onclick={() => onbugReportClick?.()}
           />
         {:else}

--- a/src/lib/components/log-report-dialog-content.svelte
+++ b/src/lib/components/log-report-dialog-content.svelte
@@ -1,7 +1,54 @@
+<script module lang="ts">
+  import LogReportDialogContent from '$lib/components/log-report-dialog-content.svelte';
+  import { showDialog, type DialogClosedBy } from '$lib/data/simple-dialogs';
+
+  export function showErrorDialogWithLogReport({
+    title,
+    message
+  }: {
+    title: string;
+    message: string;
+  }) {
+    return showLogReportDialog({
+      title,
+      message:
+        message +
+        ' Consider filing a bug report. If you do so, please include the attached log file with your report.',
+      closedBy: 'closerequest'
+    });
+  }
+
+  export function showBugReportDialog() {
+    return showLogReportDialog({
+      title: 'Bug Report',
+      message: 'Please include the attached log file with your report.',
+      closedBy: 'any'
+    });
+  }
+
+  function showLogReportDialog({
+    title,
+    message,
+    closedBy
+  }: {
+    title?: string;
+    message: string;
+    closedBy: DialogClosedBy;
+  }) {
+    return showDialog(
+      LogReportDialogContent,
+      { title, message },
+      {
+        closedBy,
+        resolveResult: () => undefined
+      }
+    );
+  }
+</script>
+
 <script lang="ts">
-  import DialogTemplate from '$lib/components/dialog-template.svelte';
   import { ripple } from '$lib/components/ripple';
-  import { buttonClasses } from '$lib/css-classes';
+  import { buttonClasses, dialogActionsClasses, dialogTitleClasses } from '$lib/css-classes';
   import { logger } from '$lib/data/logger';
   import { StorageSourceDefault } from '$lib/data/storage/storage-types';
   import {
@@ -79,11 +126,11 @@
   } from '$lib/data/store';
 
   interface Props {
-    title?: string;
+    title: string;
     message: string;
   }
 
-  let { title = 'Error', message }: Props = $props();
+  let { title, message }: Props = $props();
 
   const encodedLog = encodeURIComponent(
     JSON.stringify(
@@ -181,25 +228,16 @@
   const downloadableLog = `data:text/json;charset=utf-8,${encodedLog}`;
 </script>
 
-<DialogTemplate>
-  {#snippet header()}
-    {title}
-  {/snippet}
-  {#snippet content()}
-    <p>{message}</p>
-  {/snippet}
-  {#snippet footer()}
-    <a
-      use:ripple
-      class={buttonClasses}
-      href="https://github.com/domenic/miwake-reader"
-      target="_blank"
-      rel="noreferrer"
-    >
-      Open Repository
-    </a>
-    <a use:ripple class={buttonClasses} href={downloadableLog} download="log.json">
-      Download Report
-    </a>
-  {/snippet}
-</DialogTemplate>
+<h2 class={dialogTitleClasses}>{title}</h2>
+<p>{message}</p>
+<form method="dialog" class={dialogActionsClasses}>
+  <a
+    use:ripple
+    class={buttonClasses}
+    href="https://github.com/domenic/miwake-reader/issues"
+    target="_blank"
+    rel="noreferrer">Open Issue Tracker</a
+  >
+  <a use:ripple class={buttonClasses} href={downloadableLog} download="log.json">Download Logs</a>
+  <button use:ripple class={buttonClasses} value="close" type="submit">Close</button>
+</form>

--- a/src/lib/components/merged-header-icon/merged-entries.ts
+++ b/src/lib/components/merged-header-icon/merged-entries.ts
@@ -22,7 +22,7 @@ export const mergeEntries = {
     icon: faChartLine,
     title: 'Go to Statistics'
   },
-  BUG_REPORT: { routeId: '', label: 'Issue Report', icon: faBug, title: 'Report an Issue' },
+  BUG_REPORT: { routeId: '', label: 'Bug Report', icon: faBug, title: 'Report a bug' },
   FOLDER_IMPORT: {
     routeId: '',
     label: 'Import Folder',

--- a/src/lib/data/database/books-db/database.service.ts
+++ b/src/lib/data/database/books-db/database.service.ts
@@ -26,11 +26,10 @@ import type { BaseStorageHandler } from '$lib/data/storage/handler/base-handler'
 import type { BookStatistic } from '$lib/components/statistics/statistics-types';
 import type { BooksDb } from '$lib/data/database/books-db/versions/books-db';
 import type { IDBPDatabase } from 'idb';
-import LogReportDialog from '$lib/components/log-report-dialog.svelte';
+import { showErrorDialogWithLogReport } from '$lib/components/log-report-dialog-content.svelte';
 import { messageDialog } from '$lib/data/simple-dialogs';
 import { MergeMode } from '$lib/data/merge-mode';
 import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
-import { dialogManager } from '$lib/data/dialog-manager';
 import { getDefaultStatistic } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
 import { getStorageHandler } from '$lib/data/storage/storage-handler-factory';
 import { handleErrorDuringReplication } from '$lib/functions/replication/error-handler';
@@ -79,15 +78,7 @@ export class DatabaseService {
               logger.warn(error.message);
 
               if (showReport) {
-                dialogManager.dialogs$.next([
-                  {
-                    component: LogReportDialog,
-                    props: {
-                      title: 'Failure',
-                      message: 'Error(s) occurred'
-                    }
-                  }
-                ]);
+                showErrorDialogWithLogReport({ title: 'Failure', message: 'Errors occurred.' });
               } else {
                 messageDialog({
                   title: 'Error',

--- a/src/lib/data/simple-dialogs.ts
+++ b/src/lib/data/simple-dialogs.ts
@@ -4,10 +4,12 @@ import MessageDialogContent from '$lib/components/message-dialog-content.svelte'
 import NumberDialogContent from '$lib/components/number-dialog-content.svelte';
 import { dialogSurfaceClasses } from '$lib/css-classes';
 
-function showDialog<T>(
+export type DialogClosedBy = 'any' | 'closerequest' | 'none';
+
+export function showDialog<T>(
   component: Component<any>,
   props: Record<string, unknown>,
-  options: { closedBy: string; resolveResult: (returnValue: string) => T }
+  options: { closedBy: DialogClosedBy; resolveResult: (returnValue: string) => T }
 ): Promise<T> {
   return new Promise((resolve) => {
     const dialog = document.createElement('dialog');

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -32,7 +32,7 @@
     BookmarkManager,
     PageManager
   } from '$lib/components/book-reader/types';
-  import LogReportDialog from '$lib/components/log-report-dialog.svelte';
+  import { showErrorDialogWithLogReport } from '$lib/components/log-report-dialog-content.svelte';
   import StyleSheetRenderer from '$lib/components/style-sheet-renderer.svelte';
   import {
     autoBookmark$,
@@ -1250,15 +1250,10 @@
         logger.warn(error);
 
         if (showReport) {
-          dialogManager.dialogs$.next([
-            {
-              component: LogReportDialog,
-              props: {
-                title: 'Error Processing Data',
-                message: `Some or all data could not be saved to external storage.`
-              }
-            }
-          ]);
+          showErrorDialogWithLogReport({
+            title: 'Error Processing Data',
+            message: 'Some or all data could not be saved to external storage.'
+          });
         } else {
           messageDialog({
             title: 'Error Processing Data',

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -5,7 +5,10 @@
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
   import BookManagerHeader from '$lib/components/book-card/book-manager-header.svelte';
   import BookExportDialog from '$lib/components/book-export/book-export-dialog.svelte';
-  import LogReportDialog from '$lib/components/log-report-dialog.svelte';
+  import {
+    showBugReportDialog,
+    showErrorDialogWithLogReport
+  } from '$lib/components/log-report-dialog-content.svelte';
   import { preFilteredTitlesForStatistics$ } from '$lib/components/statistics/statistics-types';
   import { pxScreen } from '$lib/css-classes';
   import type { BooksDbBookmarkData } from '$lib/data/database/books-db/versions/books-db';
@@ -261,12 +264,12 @@
 
     const supportedExtRegex = /\.(?:htmlz|epub|txt)$/;
     const files = Array.from(fileList).filter((f) => supportedExtRegex.test(f.name));
-    const errorTitle = 'Bookimport failed';
+    const errorTitle = 'Book Import Failed';
 
     if (!files.length) {
       resetProgress();
 
-      showError(errorTitle, 'File(s) must be HTMLZ, TXT or EPUB', '');
+      showError(errorTitle, 'Imported files must be in EPUB, TXT, or HTMLZ format.');
       return;
     }
 
@@ -290,25 +293,17 @@
     resetProgress();
 
     if (error) {
-      showError(errorTitle, error, 'Error(s) occurred during book import.');
+      showError(errorTitle, error, 'An error occurred during book import.');
     }
   }
 
-  function showError(title: string, message: string, fallbackMessage: string) {
+  function showError(title: string, message: string, fallbackMessage: string = message) {
     const showReport = logger.errorCount > 1;
 
     logger.warn(message);
 
     if (showReport) {
-      dialogManager.dialogs$.next([
-        {
-          component: LogReportDialog,
-          props: {
-            title,
-            message: fallbackMessage
-          }
-        }
-      ]);
+      showErrorDialogWithLogReport({ title, message: fallbackMessage });
     } else {
       messageDialog({ title, message });
     }
@@ -377,7 +372,7 @@
     }
 
     if (error) {
-      showError('Deletion failed', error, 'Error(s) occurred during deletion');
+      showError('Deletion Failed', error, 'An error occurred during book deletion.');
     }
   }
 
@@ -386,7 +381,7 @@
       return;
     }
 
-    const errorTitle = 'Import failed';
+    const errorTitle = 'Import Failed';
 
     cancelTooltip = `Cancels the current Import\nAlready imported data will not be deleted`;
 
@@ -395,7 +390,7 @@
     if (!file.name.endsWith('.zip')) {
       resetProgress();
 
-      showError(errorTitle, 'Invalid file - expected zip archive', '');
+      showError(errorTitle, 'Only ZIP files can be imported.');
       return;
     }
 
@@ -427,20 +422,8 @@
     resetProgress();
 
     if (error) {
-      showError(errorTitle, error, 'Error(s) occurred during import');
+      showError(errorTitle, error, 'An error occurred during book import.');
     }
-  }
-
-  function onBugReportClick() {
-    dialogManager.dialogs$.next([
-      {
-        component: LogReportDialog,
-        props: {
-          title: 'Bug Report',
-          message: 'Please include the attached file for your report.'
-        }
-      }
-    ]);
   }
 
   function onReplicateData() {
@@ -504,9 +487,7 @@
     resetProgress();
 
     if (failed) {
-      const errorMessage = `Unable to delete statistics of ${pluralize(failed, 'Title')}`;
-
-      showError('Deletion Failed', errorMessage, errorMessage);
+      showError('Deletion Failed', `Unable to delete statistics for ${pluralize(failed, 'book')}.`);
     }
   }
 
@@ -585,7 +566,7 @@
       resetProgress();
 
       if (error) {
-        showError('Export failed', error, 'Error(s) occurred during export');
+        showError('Export Failed', error, 'Error(s) occurred during export.');
       }
     }),
     reduceToEmptyString()
@@ -616,7 +597,7 @@
     onselectAllClick={onSelectAllBooks}
     onremoveClick={() => removeBooks(Array.from(selectedBookIds))}
     onfilesChange={onFilesChange}
-    onbugReportClick={onBugReportClick}
+    onbugReportClick={showBugReportDialog}
     oncancelReplication={() => {
       if (!cancelSignal.aborted) {
         cancelToken.abort();


### PR DESCRIPTION
## Summary
- Replace the `dialogManager`-based `LogReportDialog` with a native `<dialog>` using the `showDialog` helper from `simple-dialogs.ts`
- Export `showDialog` and a new `DialogClosedBy` type so domain-specific dialogs can reuse them
- Split into `showErrorDialogWithLogReport` (for error paths, `closedBy: 'closerequest'`) and `showBugReportDialog` (for manual bug reports, `closedBy: 'any'`)
- Clean up error messages and button labels for consistency

Helps with #11.

## Test plan
- [ ] Trigger an error during book import (e.g. import an invalid file type) with `logger.errorCount > 1` to verify `showErrorDialogWithLogReport` renders correctly
- [x] Click the bug report button in the manager header to verify `showBugReportDialog` works
- [x] Verify "Download Logs" link downloads valid JSON
- [x] Verify "Open Issue Tracker" link opens the correct GitHub URL
- [x] Verify the Close button and backdrop click dismiss the dialog appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)