### PR TITLE
Show Import Folder based on capability, not isMobile

### DIFF
--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -27,7 +27,6 @@
   } from '$lib/data/store';
   import { inputAllowDirectory } from '$lib/functions/file-dom/input-allow-directory';
   import { inputFile } from '$lib/functions/file-dom/input-file';
-  import { isMobile$ } from '$lib/functions/utils';
   import {
     faArrowDownShortWide,
     faArrowDownWideShort,
@@ -45,6 +44,8 @@
   import Fa from 'svelte-fa';
   import { quintOut } from 'svelte/easing';
   import { scale } from 'svelte/transition';
+
+  const supportsDirectoryPicking = !browser || 'webkitdirectory' in HTMLInputElement.prototype;
 
   interface Props {
     selectMode: boolean;
@@ -241,7 +242,7 @@
             label="Import Files"
             onclick={() => fileImportElm?.click()}
           />
-          {#if !$isMobile$}
+          {#if supportsDirectoryPicking}
             <HeaderButton
               faIcon={faFolderPlus}
               title="Import books from a folder"


### PR DESCRIPTION
## Summary
- Replace `!$isMobile$` guard on the Import Folder button with a direct `webkitdirectory` feature check
- `isMobile$` uses `maxTouchPoints > 0` which is true on touchscreen laptops (e.g. Surface), incorrectly hiding the button
- Default to `true` during SSR to avoid a flash when hydrating

## Test plan
- [x] Verify Import Folder button appears on desktop (including touchscreen laptops)
- [x] Verify Import Folder button appears on browsers that support `webkitdirectory`
- [x] Verify no flash during page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)