### PR TITLE
fix: restore character tracking in statistics

### DIFF
--- a/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte
+++ b/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte
@@ -326,6 +326,7 @@
 
       lastTrackerFlushTime = now;
       lastTrackerTick = now;
+      updateLastExploredCharCount();
 
       return interval(1000);
     }),
@@ -360,12 +361,6 @@
 
   $effect(() => {
     updateReadingGoalWindowForPausedState($isTrackerMenuOpen$);
-  });
-
-  $effect(() => {
-    if (!$isTrackerPaused$) {
-      updateLastExploredCharCount();
-    }
   });
 
   $effect(() => {


### PR DESCRIPTION
## Summary
- The Svelte 5 migration (aef6f64) broke character counting in statistics by converting a `$:` statement to `$effect` without accounting for deep dependency tracking through called functions
- `updateLastExploredCharCount()` was re-running on every scroll, zeroing out the diff before `processTicks` could record it
- Moved the call into the RxJS `switchMap` that already handles pause→unpause transitions, avoiding the dependency tracking issue without `untrack()`

Fixes #72.

## Test plan
- [x] Open a book and start the tracker
- [x] Read for a bit (scroll through pages)
- [x] Open the tracker menu and verify characters read is non-zero
- [x] Check the statistics page heatmap shows character data for the session
- [x] Verify pausing and unpausing the tracker still correctly resets the character baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)