### PR TITLE
Expand privacy policy for Google API compliance

### DIFF
--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -6,12 +6,46 @@
     transmitted to any server operated by Miwake Reader.
   </p>
 
+  <h2 class="mb-3 mt-6 text-xl font-semibold">Google Drive integration</h2>
+
   <p class="mb-4">
-    If you choose to connect a Google Drive or OneDrive account, the app accesses only files it
-    creates in a dedicated folder (<code>miwake-reader-data</code>). OAuth tokens are stored locally
-    in your browser and are never sent to any third party. The app requests the minimum necessary
-    scope (<code>drive.file</code> for Google Drive, <code>files.readwrite</code> for OneDrive).
+    If you choose to connect a Google Drive account, the app requests the
+    <code>drive.file</code> OAuth scope. This is the minimum scope that allows the app to create, read,
+    and update only the files it itself creates. It does not grant access to any other files in your Google
+    Drive.
   </p>
+
+  <h3 class="mb-2 mt-4 text-lg font-semibold">Data accessed</h3>
+  <p class="mb-4">
+    The app creates and accesses files within a <code>Miwake Reader</code> folder in your Google
+    Drive. These files contain your book data, reading progress, bookmarks, cover images, reading
+    statistics, and reading goals. The <code>drive.file</code> scope means the app cannot access, read,
+    or modify any files it did not create.
+  </p>
+
+  <h3 class="mb-2 mt-4 text-lg font-semibold">Data usage</h3>
+  <p class="mb-4">
+    Your Google Drive data is used solely to sync your reading data across your own devices. The app
+    reads data from Google Drive to restore your reading state, and writes data back to Google Drive
+    to keep it up to date. No other processing is performed on this data.
+  </p>
+
+  <h3 class="mb-2 mt-4 text-lg font-semibold">Data storage and sharing</h3>
+  <p class="mb-4">
+    Miwake Reader has no backend server. Your Google OAuth tokens and all data read from Google
+    Drive are stored locally in your browser only. They are never transmitted to any server operated
+    by Miwake Reader or shared with any third party.
+  </p>
+
+  <h2 class="mb-3 mt-6 text-xl font-semibold">OneDrive integration</h2>
+
+  <p class="mb-4">
+    If you choose to connect a OneDrive account, the app requests the
+    <code>files.readwrite.appfolder</code> scope and uses only its dedicated app folder. The same data
+    access, usage, storage, and sharing practices described above for Google Drive apply equally to OneDrive.
+  </p>
+
+  <h2 class="mb-3 mt-6 text-xl font-semibold">Analytics</h2>
 
   <p>No analytics, tracking, or telemetry of any kind is used.</p>
 </div>


### PR DESCRIPTION
## Summary
- Expands the privacy policy with explicit sections on **data accessed**, **data usage**, and **data storage/sharing** for the Google Drive integration
- Fixes incorrect folder name and OneDrive scope references
- Adds separate OneDrive and Analytics sections

Google's API Services User Data Policy review requires these details to be spelled out clearly.

## Test plan
- [ ] Verify privacy page renders correctly at `/privacy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)