### PR TITLE
fix: deduplicate concurrent OAuth auth attempts

### DIFF
--- a/src/lib/data/storage/storage-oauth-manager.ts
+++ b/src/lib/data/storage/storage-oauth-manager.ts
@@ -63,12 +63,42 @@ export class StorageOAuthManager {
 
   private authTimeoutTimer: number | undefined;
 
+  private pendingGetToken: Promise<string | undefined> | undefined;
+
   constructor(type: StorageKey, refreshEndpoint: string) {
     this.storageType = type;
     this.refreshEndpoint = refreshEndpoint;
   }
 
   async getToken(
+    window: Window,
+    storageSourceName: string,
+    askForStorageUnlock: boolean,
+    authWindow?: Window | null,
+    oldUnlockResult?: StorageUnlockAction,
+    oldStorageSource?: BooksDbStorageSource | undefined
+  ): Promise<string | undefined> {
+    if (this.pendingGetToken) {
+      return this.pendingGetToken;
+    }
+
+    this.pendingGetToken = this.doGetToken(
+      window,
+      storageSourceName,
+      askForStorageUnlock,
+      authWindow,
+      oldUnlockResult,
+      oldStorageSource
+    );
+
+    try {
+      return await this.pendingGetToken;
+    } finally {
+      this.pendingGetToken = undefined;
+    }
+  }
+
+  private async doGetToken(
     window: Window,
     storageSourceName: string,
     askForStorageUnlock: boolean,
@@ -183,7 +213,7 @@ export class StorageOAuthManager {
           message: 'Log in to your cloud storage account when prompted.'
         });
 
-        return this.getToken(
+        return this.doGetToken(
           window,
           storageSourceName,
           false,


### PR DESCRIPTION
## Summary
- When multiple requests needed a token simultaneously (e.g. during book load after token expiry), each would independently fail refresh and open its own auth popup window
- The second call overwrote the first's `authResolver`/`broadcastChannel`/`authTimeoutTimer`, leaving the first call's promise unresolvable — it would always hit the 120s timeout
- Track the in-flight `getToken` promise so concurrent callers share it instead of racing through interactive auth
- The recursive self-call (popup-blocked retry) uses `doGetToken` directly to avoid deadlocking against the dedup guard

## Test plan
- [ ] Reproduce by triggering a book load when the refresh token is expired (forces interactive auth)
- [ ] Verify only one auth popup opens instead of two
- [ ] Verify book loads successfully after completing auth
- [ ] Verify popup-blocked fallback path still works (e.g. on mobile where popup may be blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)