### PR TITLE
fix: complete ttu→miwake rename for dummy book images

### DIFF
--- a/src/lib/functions/book-data-loader/format-book-data-html.ts
+++ b/src/lib/functions/book-data-loader/format-book-data-html.ts
@@ -51,7 +51,7 @@ function getHtmlWithImageSource(bookData: BooksDbBookData, isPaginated: boolean)
       objectUrls.push(url);
       urlIndexes.set(url, elementHtml.indexOf(dummyUrl));
 
-      elementHtml = elementHtml.replaceAll(dummyUrl, url).replaceAll(`ttu:${key}`, url);
+      elementHtml = elementHtml.replaceAll(dummyUrl, url).replaceAll(`miwake:${key}`, url);
     });
     subscriber.next(elementHtml);
 

--- a/src/lib/functions/file-loaders/utils/build-dummy-book-image.ts
+++ b/src/lib/functions/file-loaders/utils/build-dummy-book-image.ts
@@ -1,3 +1,3 @@
 export default function buildDummyBookImage(key: string) {
-  return `data:image/gif;ttu:${key};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`;
+  return `data:image/gif;miwake:${key};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`;
 }


### PR DESCRIPTION
## Summary
- The rename in af28478 updated `clearAllBadImageRef` to check for the `miwake:` prefix but missed `buildDummyBookImage` and the fallback replacement in `format-book-data-html`, which still used `ttu:`
- This caused `clearAllBadImageRef` to strip all `<img src>` attributes for inline images during EPUB import (SVG `<image xlink:href>` elements like cover pages were unaffected)

## Test plan
- [x] Import an EPUB that uses `<img>` tags for inline images (e.g. 羊をめぐる冒険) and verify images display correctly inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)