### PR TITLE
Simplify responsive layout and remove xl breakpoints

### DIFF
--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -5,7 +5,7 @@
   import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import Popover from '$lib/components/popover/popover.svelte';
-  import { baseHeaderClasses, headerDividerClasses, pxScreen } from '$lib/css-classes';
+  import { baseHeaderClasses, headerDividerClasses } from '$lib/css-classes';
   import { appName } from '$lib/data/env';
   import { SortDirection } from '$lib/data/sort-types';
   import { FilesystemStorageHandler } from '$lib/data/storage/handler/filesystem-handler';
@@ -85,8 +85,6 @@
     onsyncData,
     oncancelReplication
   }: Props = $props();
-
-  const nTranslateXHeaderMat = '-translate-x-3 xl:-translate-x-2.5';
 
   const inAnimationParams = {
     delay: 150,
@@ -192,8 +190,8 @@
 />
 <div class={baseHeaderClasses}>
   {#if !replicationToProgress}
-    <div class="flex h-full justify-between {pxScreen}">
-      <div class="flex transform-gpu {nTranslateXHeaderMat}">
+    <div class="flex h-full justify-between">
+      <div class="flex">
         <HeaderButton
           title={selectMode ? 'Disable book selection' : 'Enable book selection'}
           label="Select"
@@ -201,11 +199,7 @@
           onclick={() => (selectMode = hasBooks && !selectMode)}
         >
           {#snippet icon()}
-            <svg
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-3.5 w-3.5 xl:h-3 xl:w-3"
-            >
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5">
               <path
                 class="fill-current"
                 d="M20,4v12H8V4H20 M20,2H8C6.9,2,6,2.9,6,4v12c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2L20,2z M12.47,14 L9,10.5l1.4-1.41l2.07,2.08L17.6,6L19,7.41L12.47,14z M4,6H2v14c0,1.1,0.9,2,2,2h14v-2H4V6z"
@@ -215,7 +209,7 @@
         </HeaderButton>
         {#if selectMode}
           <span
-            class="flex items-center px-2 text-xl font-medium xl:text-lg"
+            class="flex items-center px-2 text-xl font-medium"
             title="{selectedCount} {selectedCount === 1 ? 'book' : 'books'} selected"
             >{selectedCount}</span
           >
@@ -251,11 +245,7 @@
         {:else}
           <HeaderButton title="Select all books" label="All" onclick={() => onselectAllClick?.()}>
             {#snippet icon()}
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                class="h-3.5 w-3.5 xl:h-3 xl:w-3"
-              >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-3.5 w-3.5">
                 <path
                   class="fill-current"
                   d="M18 7l-1.41-1.41-6.34 6.34 1.41 1.41L18 7zm4.24-1.41L11.66 16.17 7.48 12l-1.41 1.41L11.66 19l12-12-1.42-1.41zM.41 13.41L6 19l1.41-1.41L1.83 12 .41 13.41z"
@@ -323,7 +313,7 @@
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox={$storageIcon$.viewBox}
-                    class="h-3.5 w-3.5 xl:h-3 xl:w-3"
+                    class="h-3.5 w-3.5"
                   >
                     <path class="fill-current" d={$storageIcon$.d} />
                   </svg>
@@ -426,7 +416,7 @@
   {:else}
     <div
       title="Cancel operation"
-      class="mx-auto flex h-full transform-gpu items-center justify-center px-4 md:px-8 lg:max-w-4xl xl:max-w-none 2xl:max-w-6xl"
+      class="mx-auto flex h-full items-center justify-center px-4 max-w-6xl"
       in:scale={inAnimationParams}
       out:scale={outAnimationParams}
     >

--- a/src/lib/components/book-reader/book-reader-header.svelte
+++ b/src/lib/components/book-reader/book-reader-header.svelte
@@ -14,12 +14,7 @@
   import HeaderButton from '$lib/components/header-button.svelte';
   import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
-  import {
-    baseHeaderClasses,
-    headerDividerClasses,
-    nTranslateXHeaderFa,
-    translateXHeaderFa
-  } from '$lib/css-classes';
+  import { baseHeaderClasses, headerDividerClasses } from '$lib/css-classes';
   import { customReadingPointEnabled$, viewMode$ } from '$lib/data/store';
   import { ViewMode } from '$lib/data/view-mode';
   import { isMobile$ } from '$lib/functions/utils';
@@ -81,8 +76,8 @@
   ]);
 </script>
 
-<div class="flex justify-between px-4 md:px-8 {baseHeaderClasses}">
-  <div class="flex transform-gpu {nTranslateXHeaderFa}">
+<div class="flex justify-between {baseHeaderClasses}">
+  <div class="flex">
     {#if hasChapterData}
       <HeaderButton
         faIcon={faList}
@@ -106,10 +101,7 @@
       />
     {/if}
     {#if $viewMode$ === ViewMode.Continuous && !$isMobile$}
-      <div
-        class="flex items-center px-4 text-xl xl:px-3 xl:text-lg"
-        title="Current autoscroll speed"
-      >
+      <div class="flex items-center px-4 text-xl" title="Current autoscroll speed">
         {autoScrollMultiplier}x
       </div>
     {/if}
@@ -145,7 +137,7 @@
     {/if}
   </div>
 
-  <div class="flex transform-gpu {translateXHeaderFa}">
+  <div class="flex">
     {#if $customReadingPointEnabled$ || $viewMode$ === ViewMode.Paginated}
       <HeaderMenuButton
         faIcon={faCrosshairs}

--- a/src/lib/components/header-button.svelte
+++ b/src/lib/components/header-button.svelte
@@ -31,9 +31,8 @@
     icon
   }: Props = $props();
 
-  const iconWrapperBaseClasses = 'flex items-center justify-center leading-none';
-  const labeledIconWrapperClasses = `${iconWrapperBaseClasses} mb-0.5`;
-  const labeledFontAwesomeIconClasses = `${labeledIconWrapperClasses} text-sm xl:text-xs`;
+  const iconClasses = 'flex items-center justify-center leading-none mb-0.5';
+  const faIconClasses = `${iconClasses} text-sm`;
   const inAnimationParams = {
     delay: 150,
     duration: 150,
@@ -44,8 +43,8 @@
     easing: quintOut
   };
   const variantClasses = {
-    action: 'min-w-16 px-2 opacity-60 transition-opacity xl:text-[10px]',
-    tab: 'px-3'
+    action: 'opacity-60 transition-opacity',
+    tab: ''
   } satisfies Record<Variant, string>;
 </script>
 
@@ -56,7 +55,7 @@
   out:scale={outAnimationParams}
   {title}
   {disabled}
-  class={`flex h-12 flex-col items-center justify-center text-center text-xs select-none xl:h-10 ${variantClasses[variant]}`}
+  class={`flex h-12 min-w-16 flex-col items-center justify-center px-2 text-center text-xs select-none ${variantClasses[variant]}`}
   class:opacity-100={variant === 'action' && selected}
   class:bg-gray-900={variant === 'tab' && selected}
   class:hover:bg-gray-800={variant === 'tab' && selected}
@@ -67,11 +66,11 @@
   {onclick}
 >
   {#if icon}
-    <span class={labeledIconWrapperClasses}>
+    <span class={iconClasses}>
       {@render icon()}
     </span>
   {:else if faIcon}
-    <Fa icon={faIcon} class={labeledFontAwesomeIconClasses} />
+    <Fa icon={faIcon} class={faIconClasses} />
   {/if}
 
   {#if label}

--- a/src/lib/components/settings/settings-header.svelte
+++ b/src/lib/components/settings/settings-header.svelte
@@ -4,7 +4,7 @@
   import HeaderButton from '$lib/components/header-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import type { SettingsRoute } from '$lib/components/settings/settings-route';
-  import { baseHeaderClasses, pxScreen } from '$lib/css-classes';
+  import { baseHeaderClasses } from '$lib/css-classes';
 
   interface Props {
     activeRouteId?: RouteId | null;
@@ -39,7 +39,7 @@
 </script>
 
 <div class={baseHeaderClasses}>
-  <div class="{pxScreen} flex h-full justify-between px-0 md:px-5">
+  <div class="flex h-full justify-between">
     <div class="flex">
       {#each settingItems as settingItem (settingItem.label)}
         <HeaderButton

--- a/src/lib/components/statistics/statistics-header.svelte
+++ b/src/lib/components/statistics/statistics-header.svelte
@@ -17,7 +17,7 @@
     statisticsTitleFilterIsOpen$,
     type StatisticsDataSource
   } from '$lib/components/statistics/statistics-types';
-  import { baseHeaderClasses, headerDividerClasses, pxScreen } from '$lib/css-classes';
+  import { baseHeaderClasses, headerDividerClasses } from '$lib/css-classes';
 
   interface Props {
     activeRouteId?: RouteId | null;
@@ -38,7 +38,7 @@
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
   <div class={baseHeaderClasses}>
-    <div class="{pxScreen} flex h-full justify-between px-0 md:px-5">
+    <div class="flex h-full justify-between">
       <div class="flex">
         <HeaderButton
           faIcon={faCalendarDays}

--- a/src/lib/css-classes.ts
+++ b/src/lib/css-classes.ts
@@ -1,14 +1,11 @@
-export const baseHeaderClasses = 'relative h-12 bg-gray-700 text-white xl:h-10';
-export const pHeaderMat = 'p-2.5';
-export const pxScreen = 'px-4 md:px-8 lg:max-w-4xl xl:max-w-none 2xl:max-w-6xl mx-auto';
-export const opacityHeaderIcon = 'opacity-60 hover:opacity-100 transition-opacity';
-export const nTranslateXHeaderFa = '-translate-x-4 xl:-translate-x-3';
-export const translateXHeaderFa = 'translate-x-4 xl:translate-x-3';
+export const baseHeaderClasses = 'relative h-12 bg-gray-700 text-white';
+export const pxScreen = 'px-4 max-w-6xl mx-auto';
 export const inputClasses =
   'mt-1 block w-full px-0.5 bg-background-color border-0 border-b-2 border-b-gray-400/50 focus:ring-0 focus:border-b-black focus:outline-hidden transition-colors';
 export const buttonClasses =
   'inline-block no-underline font-medium rounded-sm min-w-[32px] sm:min-w-[64px] px-4 leading-9 cursor-pointer text-cyan-900';
-export const baseIconClasses = `flex justify-center select-none items-center h-12 w-12 cursor-pointer text-xl xl:h-10 xl:w-10 xl:text-lg ${pHeaderMat} ${opacityHeaderIcon}`;
+export const baseIconClasses =
+  'flex justify-center select-none items-center h-12 w-12 cursor-pointer text-xl p-2.5 opacity-60 hover:opacity-100 transition-opacity';
 export const headerDividerClasses = 'mx-1 h-6 w-px self-center bg-white/30';
 export const dialogSurfaceClasses = 'mdc-elevation--z24 rounded-sm bg-white p-6';
 export const dialogTitleClasses = 'weight-medium mb-5 text-xl';

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -612,7 +612,7 @@
 
 <div
   role="application"
-  class="{pxScreen} h-full pt-16 xl:pt-14"
+  class="{pxScreen} h-full pt-16"
   ondragenter={(ev) => ev.preventDefault()}
   ondragover={(ev) => ev.preventDefault()}
   ondragend={(ev) => ev.preventDefault()}

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -29,8 +29,6 @@
   <SettingsHeader {activeRouteId} onselect={navigateToSettingsSection} />
 </div>
 
-<div class="{pxScreen} h-full pt-16 xl:pt-14">
-  <div class="max-w-5xl">
-    {@render children?.()}
-  </div>
+<div class="{pxScreen} h-full pt-16">
+  {@render children?.()}
 </div>

--- a/src/routes/statistics/+layout.svelte
+++ b/src/routes/statistics/+layout.svelte
@@ -152,7 +152,7 @@
   onselecttab={navigateToStatisticsTab}
 />
 
-<div class="{pxScreen} flex h-full flex-col pt-16 xl:pt-14">
+<div class="{pxScreen} flex h-full flex-col pt-16">
   {@render children?.()}
 </div>
 


### PR DESCRIPTION
## Summary
- Remove inconsistent side padding from all toolbars (reader, settings, statistics, manager) — toolbars now have zero side padding at all widths
- Replace breakpoint-dependent content width strategy (`lg:max-w-4xl xl:max-w-none 2xl:max-w-6xl`) with a single `max-w-6xl mx-auto` centered layout
- Remove the xl (1280px) toolbar size reduction — toolbar stays 48px tall at all widths, no more shrinking icons/text/height
- Unify HeaderButton sizing across action and tab variants (same `min-w-16 px-2 text-xs`)
- Remove unnecessary wrapper div and dead CSS class exports (`pHeaderMat`, `opacityHeaderIcon`, `nTranslateXHeaderFa`, `translateXHeaderFa`)

Helps with #15.

## Test plan
- [x] Verify all four toolbars (reader, settings, statistics, manager) have no side padding gaps at any width
- [x] Verify content areas (settings, statistics, manager) center correctly with max-width at wide viewports
- [x] Resize across breakpoints and confirm no layout jumps at 768px, 1024px, or 1280px
- [x] Check toolbar button labels (e.g. "Bug Report", "Import Files") don't overflow at any width

🤖 Generated with [Claude Code](https://claude.com/claude-code)