### PR TITLE
fix: improve image rendering and spoiler handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ _Note: the refreshed interface, especially the top bars, has not yet been adapte
 
 ### Book content presentation fixes
 
+- Inline images (fractions, symbols, decorative glyphs) are no longer broken out of text flow, or included in the image gallery.
+- The "after table of contents" spoiler mode no longer hides cover pages in books with no table of contents.
 - Section-break margins in EPUBs are now preserved correctly in vertical writing mode.
 - Furigana on the rightmost line of text is no longer clipped in vertical paginated mode.
 

--- a/src/lib/components/book-reader/styles.css
+++ b/src/lib/components/book-reader/styles.css
@@ -2,6 +2,16 @@
   font-family: var(--font-family-serif, 'Lora', 'Noto Serif JP', serif);
 }
 
+/* Undo Tailwind Preflight's display: block / vertical-align: middle on replaced
+   elements so that EPUB content renders with browser defaults (inline). The
+   :where() keeps specificity at zero so any reader-specific rules still win. */
+.book-content {
+  :global(:where(img, svg, video, canvas, audio, iframe, embed, object)) {
+    display: revert;
+    vertical-align: revert;
+  }
+}
+
 .book-content {
   :global(.ttu-book-html-wrapper.ttu-no-text),
   :global(.ttu-book-body-wrapper.ttu-no-text) {
@@ -9,6 +19,7 @@
   }
 
   :global(svg) {
+    display: block;
     margin: auto;
   }
 
@@ -35,8 +46,7 @@
   }
 
   :global(.ttu-img-parent) {
-    display: flex;
-    justify-content: center;
+    display: contents;
   }
 
   &:not(.ttu-apply-important) {
@@ -189,8 +199,6 @@
 .book-content--hide-spoiler-image {
   :global([data-miwake-spoiler-img]) {
     display: inline-block;
-    width: 100%;
-    height: 100%;
     vertical-align: middle;
     overflow: hidden;
     position: relative;

--- a/src/lib/functions/book-data-loader/format-book-data-html.ts
+++ b/src/lib/functions/book-data-loader/format-book-data-html.ts
@@ -16,8 +16,8 @@ export default function formatBookDataHtml(
   isPaginated: boolean,
   blurMode: BlurMode
 ) {
-  return getHtmlWithImageSource(bookData, isPaginated).pipe(
-    map((elementHtml) => {
+  return getHtmlWithImageSource(bookData).pipe(
+    map(({ elementHtml, objectUrls, urlIndexes }) => {
       const element = document.createElement('div');
       element.innerHTML = elementHtml;
 
@@ -26,14 +26,21 @@ export default function formatBookDataHtml(
       removeSvgDimensions(element);
       addSpoilerTags(element, document, blurMode);
       removeOldBrTagSolution(element);
+      publishImageGallery(element, objectUrls, urlIndexes, isPaginated);
 
       return element.innerHTML;
     })
   );
 }
 
-function getHtmlWithImageSource(bookData: BooksDbBookData, isPaginated: boolean) {
-  return new Observable<string>((subscriber) => {
+interface HtmlWithImageSource {
+  elementHtml: string;
+  objectUrls: string[];
+  urlIndexes: Map<string, number>;
+}
+
+function getHtmlWithImageSource(bookData: BooksDbBookData) {
+  return new Observable<HtmlWithImageSource>((subscriber) => {
     const { blobs } = bookData;
     const objectUrls: string[] = [];
     const urlIndexes = new Map<string, number>();
@@ -53,21 +60,7 @@ function getHtmlWithImageSource(bookData: BooksDbBookData, isPaginated: boolean)
 
       elementHtml = elementHtml.replaceAll(dummyUrl, url).replaceAll(`miwake:${key}`, url);
     });
-    subscriber.next(elementHtml);
-
-    const readerImageGalleryPictures: ReaderImageGalleryPicture[] = objectUrls.map((url) => ({
-      url,
-      unspoilered: !isPaginated
-    }));
-
-    readerImageGalleryPictures.sort((picture1, picture2) => {
-      const index1 = urlIndexes.get(picture1.url) || 0;
-      const index2 = urlIndexes.get(picture2.url) || 0;
-
-      return index1 - index2;
-    });
-
-    readerImageGalleryPictures$.next(readerImageGalleryPictures);
+    subscriber.next({ elementHtml, objectUrls, urlIndexes });
 
     return () => {
       objectUrls.forEach((url) => URL.revokeObjectURL(url));
@@ -75,34 +68,78 @@ function getHtmlWithImageSource(bookData: BooksDbBookData, isPaginated: boolean)
   });
 }
 
-function addImageContainerClass(el: HTMLElement) {
-  Array.from(el.getElementsByTagName('img'))
-    .map((imgEl) => ({ parentEl: imgEl.parentElement, isGaiji: isElementGaiji(imgEl) }))
-    .forEach(({ parentEl, isGaiji }) => {
-      parentEl?.classList.add('ttu-img-container');
+function publishImageGallery(
+  el: HTMLElement,
+  objectUrls: string[],
+  urlIndexes: Map<string, number>,
+  isPaginated: boolean
+) {
+  const inlineImageUrls = new Set<string>();
+  for (const img of el.getElementsByTagName('img')) {
+    if (isImageInline(img)) {
+      inlineImageUrls.add(img.src);
+    }
+  }
 
-      if (!isGaiji) {
-        parentEl?.classList.add('ttu-illustration-container');
-      }
-    });
+  const readerImageGalleryPictures: ReaderImageGalleryPicture[] = objectUrls
+    .filter((url) => !inlineImageUrls.has(url))
+    .map((url) => ({ url, unspoilered: !isPaginated }));
+
+  readerImageGalleryPictures.sort((picture1, picture2) => {
+    const index1 = urlIndexes.get(picture1.url) || 0;
+    const index2 = urlIndexes.get(picture2.url) || 0;
+
+    return index1 - index2;
+  });
+
+  readerImageGalleryPictures$.next(readerImageGalleryPictures);
+}
+
+function addImageContainerClass(el: HTMLElement) {
+  for (const imgEl of el.getElementsByTagName('img')) {
+    const parentEl = imgEl.parentElement!;
+    parentEl.classList.add('ttu-img-container');
+
+    if (!isImageInline(imgEl)) {
+      parentEl.classList.add('ttu-illustration-container');
+    }
+  }
+}
+
+function isImageInline(el: Element): boolean {
+  if (el instanceof HTMLImageElement && isElementGaiji(el)) {
+    return true;
+  }
+
+  const parent = el.parentElement;
+  if (!parent) return false;
+
+  for (const sibling of parent.childNodes) {
+    if (sibling === el) continue;
+    const text = sibling.textContent?.replace(/[\s\u3000]+/g, '');
+    if (text) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function removeSvgDimensions(el: HTMLElement) {
-  Array.from(el.getElementsByTagName('svg')).forEach((tag) => {
+  for (const tag of el.getElementsByTagName('svg')) {
     tag.removeAttribute('width');
     tag.removeAttribute('height');
-  });
+  }
 }
 
 function addSpoilerTags(el: HTMLElement, document: Document, blurMode: BlurMode) {
   const getChildNodesAfterTableOfContents = () => {
-    let childNodes = [...el.children];
-    const afterContentsDivIndex =
-      childNodes.findIndex((childNode) => childNode.getElementsByTagName('a').length > 1) + 1;
-    if (afterContentsDivIndex > 0 && afterContentsDivIndex < childNodes.length) {
-      childNodes = childNodes.slice(afterContentsDivIndex);
-    }
-    return childNodes;
+    const childNodes = [...el.children];
+    const tocIndex = childNodes.findIndex(
+      (childNode) => childNode.getElementsByTagName('a').length > 1
+    );
+    // Skip up to and including the TOC page, or just the cover (first child) if no TOC found
+    const startIndex = tocIndex === -1 ? 1 : tocIndex + 1;
+    return childNodes.slice(startIndex);
   };
 
   const createWrapper = (tag: Element, childNode: Element) => {
@@ -121,11 +158,11 @@ function addSpoilerTags(el: HTMLElement, document: Document, blurMode: BlurMode)
     : [...el.children]
   ).forEach((childNode) => {
     Array.from(childNode.getElementsByTagName('img'))
-      .filter((tag) => !isElementGaiji(tag))
+      .filter((tag) => !isImageInline(tag))
       .forEach((tag) => createWrapper(tag, childNode));
 
     Array.from(childNode.getElementsByTagName('svg'))
-      .filter((tag) => tag.getElementsByTagName('image').length)
+      .filter((tag) => tag.getElementsByTagName('image').length && !isImageInline(tag))
       .forEach((tag) => createWrapper(tag, childNode));
   });
 }


### PR DESCRIPTION
## Summary

- Inline images (fractions, symbols, decorative glyphs) are no longer broken out of text flow or included in the image gallery
- Spoiler blur wrapper uses `display: contents` so it doesn't disrupt layout when inactive
- Reverts Tailwind Preflight's `display: block` on replaced elements within book content
- "After TOC" spoiler mode skips the cover page when no inline TOC is found

## Test plan

- [x] Open 羊をめぐる冒険: inline fraction images (1/3, 1/5000) and pointing hand glyphs should render inline within text, not as block illustrations
- [x] Open わたし、定時で帰ります。: the "VS." image in the 解説 chapter should render inline
- [x] Open ソードアート・オンライン1: cover page should not be spoiler-blurred; first page should not be blank
- [x] Verify image gallery does not contain small inline/gaiji images
- [x] Verify spoiler blur still works on actual illustration images (after TOC)

Fixes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)