### PR TITLE
fix: request offline_access scope for OneDrive to enable token refresh

### DIFF
--- a/src/lib/data/env.ts
+++ b/src/lib/data/env.ts
@@ -24,5 +24,6 @@ export const oneDriveTokenEndpoint =
 export const oneDriveDiscoveryEndpoint =
   import.meta.env.VITE_ONEDRIVE_DISCOVERY ||
   'https://login.microsoftonline.com/consumers/v2.0/.well-known/openid-configuration';
-export const oneDriveScope = import.meta.env.VITE_ONEDRIVE_SCOPE || 'files.readwrite.appfolder';
+export const oneDriveScope =
+  import.meta.env.VITE_ONEDRIVE_SCOPE || 'files.readwrite.appfolder offline_access';
 export const oneDriveClientId = import.meta.env.VITE_ONEDRIVE_CLIENT_ID || '';


### PR DESCRIPTION
## Summary
- OneDrive currently forces a re-auth roughly every 24 hours, failing with `AADSTS70000: The user could not be authenticated as the grant is expired`.
- Root cause: the OneDrive scope omits `offline_access`. Microsoft's OAuth v2.0 endpoint requires that scope to issue long-lived refresh tokens; without it the grant is session-bound and expires. (The existing `access_type=offline` param in the auth flow is Google-specific and ignored by Microsoft.)
- Fix: add `offline_access` to the default OneDrive scope in `src/lib/data/env.ts`.

No Azure app registration changes needed — `offline_access` is a standard OIDC scope accepted without pre-registration.

## Test plan
- [ ] Existing OneDrive users will re-auth once (their current refresh token was issued without `offline_access`).
- [ ] Confirm the consent screen shows "Maintain access to data you have given it access to" (the `offline_access` consent string).
- [ ] After re-auth, leave the app for >24h and confirm no re-auth popup appears — token refresh should happen silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)