### PR TITLE
docs: add minimal terms of service page

### DIFF
--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,0 +1,23 @@
+<div class="mx-auto max-w-2xl p-8">
+  <h1 class="mb-6 text-2xl font-bold">Terms of Service</h1>
+
+  <p class="mb-4">
+    Hi. Miwake Reader is a small, free, open-source web app made by one person in their spare time.
+    This page exists because OAuth providers want a link to one.
+  </p>
+
+  <p class="mb-4">
+    The actual "terms": use the app, enjoy the app, don't do anything illegal with it, and please
+    don't sue me if it breaks. It probably will break occasionally. Keep your own backups of
+    anything you care about.
+  </p>
+
+  <p class="mb-4">
+    For the boring details about what data the app touches and where it goes, see the <a
+      class="underline"
+      href="/privacy">Privacy Policy</a
+    >. That one is written a bit more carefully.
+  </p>
+
+  <p>That's it. Happy reading.</p>
+</div>


### PR DESCRIPTION
## Summary
- Adds a `/terms` page so OAuth providers (OneDrive in particular) have a terms-of-service link to point at.
- Intentionally minimal and informal — acknowledges it's a small personal web app, defers the substantive stuff to the existing Privacy Policy.

## Test plan
- [x] Visit `/terms` and confirm it renders.
- [x] Confirm the link to `/privacy` works.
- [x] Use the URL in the Azure app registration's terms-of-service field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)