### PR TITLE
[codex] reduce noisy sync activity while reading

### DIFF
--- a/src/lib/components/bottom-left-cluster.svelte
+++ b/src/lib/components/bottom-left-cluster.svelte
@@ -35,6 +35,7 @@
       location: syncState.location,
       health: syncState.health,
       online: $isOnline$,
+      pending: syncState.isSyncPending,
       syncing: syncState.isSyncing
     })
   );
@@ -43,6 +44,7 @@
     disabled: faCloudArrowUp,
     offline: faWifi,
     idle: faCircleCheck,
+    pending: faCloudArrowUp,
     syncing: faArrowsRotate,
     'needs-attention': faTriangleExclamation,
     error: faCircleXmark
@@ -56,6 +58,7 @@
     disabled: 'text-gray-400',
     offline: 'text-gray-400',
     idle: 'text-emerald-500/80',
+    pending: 'text-sky-500/80',
     syncing: 'text-sky-500',
     'needs-attention': 'text-amber-500',
     error: 'text-red-500'
@@ -71,6 +74,8 @@
         return indicator.lastSyncedAt
           ? `Synced ${formatRelativeTimeLive(indicator.lastSyncedAt)}`
           : 'Up to date';
+      case 'pending':
+        return 'Sync pending…';
       case 'syncing':
         return 'Syncing…';
       case 'needs-attention':

--- a/src/lib/components/settings/sync/sync-data-management-section.svelte
+++ b/src/lib/components/settings/sync/sync-data-management-section.svelte
@@ -121,8 +121,12 @@
       title: 'Force full re-sync',
       description:
         'Walk every file in your library to ensure there are no differences between your sync location and this device. Useful if you suspect something drifted.',
-      action: syncState.isSyncing ? 'Syncing…' : 'Re-sync',
-      disabled: syncState.isSyncing,
+      action: syncState.isSyncing
+        ? 'Syncing…'
+        : syncState.isSyncPending
+          ? 'Sync pending…'
+          : 'Re-sync',
+      disabled: syncState.isSyncing || syncState.isSyncPending,
       onclick: onForceResync
     },
     {

--- a/src/lib/data/sync/backup-service.ts
+++ b/src/lib/data/sync/backup-service.ts
@@ -13,7 +13,7 @@ import { BaseStorageHandler } from '$lib/data/storage/handler/base-handler';
 import { getLocalEndpoint, getSyncEndpoint } from '$lib/data/storage/storage-handler-factory';
 import { StorageDataType, SyncEndpointType } from '$lib/data/storage/storage-types';
 import { replicateData } from '$lib/functions/replication/replicator';
-import { scopedSettings } from '$lib/data/sync/sync-engine';
+import { scopedSettings, syncAfterSourceConnected } from '$lib/data/sync/sync-engine';
 
 /**
  * Reading-goal data lives in two places: archived goals in IDB's
@@ -331,6 +331,13 @@ export async function importBackup(
   }
 
   backupHandler.clearData();
+
+  // Boot no longer runs a whole-library push. If a backup import
+  // changed local library data, mirror it before the hard reload can
+  // discard the in-memory ambient queue.
+  if (booksImported > 0 || readingGoalsImported) {
+    await syncAfterSourceConnected({ immediate: true, reason: 'backup-import' });
+  }
 
   // localStorage-backed stores don't observe storage events, so we
   // need a hard reload for app-settings to take effect. Even without

--- a/src/lib/data/sync/source-manager.ts
+++ b/src/lib/data/sync/source-manager.ts
@@ -247,11 +247,12 @@ async function completeFsConnection(
   // inert until mirrored to this source.
   await reconcileAfterAuthoritativeListing(books, sourceInstanceId);
 
-  // Mirror existing local content into the new folder. Ambient sync
-  // only fires on local edits; without this, a fresh connect with an
-  // empty folder would stay empty until the user happened to bookmark
-  // something.
-  await syncAfterSourceConnected();
+  // Mirror existing local content into a newly-attached folder.
+  // Same-source re-grants keep their source id and do not need a
+  // whole-library verification pass.
+  if (!opts.reuseSourceInstanceId) {
+    await syncAfterSourceConnected({ reason: 'fs-connect' });
+  }
 }
 
 async function completeCloudConnection(
@@ -345,7 +346,9 @@ async function completeCloudConnection(
     // See completeFsConnection for the install-before-reconcile rationale.
     await reconcileAfterAuthoritativeListing(books, sourceInstanceId);
 
-    await syncAfterSourceConnected();
+    if (!opts.reuseSourceInstanceId) {
+      await syncAfterSourceConnected({ reason: 'cloud-connect' });
+    }
   } finally {
     if (!authWindow.closed) {
       authWindow.close();

--- a/src/lib/data/sync/sync-engine.ts
+++ b/src/lib/data/sync/sync-engine.ts
@@ -225,7 +225,7 @@ interface PendingPush {
 export type LocalMutationSync =
   | { kind: 'book-data'; context: ReplicationContext }
   | { kind: 'progress'; context: ReplicationContext }
-  | { kind: 'statistics'; context: ReplicationContext }
+  | { kind: 'statistics'; context: ReplicationContext; debounceMs?: number; immediate?: boolean }
   | { kind: 'reading-goals' }
   | { kind: 'books-deleted'; titles: string[]; cancelSignal: AbortSignal }
   | { kind: 'statistics-deleted'; titles: string[] }
@@ -260,6 +260,10 @@ function endLongRunning(): void {
   emitSyncingState();
 }
 
+function formatTypes(types: Iterable<StorageDataType>): string {
+  return [...types].join(',');
+}
+
 /** Key by book title so concurrent edits to the same book coalesce. */
 function pendingKey(context: ReplicationContext): string {
   return context.title;
@@ -278,7 +282,11 @@ export function syncAfterLocalMutation(mutation: LocalMutationSync): void | Prom
     case 'progress':
       return queueBookPush(StorageDataType.PROGRESS, mutation.context);
     case 'statistics':
-      return queueBookPush(StorageDataType.STATISTICS, mutation.context);
+      return queueBookPush(StorageDataType.STATISTICS, mutation.context, {
+        debounceMs: mutation.debounceMs,
+        immediate: mutation.immediate,
+        reason: mutation.immediate ? 'reader-exit' : 'local-mutation'
+      });
     case 'reading-goals':
       return queueGoalsPush();
     case 'books-deleted':
@@ -296,13 +304,13 @@ export function syncAfterLocalMutation(mutation: LocalMutationSync): void | Prom
  * debounce window coalesce into one push of the union of types.
  * For library-scoped reading goals use `queueGoalsPush()` instead.
  */
-function queueBookPush(dataType: BookDataType, context: ReplicationContext): void {
-  if (!isPushAllowed()) return;
+function addPendingBookPush(dataType: BookDataType, context: ReplicationContext): boolean {
+  if (!isPushAllowed()) return false;
   const key = pendingKey(context);
   if (dataType === StorageDataType.DATA) {
     canceledBookPushTitles.delete(key);
   } else if (canceledBookPushTitles.has(key)) {
-    return;
+    return false;
   }
   const existing = pending.get(key);
   if (existing) {
@@ -310,8 +318,25 @@ function queueBookPush(dataType: BookDataType, context: ReplicationContext): voi
   } else {
     pending.set(key, { context, types: new Set([dataType]) });
   }
-  syncState.isSyncing = true;
-  schedulePushRun();
+  return true;
+}
+
+function queueBookPush(
+  dataType: BookDataType,
+  context: ReplicationContext,
+  {
+    debounceMs = PUSH_DEBOUNCE_MS,
+    immediate = false,
+    reason = 'local-mutation'
+  }: { debounceMs?: number; immediate?: boolean; reason?: string } = {}
+): void {
+  if (!addPendingBookPush(dataType, context)) return;
+  logger.debug(
+    `sync queue: ${reason}, title=${JSON.stringify(context.title)}, ` +
+      `type=${dataType}, debounceMs=${debounceMs}, immediate=${immediate}`
+  );
+  emitSyncingState();
+  schedulePushRun(immediate ? 0 : debounceMs, reason);
 }
 
 /**
@@ -323,8 +348,9 @@ function queueBookPush(dataType: BookDataType, context: ReplicationContext): voi
 function queueGoalsPush(): void {
   if (!isPushAllowed()) return;
   pendingGoalsPush = true;
-  syncState.isSyncing = true;
-  schedulePushRun();
+  logger.debug('sync queue: reading-goals');
+  emitSyncingState();
+  schedulePushRun(PUSH_DEBOUNCE_MS, 'reading-goals');
 }
 
 function isPushAllowed(): boolean {
@@ -364,9 +390,16 @@ function cancelBookPushes(titles: string[]): void {
  * Placeholders (no elementHtml) are skipped — they have nothing to
  * push.
  */
-async function pushAllLocalBooks(): Promise<void> {
+async function pushAllLocalBooks({
+  immediate,
+  reason
+}: {
+  immediate: boolean;
+  reason: string;
+}): Promise<void> {
   const db = await database.db;
   const all = await db.getAll('data');
+  let queuedBooks = 0;
   for (const book of all) {
     if (!book.elementHtml) continue;
     const context: ReplicationContext = {
@@ -374,27 +407,51 @@ async function pushAllLocalBooks(): Promise<void> {
       title: book.title,
       imagePath: book.coverImage || ''
     };
-    queueBookPush(StorageDataType.DATA, context);
-    queueBookPush(StorageDataType.PROGRESS, context);
-    queueBookPush(StorageDataType.STATISTICS, context);
+    if (addPendingBookPush(StorageDataType.DATA, context)) queuedBooks += 1;
+    addPendingBookPush(StorageDataType.PROGRESS, context);
+    addPendingBookPush(StorageDataType.STATISTICS, context);
   }
   // Reading goals are library-scoped — without this, a fresh connect
   // with zero downloaded books (or only placeholders) would never
   // mirror the user's goals up to the new source.
-  queueGoalsPush();
+  pendingGoalsPush = true;
+  logger.debug(
+    `sync queue: ${reason}, full local mirror queued ` +
+      `${queuedBooks} book(s), immediate=${immediate}`
+  );
+  emitSyncingState();
+  if (immediate) {
+    if (pushTimer) {
+      clearTimeout(pushTimer);
+      pushTimer = null;
+    }
+    await runPendingPushes();
+  } else {
+    schedulePushRun(PUSH_DEBOUNCE_MS, reason);
+  }
 }
 
-export async function syncAfterSourceConnected(): Promise<void> {
+export async function syncAfterSourceConnected({
+  immediate = false,
+  reason = 'source-connected'
+}: {
+  immediate?: boolean;
+  reason?: string;
+} = {}): Promise<void> {
   if (!isPushAllowed()) return;
-  await pushAllLocalBooks();
+  await pushAllLocalBooks({ immediate, reason });
 }
 
-function schedulePushRun(): void {
+function schedulePushRun(delayMs = PUSH_DEBOUNCE_MS, reason = 'local-mutation'): void {
   if (pushTimer) clearTimeout(pushTimer);
   pushTimer = setTimeout(() => {
     pushTimer = null;
     void runPendingPushes();
-  }, PUSH_DEBOUNCE_MS);
+  }, delayMs);
+  logger.debug(
+    `sync queue: scheduled run in ${delayMs}ms (${reason}); ` +
+      `pendingBooks=${pending.size}, pendingGoals=${pendingGoalsPush}`
+  );
 }
 
 async function runPendingPushes(): Promise<void> {
@@ -415,6 +472,12 @@ async function runPendingPushes(): Promise<void> {
   emitSyncingState();
 
   try {
+    logger.debug(
+      `sync run: starting batch with ${batch.size} book(s), goals=${runGoals}, ` +
+        `types=${[...batch.values()]
+          .map(({ context, types }) => `${JSON.stringify(context.title)}:[${formatTypes(types)}]`)
+          .join('; ')}`
+    );
     for (const { context, types } of batch.values()) {
       await pushOne(context, [...types]);
     }
@@ -423,15 +486,16 @@ async function runPendingPushes(): Promise<void> {
     }
   } finally {
     pushRunning = false;
-    if (pending.size > 0 || pendingGoalsPush) schedulePushRun();
+    if ((pending.size > 0 || pendingGoalsPush) && !pushTimer) schedulePushRun();
     emitSyncingState();
   }
 }
 
 function emitSyncingState(): void {
-  const active =
-    pushRunning || pending.size > 0 || pendingGoalsPush || pushTimer !== null || longRunningOps > 0;
+  const active = pushRunning || longRunningOps > 0;
+  const pendingWork = pending.size > 0 || pendingGoalsPush || pushTimer !== null;
   if (syncState.isSyncing !== active) syncState.isSyncing = active;
+  if (syncState.isSyncPending !== pendingWork) syncState.isSyncPending = pendingWork;
 }
 
 async function pushOne(context: ReplicationContext, types: BookDataType[]): Promise<void> {
@@ -456,8 +520,14 @@ async function pushOne(context: ReplicationContext, types: BookDataType[]): Prom
 
   const local = localEndpoint();
   const handler = endpointFor(location);
+  const started = Date.now();
+  const typeLabel = formatTypes(types);
 
   try {
+    logger.debug(
+      `sync push: start title=${JSON.stringify(context.title)}, ` +
+        `location=${location.kind}, types=[${typeLabel}]`
+    );
     if (location.kind === 'cloud') {
       await handler.authenticate(null, true);
     }
@@ -478,6 +548,10 @@ async function pushOne(context: ReplicationContext, types: BookDataType[]): Prom
       await markBookMirroredToSource(context.id, expectedSourceInstanceId);
     }
     markSynced();
+    logger.debug(
+      `sync push: complete title=${JSON.stringify(context.title)}, ` +
+        `types=[${typeLabel}], durationMs=${Date.now() - started}`
+    );
   } catch (err) {
     const recoverable = reportSyncError('push', err);
     if (recoverable) enqueueReplay(() => pushOne(context, types));
@@ -503,8 +577,10 @@ async function pushGoals(): Promise<void> {
 
   const local = localEndpoint();
   const handler = endpointFor(location);
+  const started = Date.now();
 
   try {
+    logger.debug(`sync push: start reading-goals, location=${location.kind}`);
     if (location.kind === 'cloud') {
       await handler.authenticate(null, true);
     }
@@ -518,6 +594,7 @@ async function pushGoals(): Promise<void> {
       settings: scopedSettings()
     });
     markSynced();
+    logger.debug(`sync push: complete reading-goals, durationMs=${Date.now() - started}`);
   } catch (err) {
     const recoverable = reportSyncError('push (goals)', err);
     if (recoverable) enqueueReplay(() => pushGoals());
@@ -873,15 +950,6 @@ export async function syncEngineStart(): Promise<void> {
   });
 
   await reconcileBooksOnBoot();
-
-  // Mirror the local library upward at every boot. Catches any books
-  // the source is missing — including the post-importBackup reload
-  // (where the in-flight ambient triggers were dropped by the reload)
-  // and any other path that writes to the library without firing
-  // mutation notification. isBookPresentAndUpToDate short-circuits
-  // the no-op case, so the cost when nothing changed is one cheap
-  // check per book.
-  void syncAfterSourceConnected();
 }
 
 /**

--- a/src/lib/data/sync/sync-state.ts
+++ b/src/lib/data/sync/sync-state.ts
@@ -4,6 +4,7 @@ export type SyncIndicatorState =
   | { kind: 'disabled' }
   | { kind: 'offline' }
   | { kind: 'idle'; lastSyncedAt: number | null }
+  | { kind: 'pending' }
   | { kind: 'syncing' }
   | {
       kind: 'needs-attention';
@@ -19,11 +20,13 @@ export function deriveIndicatorState({
   location,
   health,
   online,
+  pending,
   syncing
 }: {
   location: SyncLocation | null;
   health: SyncLocationHealth;
   online: boolean;
+  pending: boolean;
   syncing: boolean;
 }): SyncIndicatorState {
   if (!location) return { kind: 'disabled' };
@@ -40,6 +43,7 @@ export function deriveIndicatorState({
   }
 
   if (syncing) return { kind: 'syncing' };
+  if (pending) return { kind: 'pending' };
 
   return { kind: 'idle', lastSyncedAt: location.lastSyncedAt };
 }

--- a/src/lib/data/sync/sync-store.svelte.ts
+++ b/src/lib/data/sync/sync-store.svelte.ts
@@ -63,17 +63,21 @@ export type SyncLocationHealth =
  *   storageSource record is the source of truth.
  * - `health`: written by the sync engine after each ambient or
  *   long-running attempt.
- * - `isSyncing`: live indicator of whether a push or long-running
- *   op is in flight or pending.
+ * - `isSyncing`: live indicator of whether network/file sync work is
+ *   actively running.
+ * - `isSyncPending`: local changes are queued behind the debounce
+ *   window, but no sync request is currently in flight.
  */
 export const syncState = $state<{
   location: SyncLocation | null;
   health: SyncLocationHealth;
   isSyncing: boolean;
+  isSyncPending: boolean;
 }>({
   location: null,
   health: { status: 'ok' },
-  isSyncing: false
+  isSyncing: false,
+  isSyncPending: false
 });
 
 // Custom OAuth credentials are real user config — kept across

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -167,6 +167,8 @@
     pulseElement
   } from '$lib/functions/range-util';
 
+  const READER_STATISTICS_SYNC_THROTTLE_MS = 60_000;
+
   let showSpinner = $state(true);
   let showHeader = $state(false);
   let isBookmarkScreen = $state(false);
@@ -203,6 +205,8 @@
   let wasTrackerMenuOpen = $state(false);
   let dismissDialogs = true;
   let syncedResolver: () => void;
+  let lastReaderStatisticsSyncAt = 0;
+  let readerStatisticsSyncDirty = false;
 
   const syncedPromise = new Promise<void>((resolver) => {
     syncedResolver = resolver;
@@ -599,6 +603,8 @@
   /** Experimental Code - May be removed any time without warning */
 
   onDestroy(() => {
+    flushReaderStatisticsReplication();
+
     if (browser) {
       document.removeEventListener('miwake-action', handleAction, false);
       document.documentElement.lang = 'ja';
@@ -1063,6 +1069,7 @@
       if ($statisticsEnabled$ && trackerElm) {
         // Sync trigger rides the tracker's onstatisticssaved callback.
         await trackerElm.flushUpdates();
+        flushReaderStatisticsReplication();
       }
 
       dialogManager.dialogs$.next([]);
@@ -1223,7 +1230,34 @@
    * onstatisticssaved callback). Paired writes go through
    * library.user* directly.
    */
-  function scheduleReplication(dataType: StorageDataType) {
+  function scheduleReaderStatisticsReplication() {
+    readerStatisticsSyncDirty = true;
+
+    const now = Date.now();
+    const elapsed = now - lastReaderStatisticsSyncAt;
+    if (elapsed >= READER_STATISTICS_SYNC_THROTTLE_MS) {
+      lastReaderStatisticsSyncAt = now;
+      scheduleReplication(StorageDataType.STATISTICS);
+      return;
+    }
+
+    scheduleReplication(StorageDataType.STATISTICS, {
+      debounceMs: READER_STATISTICS_SYNC_THROTTLE_MS - elapsed
+    });
+  }
+
+  function flushReaderStatisticsReplication() {
+    if (!readerStatisticsSyncDirty) return;
+
+    readerStatisticsSyncDirty = false;
+    lastReaderStatisticsSyncAt = Date.now();
+    scheduleReplication(StorageDataType.STATISTICS, { immediate: true });
+  }
+
+  function scheduleReplication(
+    dataType: StorageDataType,
+    { debounceMs, immediate = false }: { debounceMs?: number; immediate?: boolean } = {}
+  ) {
     const ctx = bookReplicationContext();
     if (!ctx) return;
 
@@ -1232,7 +1266,7 @@
     } else if (dataType === StorageDataType.PROGRESS) {
       syncAfterLocalMutation({ kind: 'progress', context: ctx });
     } else if (dataType === StorageDataType.STATISTICS) {
-      syncAfterLocalMutation({ kind: 'statistics', context: ctx });
+      syncAfterLocalMutation({ kind: 'statistics', context: ctx, debounceMs, immediate });
     }
   }
 </script>
@@ -1343,7 +1377,7 @@
       bind:wasTrackerPaused
       bind:this={trackerElm}
       onfreezecurrentlocation={freezeTrackerPosition}
-      onstatisticssaved={() => scheduleReplication(StorageDataType.STATISTICS)}
+      onstatisticssaved={scheduleReaderStatisticsReplication}
     />
   {/if}
   <StyleSheetRenderer styleSheet={$bookData$.styleSheet} />


### PR DESCRIPTION
Summary:
- Stop running a whole-library upward mirror on every app boot; keep it for newly-connected sync locations and explicit backup-import mirroring.
- Split queued sync work from active sync work so the bottom-left indicator can show non-spinning pending state instead of continuous Syncing.
- Throttle reader statistics sync scheduling to a one-minute cadence while reading, with an immediate sync queue flush when leaving the reader.
- Add debug logging for queued sync types and push durations to diagnose slow OneDrive/GDrive/FS operations.

Validation:
- npm run check