### PR TITLE
[codex] Improve OneDrive reauth flow

### DIFF
--- a/src/lib/components/bottom-left-cluster.svelte
+++ b/src/lib/components/bottom-left-cluster.svelte
@@ -25,10 +25,15 @@
   } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
   import Popover from '$lib/components/popover/popover.svelte';
   import { pagePath } from '$lib/data/env';
+  import { messageDialog } from '$lib/data/simple-dialogs';
   import { isOnline$, statisticsEnabled$ } from '$lib/data/store';
+  import { connectCloud } from '$lib/data/sync/source-manager';
+  import { retryAfterReconnect } from '$lib/data/sync/sync-engine';
   import { deriveIndicatorState } from '$lib/data/sync/sync-state';
   import { syncState } from '$lib/data/sync/sync-store.svelte';
   import { formatRelativeTimeLive } from '$lib/components/settings/sync/sync-utils';
+
+  let reconnecting = $state(false);
 
   let indicator = $derived(
     deriveIndicatorState({
@@ -88,10 +93,11 @@
   });
 
   let syncClickable = $derived(
-    indicator.kind === 'disabled' ||
-      indicator.kind === 'needs-attention' ||
-      indicator.kind === 'error' ||
-      indicator.kind === 'idle'
+    !reconnecting &&
+      (indicator.kind === 'disabled' ||
+        indicator.kind === 'needs-attention' ||
+        indicator.kind === 'error' ||
+        indicator.kind === 'idle')
   );
 
   let isReaderRoute = $derived(
@@ -102,6 +108,24 @@
 
   async function onSyncClick() {
     if (!syncClickable) return;
+    const location = syncState.location;
+    if (syncState.health.status === 'reauth-required' && location?.kind === 'cloud') {
+      reconnecting = true;
+      try {
+        await connectCloud(location.provider, {
+          useCustomCredentials: location.usesCustomCredentials
+        });
+        await retryAfterReconnect();
+      } catch (err) {
+        await messageDialog({
+          title: "Couldn't reconnect",
+          message: err instanceof Error ? err.message : String(err)
+        });
+      } finally {
+        reconnecting = false;
+      }
+      return;
+    }
     await goto(`${pagePath}/settings/sync`);
   }
 

--- a/src/lib/data/storage/storage-oauth-manager.ts
+++ b/src/lib/data/storage/storage-oauth-manager.ts
@@ -295,10 +295,10 @@ export class StorageOAuthManager {
     }
     logger.debug(`refreshToken: posting to ${refreshUrl} for ${this.storageSourceName}`);
 
-    const form = new FormData();
-    form.append('client_id', this.remoteData.clientId);
-    form.append('refresh_token', this.remoteData.refreshToken);
-    form.append('grant_type', 'refresh_token');
+    const params = new URLSearchParams();
+    params.append('client_id', this.remoteData.clientId);
+    params.append('refresh_token', this.remoteData.refreshToken);
+    params.append('grant_type', 'refresh_token');
 
     // Send client_secret whenever we have one. GDrive's default app is
     // confidential and always sets one. OneDrive's default app is public
@@ -306,12 +306,16 @@ export class StorageOAuthManager {
     // — without the secret the refresh request is rejected and silent
     // sync breaks until the user reconnects.
     if (this.remoteData.clientSecret) {
-      form.append('client_secret', this.remoteData.clientSecret);
+      params.append('client_secret', this.remoteData.clientSecret);
     }
 
     let response: any;
     try {
-      const httpResponse = await fetch(refreshUrl, { method: 'POST', body: form });
+      const httpResponse = await fetch(refreshUrl, {
+        method: 'POST',
+        body: params.toString(),
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      });
       if (!httpResponse.ok) {
         const errorBody = await convertAuthErrorResponse(httpResponse);
         logger.error(`Unable to refresh token for ${this.storageSourceName}: ${errorBody}`);
@@ -434,6 +438,7 @@ export class StorageOAuthManager {
     const authData = {
       ...StorageOAuthManager.getAuthVariables(this.storageType),
       ...this.remoteData,
+      storageType: this.storageType,
       needsRefreshToken: !this.remoteData.refreshToken,
       codeVerifier: this.codeVerifier,
       codeChallenge

--- a/src/lib/data/sync/sync-engine.ts
+++ b/src/lib/data/sync/sync-engine.ts
@@ -114,10 +114,13 @@ function reportSyncError(context: string, err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
 
   if (err instanceof NeedsInteractiveAuthError) {
+    const oneDrive = err.storageType === SyncEndpointType.ONEDRIVE;
     syncState.health = {
       status: 'reauth-required',
-      summary: 'Sign-in expired',
-      detail: 'Reconnect to resume syncing. Queued changes will be pushed on reconnect.'
+      summary: oneDrive ? 'Microsoft sign-in expired' : 'Sign-in expired',
+      detail: oneDrive
+        ? 'Microsoft limits browser OneDrive sessions to about 24 hours. Reconnect to renew the session; queued changes will be pushed on reconnect.'
+        : 'Reconnect to resume syncing. Queued changes will be pushed on reconnect.'
     };
     return true;
   }

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -2,6 +2,7 @@
   import { browser } from '$app/environment';
   import { faSpinner } from '@fortawesome/free-solid-svg-icons';
   import { convertAuthErrorResponse } from '$lib/functions/replication/error-handler';
+  import { SyncEndpointType } from '$lib/data/storage/storage-types';
   import Fa from 'svelte-fa';
 
   const AUTH_CHANNEL = 'miwake-auth';
@@ -121,7 +122,7 @@
         return;
       }
 
-      const { clientId, authEndpoint, scope, codeChallenge, needsRefreshToken } =
+      const { clientId, authEndpoint, scope, codeChallenge, needsRefreshToken, storageType } =
         JSON.parse(stored);
 
       if (!clientId || !scope || !authEndpoint) {
@@ -143,7 +144,12 @@
       params.append('code_challenge_method', 'S256');
       params.append('code_challenge', codeChallenge);
 
-      if (needsRefreshToken) {
+      // Google only returns a new refresh token reliably when the
+      // offline/consent knobs are present. Microsoft keys this off
+      // the offline_access scope and caps browser-SPA refresh tokens
+      // at about a day, so forcing consent there just makes routine
+      // OneDrive renewal noisier.
+      if (needsRefreshToken && storageType === SyncEndpointType.GDRIVE) {
         params.append('access_type', 'offline');
         params.append('prompt', 'consent');
       }


### PR DESCRIPTION
## Summary

- Send OAuth refresh-token exchanges as `application/x-www-form-urlencoded`.
- Keep Google-only offline consent parameters off OneDrive auth requests.
- Let the reader sync status icon trigger cloud reconnect directly for `reauth-required`.
- Clarify the OneDrive browser-SPA 24-hour refresh-token limit in sync health messaging.

## Root Cause

The app had improved refresh-token persistence, but the browser-only OneDrive flow still runs into Microsoft's SPA refresh-token lifetime. For OneDrive, forcing consent on the reauth popup also made routine renewal more interactive than necessary, instead of allowing the quick Microsoft SSO popup path when available.

## Validation

- `npm run check`