### PR TITLE
[codex] Fix tracker auto-pause resume state

### DIFF
--- a/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker-panel.svelte
+++ b/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker-panel.svelte
@@ -12,7 +12,7 @@
     type IconDefinition
   } from '@fortawesome/free-solid-svg-icons';
   import DialogFormButton from '$lib/components/dialog-form-button.svelte';
-  import type { TrackingHistory } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+  import type { TrackingHistory } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
   import {
     getChapterData,
     type SectionWithProgress
@@ -36,7 +36,7 @@
     currentReadingGoalStart: string;
     currentReadingGoalEnd: string;
     remainingTimeInReadingGoalWindow: string;
-    wasTrackerPaused: boolean;
+    trackerPaused: boolean;
     canSaveStatistics: boolean;
     timeToFinishBook: string;
     sectionData: SectionWithProgress[];
@@ -51,6 +51,7 @@
     bookCompletionStatistics: Omit<BooksDbStatistic, 'title' | 'lastStatisticModified'> | undefined;
     autoScrollerStatistics: BooksDbStatistic | undefined;
     bookStartDate: string;
+    ontogglepause?: () => void;
     onupdatecurrentlocation?: () => void;
     onfreezecurrentlocation?: () => void;
     onsavestatistics?: () => void;
@@ -68,7 +69,7 @@
     currentReadingGoalStart,
     currentReadingGoalEnd,
     remainingTimeInReadingGoalWindow,
-    wasTrackerPaused = $bindable(),
+    trackerPaused,
     canSaveStatistics,
     timeToFinishBook,
     sectionData,
@@ -83,6 +84,7 @@
     bookCompletionStatistics,
     autoScrollerStatistics,
     bookStartDate,
+    ontogglepause,
     onupdatecurrentlocation,
     onfreezecurrentlocation,
     onsavestatistics,
@@ -160,7 +162,7 @@
   function executeAction(event: string) {
     switch (event) {
       case 'toggleTracker':
-        wasTrackerPaused = !wasTrackerPaused;
+        ontogglepause?.();
         break;
       case 'updateCurrentLocation':
         onupdatecurrentlocation?.();
@@ -285,7 +287,7 @@
                 onclick={() => executeAction(action.event)}
                 onkeyup={dummyFn}
               >
-                <Fa icon={getActionIcon(action, wasTrackerPaused)} />
+                <Fa icon={getActionIcon(action, trackerPaused)} />
               </div>
             {/if}
           {/each}

--- a/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte
+++ b/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
   import {
     getDefaultStatistic,
-    isTrackerPaused$,
     type TrackingHistory,
-    isTrackerMenuOpen$,
-    trackerAvailable$,
     TrackerSkipThresholdAction,
     TrackerAutoPause
-  } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
-  import BookTimerMenu from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker-menu.svelte';
+  } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
+  import {
+    closeTrackerMenu,
+    pauseTrackerFor,
+    resetTrackerRuntime,
+    resumeTrackerFor,
+    setTrackerAvailable,
+    toggleTrackerPauseByUser,
+    trackerStatus
+  } from '$lib/components/book-reader/book-reading-tracker/tracker-state.svelte';
+  import BookReadingTrackerPanel from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker-panel.svelte';
   import SidebarOverlay from '$lib/components/sidebar-overlay.svelte';
   import type { SectionWithProgress } from '$lib/components/book-reader/book-toc/book-toc';
   import type { AutoScroller } from '$lib/components/book-reader/types';
@@ -32,7 +38,6 @@
     trackerSkipThresholdAction$
   } from '$lib/data/store';
   import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
-  import { reduceToEmptyString } from '$lib/functions/rxjs/reduce-to-empty-string';
   import {
     getDate,
     getDateKey,
@@ -42,24 +47,13 @@
     toTimeString
   } from '$lib/functions/statistic-util';
   import { fireAndForget, filterNotNullAndNotUndefined } from '$lib/functions/utils';
-  import {
-    fromEvent,
-    interval,
-    merge,
-    NEVER,
-    Observable,
-    startWith,
-    switchMap,
-    tap,
-    throttleTime
-  } from 'rxjs';
+  import { interval, NEVER, switchMap, tap } from 'rxjs';
   import { onDestroy, onMount, tick, untrack } from 'svelte';
 
   interface Props {
     fontColor: string;
     backgroundColor: string;
     bookTitle: string;
-    wasTrackerPaused: boolean;
     exploredCharCount: number;
     bookCharCount: number;
     sectionData: SectionWithProgress[];
@@ -73,7 +67,6 @@
     fontColor,
     backgroundColor,
     bookTitle,
-    wasTrackerPaused = $bindable(),
     exploredCharCount,
     bookCharCount,
     sectionData,
@@ -231,7 +224,7 @@
       actionInProgress = false;
       lastTrackerFlushTime = Date.now();
 
-      if ($isTrackerMenuOpen$) {
+      if (trackerStatus.menuOpen) {
         updateReadingGoalWindow();
       }
     }
@@ -264,8 +257,6 @@
   let jpdbPopover: HTMLElement | null = $state(null);
   let actionInProgress = $state(false);
   let hadError = $state(false);
-  let pausedByAutoPause = false;
-  let visibilityState: DocumentVisibilityState = $state('visible');
   let currentReadingGoalStart = $state('');
   let currentReadingGoalEnd = $state('');
   let remainingTimeInReadingGoalWindow = $state('');
@@ -297,7 +288,6 @@
   let trackingHistory: TrackingHistory[] = $state([]);
   let historyIndex = 0;
   let autoScrollerStatistics = $state<BooksDbStatistic>();
-  let autoScrollerTimer$: Observable<''> | undefined;
   let lastExploredCharCountScroller = initSnapshot.exploredCharCount;
   let statisticsToStore = $state(new Set<string>());
   let lastTrackerTick = 0;
@@ -307,60 +297,72 @@
   const yomiObserver = new MutationObserver(handleYomiMutation);
   const dictionaryObserver = new MutationObserver(handleMutation);
 
-  const readingTracker$ = isTrackerPaused$.pipe(
-    switchMap((isPaused) => {
-      if (isPaused) {
+  $effect(() => {
+    const paused = trackerStatus.paused;
+
+    return untrack(() => {
+      if (paused) {
         trackerIdleTime = 0;
-
         fireAndForget(flushUpdates());
-
-        return NEVER;
+        return;
       }
 
       const now = Date.now();
-
       lastTrackerFlushTime = now;
       lastTrackerTick = now;
       updateLastExploredCharCount();
 
-      return interval(1000);
-    }),
-    tap(processTicks),
-    reduceToEmptyString()
-  );
+      const timerId = window.setInterval(processTicks, 1000);
+      return () => window.clearInterval(timerId);
+    });
+  });
 
-  const updateTrackerIdleTime$ = isTrackerPaused$.pipe(
-    switchMap((isPaused) =>
-      isPaused || $trackerIdleTime$ <= 0
-        ? NEVER
-        : merge(
-            fromEvent(document, PAGE_CHANGE),
-            fromEvent<PointerEvent>(window, 'pointermove'),
-            fromEvent<Event>(document, 'selectionchange')
-          ).pipe(
-            startWith(true),
-            throttleTime(1000),
-            tap(() => (trackerIdleTime = Date.now() + $trackerIdleTime$ * 1000))
-          )
-    ),
-    reduceToEmptyString()
-  );
+  $effect(() => {
+    const paused = trackerStatus.paused;
+    const idleSeconds = $trackerIdleTime$;
+
+    if (paused || idleSeconds <= 0) return;
+
+    let lastUpdate = 0;
+    const updateIdleDeadline = () => {
+      const now = Date.now();
+      if (now - lastUpdate < 1000) return;
+      lastUpdate = now;
+      trackerIdleTime = now + idleSeconds * 1000;
+    };
+
+    updateIdleDeadline();
+    document.addEventListener(PAGE_CHANGE, updateIdleDeadline);
+    window.addEventListener('pointermove', updateIdleDeadline);
+    document.addEventListener('selectionchange', updateIdleDeadline);
+
+    return () => {
+      document.removeEventListener(PAGE_CHANGE, updateIdleDeadline);
+      window.removeEventListener('pointermove', updateIdleDeadline);
+      document.removeEventListener('selectionchange', updateIdleDeadline);
+    };
+  });
 
   let hasReadingGoal = $derived(
     !!($readingGoal$.goalStartDate && todayKey >= $readingGoal$.goalStartDate)
   );
 
   $effect(() => {
-    handleVisibilityChange(visibilityState);
+    if (trackerStatus.menuOpen && trackerStatus.pausedOutsideMenu) {
+      untrack(() => fireAndForget(updateReadingGoalWindow()));
+    }
   });
 
   $effect(() => {
-    updateReadingGoalWindowForPausedState($isTrackerMenuOpen$);
-  });
+    const currentAutoScroller = autoScroller;
 
-  $effect(() => {
-    if (autoScroller && !autoScrollerTimer$) {
-      autoScrollerTimer$ = autoScroller.wasAutoScrollerEnabled$.pipe(
+    if (!currentAutoScroller) {
+      autoScrollerStatistics = undefined;
+      return;
+    }
+
+    const subscription = currentAutoScroller.wasAutoScrollerEnabled$
+      .pipe(
         tap((isEnabled) => {
           if (isEnabled) {
             todayKey = getDateKey($startDayHoursForTracker$);
@@ -382,10 +384,11 @@
           autoScrollerStatistics = {
             ...updateStatistic(autoScrollerStatistics, 1, diff, Date.now())
           };
-        }),
-        reduceToEmptyString()
-      );
-    }
+        })
+      )
+      .subscribe();
+
+    return () => subscription.unsubscribe();
   });
 
   $effect(() => {
@@ -421,7 +424,7 @@
   onDestroy(() => {
     yomiObserver.disconnect();
     dictionaryObserver.disconnect();
-    trackerAvailable$.set(false);
+    resetTrackerRuntime();
   });
 
   function handleYomiMutation() {
@@ -441,12 +444,10 @@
 
     const isDisplayed = isDictionaryDisplayed();
 
-    if (isDisplayed && !$isTrackerPaused$) {
-      pausedByAutoPause = true;
-      isTrackerPaused$.next(true);
-    } else if (!isDisplayed && $isTrackerPaused$ && !wasTrackerPaused && pausedByAutoPause) {
-      pausedByAutoPause = false;
-      isTrackerPaused$.next(false);
+    if (isDisplayed && !trackerStatus.paused) {
+      pauseTrackerFor('dictionary');
+    } else if (!isDisplayed) {
+      resumeTrackerFor('dictionary');
     }
   }
 
@@ -459,30 +460,26 @@
 
   function handleBlur() {
     if (
-      $isTrackerPaused$ ||
+      trackerStatus.paused ||
       $trackerAutoPause$ !== TrackerAutoPause.STRICT ||
       ($trackerPopupDetection$ && isDictionaryDisplayed())
     ) {
       return;
     }
 
-    pausedByAutoPause = true;
-    isTrackerPaused$.next(true);
+    pauseTrackerFor('window-blur');
   }
 
   function handleFocus() {
     if (
-      !$isTrackerPaused$ ||
-      !pausedByAutoPause ||
-      wasTrackerPaused ||
+      !trackerStatus.paused ||
       $trackerAutoPause$ !== TrackerAutoPause.STRICT ||
       (!$trackerPopupDetection$ && isDictionaryDisplayed())
     ) {
       return;
     }
 
-    pausedByAutoPause = false;
-    isTrackerPaused$.next(false);
+    resumeTrackerFor('window-blur');
   }
 
   function updateLastExploredCharCount() {
@@ -554,26 +551,12 @@
 
     if (
       state === 'hidden' &&
-      !$isTrackerPaused$ &&
+      !trackerStatus.paused &&
       (!$trackerPopupDetection$ || !isDictionaryDisplayed())
     ) {
-      pausedByAutoPause = true;
-      isTrackerPaused$.next(true);
-    } else if (
-      state === 'visible' &&
-      $isTrackerPaused$ &&
-      pausedByAutoPause &&
-      !wasTrackerPaused &&
-      ($trackerPopupDetection$ || !isDictionaryDisplayed())
-    ) {
-      pausedByAutoPause = false;
-      isTrackerPaused$.next(false);
-    }
-  }
-
-  function updateReadingGoalWindowForPausedState(isTrackerMenuOpen: boolean) {
-    if (isTrackerMenuOpen && wasTrackerPaused) {
-      updateReadingGoalWindow();
+      pauseTrackerFor('visibility');
+    } else if (state === 'visible' && ($trackerPopupDetection$ || !isDictionaryDisplayed())) {
+      resumeTrackerFor('visibility');
     }
   }
 
@@ -611,7 +594,7 @@
         }
       }
 
-      trackerAvailable$.set(true);
+      setTrackerAvailable(true);
     } catch ({ message }: any) {
       logger.error(`Error initializing timer: ${message}`);
     }
@@ -679,8 +662,7 @@
     lastTrackerTick = nowTick;
 
     if (trackerIdleTimeReached) {
-      wasTrackerPaused = true;
-      isTrackerPaused$.next(true);
+      pauseTrackerFor('idle');
 
       if (frozenPosition === -1) {
         if ($adjustStatisticsAfterIdleTime$) {
@@ -709,8 +691,7 @@
           finalCharacterDiff <= -Math.abs($trackerBackwardSkipThreshold$))
       ) {
         if ($trackerSkipThresholdAction$ === TrackerSkipThresholdAction.PAUSE) {
-          wasTrackerPaused = true;
-          isTrackerPaused$.next(true);
+          pauseTrackerFor('skip-threshold');
           return;
         }
         finalCharacterDiff = 0;
@@ -794,20 +775,17 @@
   }
 </script>
 
-{$readingTracker$ ?? ''}
-{$updateTrackerIdleTime$ ?? ''}
-{$autoScrollerTimer$ ?? ''}
-
 <svelte:window onblur={handleBlur} onfocus={handleFocus} />
-<svelte:document bind:visibilityState />
+<svelte:document onvisibilitychange={() => handleVisibilityChange(document.visibilityState)} />
 
 <SidebarOverlay
-  bind:open={$isTrackerMenuOpen$}
+  open={trackerStatus.menuOpen}
+  onclose={closeTrackerMenu}
   side="left"
   class="z-60 max-w-xl"
   style={`color: ${fontColor}; background-color: ${backgroundColor};`}
 >
-  <BookTimerMenu
+  <BookReadingTrackerPanel
     {fontColor}
     {backgroundColor}
     {actionInProgress}
@@ -832,8 +810,9 @@
     {bookStartDate}
     {sectionData}
     canSaveStatistics={statisticsToStore.size > 0}
-    bind:wasTrackerPaused
+    trackerPaused={trackerStatus.pausedOutsideMenu}
     {onfreezecurrentlocation}
+    ontogglepause={toggleTrackerPauseByUser}
     onupdatecurrentlocation={updateLastExploredCharCount}
     onsavestatistics={() => fireAndForget(flushUpdates())}
     onrevertstatistic={revertTrackerHistory}

--- a/src/lib/components/book-reader/book-reading-tracker/tracker-domain.ts
+++ b/src/lib/components/book-reader/book-reading-tracker/tracker-domain.ts
@@ -1,18 +1,4 @@
 import type { BooksDbStatistic } from '$lib/data/database/books-db/versions/books-db';
-import { writableSubject } from '$lib/functions/svelte/store';
-import { writable } from 'svelte/store';
-
-export const isTrackerMenuOpen$ = writable(false);
-
-export const isTrackerPaused$ = writableSubject<boolean>(true);
-
-/**
- * True once the tracker has finished initializing for the current book
- * — driven by BookReadingTracker firing its `trackeravailable` event.
- * Read by the bottom-left controls cluster to decide whether the
- * play/pause and stats-menu buttons should render.
- */
-export const trackerAvailable$ = writable<boolean>(false);
 
 export enum TrackerAutoPause {
   OFF = 'off',

--- a/src/lib/components/book-reader/book-reading-tracker/tracker-state.svelte.ts
+++ b/src/lib/components/book-reader/book-reading-tracker/tracker-state.svelte.ts
@@ -1,0 +1,135 @@
+export type TrackerPauseReason =
+  | 'manual'
+  | 'menu'
+  | 'toc'
+  | 'jump'
+  | 'custom-reading-point'
+  | 'resize'
+  | 'completion'
+  | 'leaving-reader'
+  | 'visibility'
+  | 'window-blur'
+  | 'dictionary'
+  | 'idle'
+  | 'skip-threshold';
+
+type TrackerPauseReasons = Record<TrackerPauseReason, boolean>;
+
+const trackerPauseReasons: TrackerPauseReason[] = [
+  'manual',
+  'menu',
+  'toc',
+  'jump',
+  'custom-reading-point',
+  'resize',
+  'completion',
+  'leaving-reader',
+  'visibility',
+  'window-blur',
+  'dictionary',
+  'idle',
+  'skip-threshold'
+];
+
+function createPauseReasons(): TrackerPauseReasons {
+  return {
+    manual: true,
+    menu: false,
+    toc: false,
+    jump: false,
+    'custom-reading-point': false,
+    resize: false,
+    completion: false,
+    'leaving-reader': false,
+    visibility: false,
+    'window-blur': false,
+    dictionary: false,
+    idle: false,
+    'skip-threshold': false
+  };
+}
+
+let available = $state(false);
+let menuOpen = $state(false);
+let pauseReasons = $state<TrackerPauseReasons>(createPauseReasons());
+const paused = $derived.by(() => trackerPauseReasons.some((reason) => pauseReasons[reason]));
+const pausedOutsideMenu = $derived.by(() => isPausedExceptFor('menu'));
+
+export const trackerStatus = {
+  get available() {
+    return available;
+  },
+  get menuOpen() {
+    return menuOpen;
+  },
+  get pausedOutsideMenu() {
+    return pausedOutsideMenu;
+  },
+  get paused() {
+    return paused;
+  }
+};
+
+export function setTrackerAvailable(value: boolean) {
+  available = value;
+}
+
+export function openTrackerMenu() {
+  pauseReasons.menu = true;
+  menuOpen = true;
+}
+
+export function closeTrackerMenu() {
+  menuOpen = false;
+  pauseReasons.menu = false;
+}
+
+export function toggleTrackerPauseByUser() {
+  if (menuOpen) {
+    if (isPausedExceptFor('menu')) {
+      clearPauseReasonsExcept('menu');
+    } else {
+      pauseReasons.manual = true;
+    }
+
+    return;
+  }
+
+  if (paused) {
+    clearPauseReasons();
+  } else {
+    pauseReasons.manual = true;
+  }
+}
+
+export function pauseTrackerFor(reason: TrackerPauseReason) {
+  pauseReasons[reason] = true;
+}
+
+export function resumeTrackerFor(reason: TrackerPauseReason) {
+  pauseReasons[reason] = false;
+}
+
+export function resetTrackerRuntime() {
+  available = false;
+  menuOpen = false;
+  pauseReasons = createPauseReasons();
+}
+
+function isPausedExceptFor(excludedReason: TrackerPauseReason) {
+  return trackerPauseReasons.some((reason) => reason !== excludedReason && pauseReasons[reason]);
+}
+
+function clearPauseReasons() {
+  for (const reason of trackerPauseReasons) {
+    pauseReasons[reason] = false;
+  }
+}
+
+function clearPauseReasonsExcept(excludedReason: TrackerPauseReason) {
+  for (const reason of trackerPauseReasons) {
+    if (reason !== excludedReason) {
+      pauseReasons[reason] = false;
+    }
+  }
+}

--- a/src/lib/components/book-reader/book-toc/book-toc.svelte
+++ b/src/lib/components/book-reader/book-toc/book-toc.svelte
@@ -17,10 +17,15 @@
     sectionData?: SectionWithProgress[];
     exploredCharCount?: number;
     verticalMode: boolean;
-    wasTrackerPaused: boolean;
+    resumeTrackerAfterTocCloses: boolean;
   }
 
-  let { sectionData = [], exploredCharCount = 0, verticalMode, wasTrackerPaused }: Props = $props();
+  let {
+    sectionData = [],
+    exploredCharCount = 0,
+    verticalMode,
+    resumeTrackerAfterTocCloses
+  }: Props = $props();
 
   let chapters: SectionWithProgress[] = $state([]);
   let currentChapter: SectionWithProgress = $state(undefined as any);
@@ -90,7 +95,7 @@
     const nextChapter = chapters.find((chapter) => chapter.reference === chapterId);
     const hasCharacterChange = exploredCharCount !== nextChapter?.startCharacter;
 
-    if ($statisticsEnabled$ && closeToc && hasCharacterChange && !wasTrackerPaused) {
+    if ($statisticsEnabled$ && closeToc && hasCharacterChange && resumeTrackerAfterTocCloses) {
       merge(fromEvent(document, PAGE_CHANGE))
         .pipe(debounceTime(200), take(1))
         .subscribe(() => {
@@ -102,7 +107,7 @@
 
     nextChapter$.next(chapterId);
 
-    if ((!hasCharacterChange || !$statisticsEnabled$ || wasTrackerPaused) && closeToc) {
+    if ((!hasCharacterChange || !$statisticsEnabled$ || !resumeTrackerAfterTocCloses) && closeToc) {
       tocIsOpen$.set(false);
     }
   }

--- a/src/lib/components/bottom-left-cluster.svelte
+++ b/src/lib/components/bottom-left-cluster.svelte
@@ -19,10 +19,10 @@
     type IconDefinition
   } from '@fortawesome/free-solid-svg-icons';
   import {
-    isTrackerMenuOpen$,
-    isTrackerPaused$,
-    trackerAvailable$
-  } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+    openTrackerMenu,
+    toggleTrackerPauseByUser,
+    trackerStatus
+  } from '$lib/components/book-reader/book-reading-tracker/tracker-state.svelte';
   import Popover from '$lib/components/popover/popover.svelte';
   import { pagePath } from '$lib/data/env';
   import { messageDialog } from '$lib/data/simple-dialogs';
@@ -104,7 +104,9 @@
     page.url.pathname === `${pagePath}/b` || page.url.pathname.startsWith(`${pagePath}/b/`)
   );
 
-  let showTrackerButtons = $derived(isReaderRoute && $statisticsEnabled$ && $trackerAvailable$);
+  let showTrackerButtons = $derived(
+    isReaderRoute && $statisticsEnabled$ && trackerStatus.available
+  );
 
   async function onSyncClick() {
     if (!syncClickable) return;
@@ -127,18 +129,6 @@
       return;
     }
     await goto(`${pagePath}/settings/sync`);
-  }
-
-  function togglePause() {
-    isTrackerPaused$.next(!$isTrackerPaused$);
-  }
-
-  function openTrackerMenu() {
-    // /b owns the pause bookkeeping (wasTrackerPaused) — its
-    // menu-open edge effect captures the prior state and pauses.
-    // Mutating isTrackerPaused$ here would race that handler and
-    // leave wasTrackerPaused stale on close.
-    isTrackerMenuOpen$.set(true);
   }
 
   // 32px hit target, 16-18px icon. Hover dabs a faint translucent
@@ -191,9 +181,9 @@
 
   {#if showTrackerButtons}
     {@render clusterButton(
-      $isTrackerPaused$ ? 'Resume reading tracker' : 'Pause reading tracker',
-      $isTrackerPaused$ ? faPlay : faPause,
-      { onClick: togglePause, colorClass: 'text-gray-600' }
+      trackerStatus.paused ? 'Resume reading tracker' : 'Pause reading tracker',
+      trackerStatus.paused ? faPlay : faPause,
+      { onClick: toggleTrackerPauseByUser, colorClass: 'text-gray-600' }
     )}
     {@render clusterButton('Open reading statistics', faChartBar, {
       onClick: openTrackerMenu,

--- a/src/lib/components/settings/settings-reading-goals.svelte
+++ b/src/lib/components/settings/settings-reading-goals.svelte
@@ -7,7 +7,7 @@
     faSave,
     faTrash
   } from '@fortawesome/free-solid-svg-icons';
-  import { ReadingGoalFrequency } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+  import { ReadingGoalFrequency } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
   import SettingsReadingGoalsMerge from '$lib/components/settings/settings-reading-goals-merge.svelte';
   import { buttonClasses } from '$lib/css-classes';
   import { confirmDialog, messageDialog } from '$lib/data/simple-dialogs';

--- a/src/lib/components/sidebar-overlay.svelte
+++ b/src/lib/components/sidebar-overlay.svelte
@@ -14,6 +14,7 @@
     side?: 'left' | 'right';
     class?: string;
     style?: string;
+    onclose?: () => void;
     children?: Snippet;
   }
 
@@ -22,6 +23,7 @@
     side = 'right',
     class: className = '',
     style,
+    onclose,
     children
   }: Props = $props();
 
@@ -92,7 +94,10 @@
   data-side={side}
   closedby="any"
   {style}
-  onclose={() => (open = false)}
+  onclose={() => {
+    open = false;
+    onclose?.();
+  }}
 >
   {@render children?.()}
 </dialog>

--- a/src/lib/components/statistics/statistics-heatmap/statistics-heatmap.svelte
+++ b/src/lib/components/statistics/statistics-heatmap/statistics-heatmap.svelte
@@ -6,7 +6,7 @@
     faLayerGroup,
     faRepeat
   } from '@fortawesome/free-solid-svg-icons';
-  import { ReadingGoalFrequency } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+  import { ReadingGoalFrequency } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
   import Popover from '$lib/components/popover/popover.svelte';
   import {
     type HeatmapMonthLabel,

--- a/src/lib/components/statistics/statistics-shell.svelte
+++ b/src/lib/components/statistics/statistics-shell.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onKeyUpStatisticsTab } from '../../../routes/b/on-keydown-reader';
   import { faSpinner } from '@fortawesome/free-solid-svg-icons';
-  import { getDefaultStatistic } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+  import { getDefaultStatistic } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
   import SidebarOverlay from '$lib/components/sidebar-overlay.svelte';
   import type {
     StatisticsDeleteRequest,

--- a/src/lib/data/database/books-db/database.service.ts
+++ b/src/lib/data/database/books-db/database.service.ts
@@ -31,7 +31,7 @@ import { showErrorDialogWithLogReport } from '$lib/components/log-report-dialog-
 import { messageDialog } from '$lib/data/simple-dialogs';
 import type { MergeMode } from '$lib/data/merge-mode';
 import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
-import { getDefaultStatistic } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+import { getDefaultStatistic } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
 import { handleErrorDuringReplication } from '$lib/functions/replication/error-handler';
 import { iffBrowser } from '$lib/functions/rxjs/iff-browser';
 import { logger } from '$lib/data/logger';

--- a/src/lib/data/reading-goal.ts
+++ b/src/lib/data/reading-goal.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/functions/statistic-util';
 
 import type { BooksDbReadingGoal } from '$lib/data/database/books-db/versions/books-db';
-import { ReadingGoalFrequency } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+import { ReadingGoalFrequency } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
 import { database } from '$lib/data/store';
 
 export interface ReadingGoal {

--- a/src/lib/data/store.ts
+++ b/src/lib/data/store.ts
@@ -7,7 +7,7 @@ import {
   ReadingGoalFrequency,
   TrackerAutoPause,
   TrackerSkipThresholdAction
-} from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+} from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
 import { HeatmapDataAggregration } from '$lib/components/statistics/statistics-heatmap/statistics-heatmap';
 import {
   defaultStatisticsRoute,

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -92,11 +92,15 @@
     updateImageGalleryPictureSpoilers$
   } from '$lib/components/book-reader/book-reader-image-gallery/book-reader-image-gallery';
   import BookReaderImageGallery from '$lib/components/book-reader/book-reader-image-gallery/book-reader-image-gallery.svelte';
+  import { getDefaultStatistic } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
   import {
-    getDefaultStatistic,
-    isTrackerMenuOpen$,
-    isTrackerPaused$
-  } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+    openTrackerMenu,
+    pauseTrackerFor,
+    resumeTrackerFor,
+    toggleTrackerPauseByUser,
+    trackerStatus,
+    type TrackerPauseReason
+  } from '$lib/components/book-reader/book-reading-tracker/tracker-state.svelte';
   import BookReadingTracker from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte';
   import {
     getChapterData,
@@ -193,7 +197,7 @@
   let storedExploredCharacter = 0;
   let hasBookmarkData = $state(false);
   let trackerElm: BookReadingTracker = $state()!;
-  let wasTrackerPaused = $state(true);
+  let resumeTrackerAfterTocCloses = $state(false);
   let frozenPosition = $state(-1);
   let skipFirstFreezeChange = $state(false);
   let bookCompleted = $state(false);
@@ -470,8 +474,7 @@
     debounceTime($trackerAutostartTime$ * 1000),
     take(1),
     tap(() => {
-      wasTrackerPaused = false;
-      isTrackerPaused$.next(wasTrackerPaused);
+      resumeTrackerFor('manual');
     }),
     reduceToEmptyString()
   );
@@ -487,32 +490,21 @@
     }
 
     if ($tocIsOpen$ && !wasTocOpen) {
-      wasTrackerPaused = $isTrackerPaused$;
-      pauseTracker();
-    } else if (!$tocIsOpen$ && wasTocOpen && !wasTrackerPaused) {
-      isTrackerPaused$.next(false);
+      resumeTrackerAfterTocCloses = !trackerStatus.paused;
+      pauseTrackerFor('toc');
+    } else if (!$tocIsOpen$ && wasTocOpen) {
+      resumeTrackerFor('toc');
     }
 
     wasTocOpen = $tocIsOpen$;
   });
 
   $effect(() => {
-    if ($isTrackerMenuOpen$ && !wasTrackerMenuOpen) {
-      // Capture the pre-pause state at open so the close-side effect
-      // knows whether to resume. Any caller (cluster button,
-      // completion flow) can just flip the menu flag and trust this
-      // edge handler to keep wasTrackerPaused in sync.
-      wasTrackerPaused = $isTrackerPaused$;
-      isTrackerPaused$.next(true);
-    } else if (!$isTrackerMenuOpen$ && wasTrackerMenuOpen) {
-      if (!wasTrackerPaused) {
-        isTrackerPaused$.next(false);
-      }
-
+    if (!trackerStatus.menuOpen && wasTrackerMenuOpen) {
       bookCompleted = false;
     }
 
-    wasTrackerMenuOpen = $isTrackerMenuOpen$;
+    wasTrackerMenuOpen = trackerStatus.menuOpen;
   });
 
   $effect(() => {
@@ -530,7 +522,7 @@
   $effect(() => {
     if (showCustomReadingPoint) {
       untrack(() => {
-        pauseTracker();
+        pauseTracker('custom-reading-point');
 
         pulseElement(customReadingPointRange?.endContainer?.parentElement, 'add', 1);
 
@@ -539,7 +531,7 @@
           .subscribe(() => {
             showCustomReadingPoint = false;
             pulseElement(customReadingPointRange?.endContainer?.parentElement, 'remove', 1);
-            restartTrackerAfterCharacterChangeOrTime(1);
+            restartTrackerAfterCharacterChangeOrTime('custom-reading-point', 1);
           });
       });
     }
@@ -585,7 +577,9 @@
     }
   });
 
-  onMount(() => document.addEventListener('miwake-action', handleAction, false));
+  onMount(() => {
+    document.addEventListener('miwake-action', handleAction, false);
+  });
 
   function handleAction({ detail }: any) {
     if (!detail.type) {
@@ -628,13 +622,12 @@
   }
 
   function toggleTrackerPause() {
-    if (!statisticsEnabled$) {
+    if (!$statisticsEnabled$) {
       return;
     }
 
     dialogManager.dialogs$.next([]);
-    wasTrackerPaused = !$isTrackerPaused$;
-    isTrackerPaused$.next(wasTrackerPaused);
+    toggleTrackerPauseByUser();
   }
 
   async function handleJump() {
@@ -644,7 +637,7 @@
       return;
     }
 
-    pauseTracker();
+    pauseTracker('jump');
     skipKeyDownListener$.next(true);
 
     const target = await numberDialog({
@@ -657,11 +650,11 @@
     skipKeyDownListener$.next(false);
 
     if (typeof target !== 'number') {
-      restartTrackerAfterCharacterChangeOrTime(1);
+      restartTrackerAfterCharacterChangeOrTime('jump', 1);
       return;
     }
 
-    restartTrackerAfterCharacterChangeOrTime(1000);
+    restartTrackerAfterCharacterChangeOrTime('jump', 1000);
 
     bookmarkManager.scrollToBookmark(
       {
@@ -680,14 +673,11 @@
     }
 
     const wasAutoscrollerEnabled = autoScroller?.wasAutoScrollerEnabled$.getValue();
-    const wasTrackerPausedBefore = $statisticsEnabled$ ? $isTrackerPaused$ : true;
-
     showHeader = false;
     autoScroller?.off();
 
     if ($statisticsEnabled$) {
-      wasTrackerPaused = true;
-      isTrackerPaused$.next(true);
+      pauseTrackerFor('completion');
     }
 
     const diffToComplete =
@@ -702,9 +692,8 @@
     });
 
     if (wasCanceled) {
-      if ($statisticsEnabled$ && !wasTrackerPausedBefore) {
-        wasTrackerPaused = false;
-        $isTrackerPaused$ = false;
+      if ($statisticsEnabled$) {
+        resumeTrackerFor('completion');
       }
 
       if (wasAutoscrollerEnabled) {
@@ -801,7 +790,7 @@
         confettiWidthModifier = 36;
         confettiMaxRuns = 0;
         bookCompleted = window.matchMedia('(min-width: 900px)').matches;
-        isTrackerMenuOpen$.set(true);
+        openTrackerMenu();
       } else {
         dialogManager.dialogs$.next([]);
         confettiWidthModifier = 0;
@@ -981,7 +970,7 @@
     if (!data || !bookmarkManager) return;
 
     if (data.exploredCharCount !== exploredCharCount) {
-      pauseTracker(true);
+      pauseTracker('jump', true);
     }
 
     bookmarkManager.scrollToBookmark(data, customReadingPointScrollOffset);
@@ -1018,7 +1007,7 @@
     }
 
     if (nextChapter.startCharacter !== exploredCharCount) {
-      pauseTracker(true);
+      pauseTracker('jump', true);
     }
 
     nextChapter$.next(nextChapter.reference);
@@ -1040,8 +1029,7 @@
       await tick();
 
       autoScroller?.off();
-      wasTrackerPaused = true;
-      isTrackerPaused$.next(true);
+      pauseTrackerFor('leaving-reader');
 
       if ($confirmClose$ && storedExploredCharacter !== exploredCharCount) {
         const wasCanceled = await confirmDialog({
@@ -1050,6 +1038,7 @@
         });
 
         if (wasCanceled) {
+          resumeTrackerFor('leaving-reader');
           return;
         }
 
@@ -1101,7 +1090,7 @@
     autoScroller?.off();
 
     if ($pauseTrackerOnCustomPointChange$) {
-      pauseTracker();
+      pauseTracker('custom-reading-point');
     }
 
     if (isPaginated) {
@@ -1170,7 +1159,7 @@
             }
 
             if ($pauseTrackerOnCustomPointChange$) {
-              restartTrackerAfterCharacterChangeOrTime(1000);
+              restartTrackerAfterCharacterChangeOrTime('custom-reading-point', 1000);
             }
           });
         } else {
@@ -1191,27 +1180,28 @@
       });
   }
 
-  function pauseTracker(restartAfterCharacterChange = false) {
-    if ($statisticsEnabled$ && !$isTrackerPaused$) {
-      wasTrackerPaused = false;
-      $isTrackerPaused$ = true;
+  function pauseTracker(reason: TrackerPauseReason = 'jump', restartAfterCharacterChange = false) {
+    if ($statisticsEnabled$ && !trackerStatus.paused) {
+      pauseTrackerFor(reason);
 
       if (restartAfterCharacterChange) {
-        restartTrackerAfterCharacterChangeOrTime();
+        restartTrackerAfterCharacterChangeOrTime(reason);
       }
     }
   }
 
-  function restartTrackerAfterCharacterChangeOrTime(timerAmount = 0) {
-    if (!$statisticsEnabled$ || wasTrackerPaused) {
+  function restartTrackerAfterCharacterChangeOrTime(
+    reason: TrackerPauseReason = 'jump',
+    timerAmount = 0
+  ) {
+    if (!$statisticsEnabled$) {
       return;
     }
 
     merge(fromEvent(document, PAGE_CHANGE), timerAmount ? timer(timerAmount) : NEVER)
       .pipe(debounceTime(200), take(1))
       .subscribe(() => {
-        wasTrackerPaused = false;
-        $isTrackerPaused$ = false;
+        resumeTrackerFor(reason);
       });
   }
 
@@ -1323,7 +1313,7 @@
         showHeader = false;
 
         if ($pauseTrackerOnCustomPointChange$) {
-          pauseTracker();
+          pauseTracker('custom-reading-point');
         }
 
         if (isPaginated) {
@@ -1337,7 +1327,7 @@
         }
 
         if ($pauseTrackerOnCustomPointChange$) {
-          restartTrackerAfterCharacterChangeOrTime(1000);
+          restartTrackerAfterCharacterChangeOrTime('custom-reading-point', 1000);
         }
       }}
       onfullscreenClick={onFullscreenClick}
@@ -1374,7 +1364,6 @@
       {exploredCharCount}
       {bookCharCount}
       {autoScroller}
-      bind:wasTrackerPaused
       bind:this={trackerElm}
       onfreezecurrentlocation={freezeTrackerPosition}
       onstatisticssaved={scheduleReaderStatisticsReplication}
@@ -1426,7 +1415,7 @@
     onbookcharcountchange={(count) => (bookCharCount = count)}
     onisbookmarkscreenchange={(value) => (isBookmarkScreen = value)}
     onbookmark={bookmarkPage}
-    ontrackerPause={() => pauseTracker(true)}
+    ontrackerPause={() => pauseTracker('jump', true)}
   />
 {:else}
   {$leaveIfBookMissing$ ?? ''}
@@ -1443,7 +1432,7 @@
       sectionData={$sectionData$}
       verticalMode={$verticalMode$}
       {exploredCharCount}
-      {wasTrackerPaused}
+      {resumeTrackerAfterTocCloses}
     />
   {/if}
 </SidebarOverlay>
@@ -1546,13 +1535,13 @@
   onkeydown={onKeydown}
   onbeforeunload={handleUnload}
   onresize={() => {
-    if ($statisticsEnabled$ && !$isTrackerPaused$) {
-      pauseTracker();
+    if ($statisticsEnabled$ && !trackerStatus.paused) {
+      pauseTracker('resize');
 
       merge(fromEvent(document, PAGE_CHANGE), timer(1000))
         .pipe(debounceTime(1000), take(1))
         .subscribe(() => {
-          restartTrackerAfterCharacterChangeOrTime(1000);
+          restartTrackerAfterCharacterChangeOrTime('resize', 1000);
         });
     }
   }}

--- a/src/routes/settings/reader/+page.svelte
+++ b/src/routes/settings/reader/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { faPlus } from '@fortawesome/free-solid-svg-icons';
-  import { TrackerAutoPause } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+  import { TrackerAutoPause } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
   import ButtonToggleGroup from '$lib/components/button-toggle-group/button-toggle-group.svelte';
   import {
     optionsForToggle,

--- a/src/routes/settings/statistics/+page.svelte
+++ b/src/routes/settings/statistics/+page.svelte
@@ -3,7 +3,7 @@
   import {
     TrackerAutoPause,
     TrackerSkipThresholdAction
-  } from '$lib/components/book-reader/book-reading-tracker/book-reading-tracker';
+  } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
   import ButtonToggleGroup from '$lib/components/button-toggle-group/button-toggle-group.svelte';
   import {
     optionsForToggle,


### PR DESCRIPTION
## Summary
- replace tracker writable/control-store state with a Svelte 5 rune runtime
- model tracker pauses as independent reasons so temporary auto-pauses resume independently
- route bottom-left controls, the tracker menu, reader page, and TOC through the runtime API
- simplify tracker effects for visibility handling and autoscroller subscriptions

## Root Cause
The bottom-left tracker control could resume the tracker without updating the reader page's old pause bookkeeping. After a tab-hidden auto-pause, that stale state could block the visibility-return resume path.

## Validation
- npm run check
- node ~/miwake-harness/46-tracker-toggle-autoresumes-after-tab-return.mjs