### PR TITLE
Consolidate sidebar close controls

### DIFF
--- a/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker-panel.svelte
+++ b/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker-panel.svelte
@@ -11,7 +11,6 @@
     faTrash,
     type IconDefinition
   } from '@fortawesome/free-solid-svg-icons';
-  import DialogFormButton from '$lib/components/dialog-form-button.svelte';
   import type { TrackingHistory } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
   import {
     getChapterData,
@@ -205,34 +204,30 @@
   }
 </script>
 
-<div class="flex items-center justify-between min-h-[60px] px-4">
-  <div class="mr-4">
-    {#if hadError}
-      Last Update failed
-    {/if}
-  </div>
-  <div class="hover:text-red-500">
-    <DialogFormButton title="Close tracker menu" class="flex items-center md:items-center" />
-  </div>
-</div>
-<div class="flex flex-1 flex-col overflow-auto p-4">
+{#if hadError}
+  <div class="p-4 pr-12">Last Update failed</div>
+{/if}
+<div class="flex flex-1 flex-col overflow-auto p-4 pr-12">
   {#if currentReadingGoal}
-    <div class="mb-6">
+    <div class="mb-6 flex flex-col gap-4">
       {#if currentReadingGoal.timeGoal}
         {@const timeGoalPercentage = caluclatePercentage(
           currentTimeGoal,
           currentReadingGoal.timeGoal
         )}
         <div>
-          {secondsToMinutes(currentTimeGoal)} / {secondsToMinutes(currentReadingGoal.timeGoal)} Min ({timeGoalPercentage}%)
-        </div>
-        <!-- eslint-disable-next-line svelte/no-unknown-style-directive-property -->
-        <div class="w-full rounded-full h-2.5" style:background-Color={fontColor}>
-          <div
-            class="h-2.5 rounded-full opacity-70"
-            style:width={`${Math.min(100, timeGoalPercentage)}%`}
-            style:background-color={backgroundColor}
-          ></div>
+          <div>
+            {secondsToMinutes(currentTimeGoal)} / {secondsToMinutes(currentReadingGoal.timeGoal)} Min
+            ({timeGoalPercentage}%)
+          </div>
+          <!-- eslint-disable-next-line svelte/no-unknown-style-directive-property -->
+          <div class="w-full rounded-full h-2.5" style:background-Color={fontColor}>
+            <div
+              class="h-2.5 rounded-full opacity-70"
+              style:width={`${Math.min(100, timeGoalPercentage)}%`}
+              style:background-color={backgroundColor}
+            ></div>
+          </div>
         </div>
       {/if}
       {#if currentReadingGoal.characterGoal}
@@ -240,21 +235,23 @@
           currentCharacterGoal,
           currentReadingGoal.characterGoal
         )}
-        <div class="mt-4">
-          {currentCharacterGoal} / {currentReadingGoal.characterGoal} Characters ({characterGoalPercentage}%)
-        </div>
-        <!-- eslint-disable-next-line svelte/no-unknown-style-directive-property -->
-        <div class="w-full rounded-full h-2.5" style:background-Color={fontColor}>
-          <!-- eslint-disable svelte/no-unknown-style-directive-property -->
-          <div
-            class="h-2.5 rounded-full opacity-70"
-            style:width={`${Math.min(100, characterGoalPercentage)}%`}
-            style:background-Color={backgroundColor}
-          ></div>
-          <!-- eslint-enable svelte/no-unknown-style-directive-property -->
+        <div>
+          <div>
+            {currentCharacterGoal} / {currentReadingGoal.characterGoal} Characters ({characterGoalPercentage}%)
+          </div>
+          <!-- eslint-disable-next-line svelte/no-unknown-style-directive-property -->
+          <div class="w-full rounded-full h-2.5" style:background-Color={fontColor}>
+            <!-- eslint-disable svelte/no-unknown-style-directive-property -->
+            <div
+              class="h-2.5 rounded-full opacity-70"
+              style:width={`${Math.min(100, characterGoalPercentage)}%`}
+              style:background-Color={backgroundColor}
+            ></div>
+            <!-- eslint-enable svelte/no-unknown-style-directive-property -->
+          </div>
         </div>
       {/if}
-      <div class="grid grid-cols-[max-content_auto] gap-x-4 gap-y-2 mt-4">
+      <div class="grid grid-cols-[max-content_auto] gap-x-4 gap-y-2">
         <div>Current Reading Goal:</div>
         <div class="flex flex-col sm:block">
           <span>{currentReadingGoalStart}</span>

--- a/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte
+++ b/src/lib/components/book-reader/book-reading-tracker/book-reading-tracker.svelte
@@ -783,6 +783,7 @@
   onclose={closeTrackerMenu}
   side="left"
   class="z-60 max-w-xl"
+  closeTitle="Close tracker menu"
   style={`color: ${fontColor}; background-color: ${backgroundColor};`}
 >
   <BookReadingTrackerPanel

--- a/src/lib/components/book-reader/book-toc/book-toc.svelte
+++ b/src/lib/components/book-reader/book-toc/book-toc.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-  import DialogFormButton from '$lib/components/dialog-form-button.svelte';
   import {
     getChapterData,
     nextChapter$,
@@ -113,9 +112,8 @@
   }
 </script>
 
-<div class="flex justify-between p-4">
+<div class="p-4 pr-12">
   <div>Chapter Progress: {currentChapterCharacterProgress} ({currentChapterProgress}%)</div>
-  <DialogFormButton title="Close table of contents" />
 </div>
 <div class="flex-1 overflow-auto p-4">
   {#each chapters as chapter (chapter.reference)}

--- a/src/lib/components/sidebar-overlay.svelte
+++ b/src/lib/components/sidebar-overlay.svelte
@@ -6,6 +6,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { browser } from '$app/environment';
+  import DialogFormButton from '$lib/components/dialog-form-button.svelte';
   import { skipKeyDownListener$ } from '$lib/data/store';
   import { onDestroy } from 'svelte';
 
@@ -13,6 +14,7 @@
     open: boolean;
     side?: 'left' | 'right';
     class?: string;
+    closeTitle?: string;
     style?: string;
     onclose?: () => void;
     children?: Snippet;
@@ -22,6 +24,7 @@
     open = $bindable(),
     side = 'right',
     class: className = '',
+    closeTitle,
     style,
     onclose,
     children
@@ -29,6 +32,9 @@
 
   let dialogElement = $state<HTMLDialogElement>();
   let wasOpen = $state(false);
+  const closeButtonClasses = $derived(
+    `absolute top-4 z-10 flex items-center transition-colors hover:text-red-500 focus-visible:text-red-500 ${side === 'left' ? 'right-4' : 'left-4'}`
+  );
 
   function startSkipKeyDownListener() {
     if (openOverlayCount === 0) {
@@ -99,6 +105,10 @@
     onclose?.();
   }}
 >
+  {#if closeTitle}
+    <DialogFormButton title={closeTitle} class={closeButtonClasses} />
+  {/if}
+
   {@render children?.()}
 </dialog>
 

--- a/src/lib/components/statistics/statistics-settings.svelte
+++ b/src/lib/components/statistics/statistics-settings.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { faCircleQuestion, faLeftLong, faRightLong } from '@fortawesome/free-solid-svg-icons';
   import ButtonToggleGroup from '$lib/components/button-toggle-group/button-toggle-group.svelte';
-  import DialogFormButton from '$lib/components/dialog-form-button.svelte';
   import { optionsForToggle } from '$lib/components/button-toggle-group/toggle-option';
   import Popover from '$lib/components/popover/popover.svelte';
   import SettingsItemGroup from '$lib/components/settings/settings-item-group.svelte';
@@ -69,20 +68,17 @@
   }
 </script>
 
-<div class="flex items-center p-4">
-  <DialogFormButton title="Close statistics settings" />
-  <div class="flex flex-1 justify-end">
-    <button class="mr-2 sm:mr-4 hover:text-red-500" onclick={() => exportStatisticsData(false)}>
-      Export Selection
-    </button>
-    <button class="mr-2 sm:mr-4 hover:text-red-500" onclick={() => deleteStatisticsData(false)}>
-      Delete Selection
-    </button>
-    <button class="mr-2 sm:mr-4 hover:text-red-500" onclick={() => exportStatisticsData()}>
-      Export All
-    </button>
-    <button class="hover:text-red-500" onclick={() => deleteStatisticsData()}>Delete All</button>
-  </div>
+<div class="flex items-center justify-end p-4 pl-12">
+  <button class="mr-2 sm:mr-4 hover:text-red-500" onclick={() => exportStatisticsData(false)}>
+    Export Selection
+  </button>
+  <button class="mr-2 sm:mr-4 hover:text-red-500" onclick={() => deleteStatisticsData(false)}>
+    Delete Selection
+  </button>
+  <button class="mr-2 sm:mr-4 hover:text-red-500" onclick={() => exportStatisticsData()}>
+    Export All
+  </button>
+  <button class="hover:text-red-500" onclick={() => deleteStatisticsData()}>Delete All</button>
 </div>
 <div class="flex-1 p-4 overflow-auto">
   <div class="flex flex-col mb-6">

--- a/src/lib/components/statistics/statistics-shell.svelte
+++ b/src/lib/components/statistics/statistics-shell.svelte
@@ -732,6 +732,7 @@
   bind:open={$statisticsTitleFilterIsOpen$}
   side="right"
   class="overflow-hidden bg-gray-700 text-white"
+  closeTitle="Close book filter"
 >
   <StatisticsTitleFilter bind:titleFilterSelections {titlesInStatisticsDateRange} />
 </SidebarOverlay>

--- a/src/lib/components/statistics/statistics-title-filter.svelte
+++ b/src/lib/components/statistics/statistics-title-filter.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import DialogFormButton from '$lib/components/dialog-form-button.svelte';
   import ToggleSwitch from '$lib/components/toggle-switch.svelte';
   import { lastStatisticsFilterDateRangeOnly$ } from '$lib/data/store';
 
@@ -41,10 +40,7 @@
   }
 </script>
 
-<div class="flex items-center p-4">
-  <DialogFormButton title="Close book filter" />
-</div>
-<div class="flex flex-col flex-1 px-4 min-h-0">
+<div class="flex flex-col flex-1 px-4 pt-12 min-h-0">
   <div class="flex items-center gap-4">
     <input
       type="search"

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -1427,6 +1427,7 @@
   bind:open={$tocIsOpen$}
   side="left"
   class="overflow-hidden bg-background-color text-(--font-color)"
+  closeTitle="Close table of contents"
   style={`color: ${$themeOption$?.fontColor}; background-color: ${$backgroundColor$};`}
 >
   {#if $sectionData$}

--- a/src/routes/statistics/+layout.svelte
+++ b/src/routes/statistics/+layout.svelte
@@ -160,6 +160,7 @@
   bind:open={showStatisticsSettings}
   side="right"
   class="overflow-hidden bg-gray-700 text-white"
+  closeTitle="Close statistics settings"
 >
   <StatisticsSettings onstatisticsDateChange={handleSelectedStatisticsDateChange} />
 </SidebarOverlay>


### PR DESCRIPTION
Moves sidebar close controls into the shared overlay chrome and removes the reading tracker’s extra top spacing.