### PR TITLE
Refer to books in statistics UI

### DIFF
--- a/src/lib/components/statistics/statistics-header.svelte
+++ b/src/lib/components/statistics/statistics-header.svelte
@@ -59,7 +59,7 @@
         <div class={headerDividerClasses}></div>
         <HeaderButton
           faIcon={faFilter}
-          title="Open title filter menu"
+          title="Open book filter menu"
           label="Filter"
           disabled={!$statisticsTitleFilterEnabled$}
           onclick={() => {

--- a/src/lib/components/statistics/statistics-heatmap/statistics-heatmap.svelte
+++ b/src/lib/components/statistics/statistics-heatmap/statistics-heatmap.svelte
@@ -993,7 +993,7 @@
             dateString,
             `${secondsToMinutes(dayData.readingTime)} min`,
             `${dayData.charactersRead} characters`,
-            pluralize(dayData.titles.size, 'title')
+            pluralize(dayData.titles.size, 'book')
           ],
           readingTime: dayData.readingTime
         }
@@ -1003,7 +1003,7 @@
           heatmapRow,
           heatmapColumn,
           color: '',
-          dayDetails: [dateString, `0 min`, `0 characters`, `0 titles`],
+          dayDetails: [dateString, `0 min`, `0 characters`, `0 books`],
           readingTime: 0
         };
 
@@ -1067,7 +1067,7 @@
                 currentReadingGoalWindow.readingGoalEndDate
               )
             ]),
-        pluralize(currentReadingGoalWindow.titles.size, 'title'),
+        pluralize(currentReadingGoalWindow.titles.size, 'book'),
         ...(currentReadingGoalWindow.timeGoal
           ? [
               `${secondsToMinutes(currentReadingGoalWindow.readingTime)} / ${secondsToMinutes(

--- a/src/lib/components/statistics/statistics-settings.svelte
+++ b/src/lib/components/statistics/statistics-settings.svelte
@@ -11,6 +11,7 @@
     charactersDataSources,
     readingSpeedDataSources,
     statisticsDataAggregrationModes,
+    StatisticsReadingDataAggregationMode,
     exportStatisticsData$,
     statisticsActionInProgress$,
     deleteStatisticsData$,
@@ -157,7 +158,7 @@
     class="text-left mt-3 hover:text-red-500"
     onclick={() => setStatisticsDatesToAllTime$.next()}
   >
-    Set to All Time for selected Book Titles
+    Set to all time for the selected books
   </button>
   <div class="flex flex-wrap justify-between mt-4">
     <div class="flex flex-col my-2 w-full sm:w-[initial]">
@@ -232,7 +233,9 @@
     >
       {#each statisticsDataAggregrationModes as statisticsDataAggregrationMode (statisticsDataAggregrationMode)}
         <option value={statisticsDataAggregrationMode}>
-          {statisticsDataAggregrationMode}
+          {statisticsDataAggregrationMode === StatisticsReadingDataAggregationMode.TITLE
+            ? 'Book'
+            : statisticsDataAggregrationMode}
         </option>
       {/each}
     </select>

--- a/src/lib/components/statistics/statistics-title-filter.svelte
+++ b/src/lib/components/statistics/statistics-title-filter.svelte
@@ -68,7 +68,7 @@
                 bind:this={headerCheckbox}
               />
             </th>
-            <th class="py-2 text-left font-semibold">Book title</th>
+            <th class="py-2 text-left font-semibold">Book</th>
           </tr>
         </thead>
         <tbody>

--- a/src/lib/components/statistics/statistics-types.ts
+++ b/src/lib/components/statistics/statistics-types.ts
@@ -66,7 +66,7 @@ export const readingSpeedDataSources: StatisticsDataSource[] = [
 
 export const dateDataSources: StatisticsDataSource[] = [{ key: 'dateKey', label: 'Date' }];
 
-export const titleDataSources: StatisticsDataSource[] = [{ key: 'title', label: 'Title' }];
+export const titleDataSources: StatisticsDataSource[] = [{ key: 'title', label: 'Book' }];
 
 export const copyStatisticsData$ = new Subject<keyof BookStatistic>();
 

--- a/tests/integration/helpers/fixtures.ts
+++ b/tests/integration/helpers/fixtures.ts
@@ -403,7 +403,7 @@ function bookPlaceholderIndicator(page: Page, fixture: LibraryBookFixture) {
 async function showAllStatistics(page: Page) {
   await navigateToStatisticsSummary(page);
   const settings = await openStatisticsSettings(page);
-  await settings.getByRole('button', { name: 'Set to All Time for selected Book Titles' }).click();
+  await settings.getByRole('button', { name: 'Set to all time for the selected books' }).click();
   await settings.getByTitle('Close statistics settings').click();
   await expect(settings).toHaveCount(0, { timeout: SYNC_ASSERTION_TIMEOUT });
 }


### PR DESCRIPTION
Updates statistics UI copy so user-facing references describe selected items as books instead of titles.