### PR TITLE
Preserve original margins in auto text margin mode

### DIFF
--- a/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -10,6 +10,7 @@
   import { isStoredFont } from '$lib/data/fonts';
   import { FuriganaStyle } from '$lib/data/furigana-style';
   import { logger } from '$lib/data/logger';
+  import type { TextMarginMode } from '$lib/data/text-margin-mode';
   import {
     customReadingPointEnabled$,
     disableWheelNavigation$,
@@ -67,6 +68,7 @@
     fontSize: number;
     lineHeight: number;
     textIndentation: number;
+    textMarginMode: TextMarginMode;
     textMarginValue: number;
     hideSpoilerImage: boolean;
     furiganaStyle: FuriganaStyle;
@@ -111,6 +113,7 @@
     fontSize,
     lineHeight,
     textIndentation,
+    textMarginMode,
     textMarginValue,
     hideSpoilerImage,
     furiganaStyle,
@@ -735,6 +738,7 @@
   class:book-content--furigana-style-toggle={furiganaStyle === FuriganaStyle.Toggle}
   class:ttu-apply-important={prioritizeReaderStyles}
   class:ttu-apply-justification={enableTextJustification}
+  class:ttu-margin-manual={textMarginMode === 'manual'}
   class:ttu-text-wrap-pretty={enableTextWrapPretty}
   class="book-content m-auto"
   lang="ja"

--- a/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -6,6 +6,7 @@
   import { isStoredFont } from '$lib/data/fonts';
   import { FuriganaStyle } from '$lib/data/furigana-style';
   import { logger } from '$lib/data/logger';
+  import type { TextMarginMode } from '$lib/data/text-margin-mode';
   import {
     disableWheelNavigation$,
     firstDimensionMargin$,
@@ -60,6 +61,7 @@
     fontSize: number;
     lineHeight: number;
     textIndentation: number;
+    textMarginMode: TextMarginMode;
     textMarginValue: number;
     hideSpoilerImage: boolean;
     furiganaStyle: FuriganaStyle;
@@ -101,6 +103,7 @@
     fontSize,
     lineHeight,
     textIndentation,
+    textMarginMode,
     textMarginValue,
     hideSpoilerImage,
     furiganaStyle,
@@ -750,6 +753,7 @@
   class:book-content--furigana-style-toggle={furiganaStyle === FuriganaStyle.Toggle}
   class:ttu-apply-important={prioritizeReaderStyles}
   class:ttu-apply-justification={enableTextJustification}
+  class:ttu-margin-manual={textMarginMode === 'manual'}
   class:ttu-text-wrap-pretty={enableTextWrapPretty}
   class="book-content m-auto"
   {...useSwipe(onSwipe, () => ({

--- a/src/lib/components/book-reader/book-reader.svelte
+++ b/src/lib/components/book-reader/book-reader.svelte
@@ -19,6 +19,7 @@
   import { pxReader } from '$lib/components/book-reader/css-classes';
   import type { BooksDbBookmarkData } from '$lib/data/database/books-db/versions/books-db';
   import { FuriganaStyle } from '$lib/data/furigana-style';
+  import type { TextMarginMode } from '$lib/data/text-margin-mode';
   import { ViewMode } from '$lib/data/view-mode';
   import { iffBrowser } from '$lib/functions/rxjs/iff-browser';
   import { reduceToEmptyString } from '$lib/functions/rxjs/reduce-to-empty-string';
@@ -42,6 +43,7 @@
     enableTextJustification: boolean;
     enableTextWrapPretty: boolean;
     textIndentation: number;
+    textMarginMode: TextMarginMode;
     textMarginValue: number;
     fontColor: string;
     backgroundColor: string;
@@ -90,6 +92,7 @@
     enableTextJustification,
     enableTextWrapPretty,
     textIndentation,
+    textMarginMode,
     textMarginValue,
     fontColor,
     backgroundColor,
@@ -317,6 +320,7 @@
       {fontSize}
       {lineHeight}
       {textIndentation}
+      {textMarginMode}
       {textMarginValue}
       {hideSpoilerImage}
       {furiganaStyle}
@@ -361,6 +365,7 @@
       {fontSize}
       {lineHeight}
       {textIndentation}
+      {textMarginMode}
       {textMarginValue}
       {hideSpoilerImage}
       {furiganaStyle}

--- a/src/lib/components/book-reader/styles.css
+++ b/src/lib/components/book-reader/styles.css
@@ -78,14 +78,14 @@
       text-indent: var(--book-content-text-intendation, 0rem) !important;
     }
 
-    &.book-content--writing-vertical-rl {
+    &.book-content--writing-vertical-rl.ttu-margin-manual {
       :global(p) {
         margin-right: var(--book-content-text-margin, 0rem) !important;
         margin-left: var(--book-content-text-margin, 0rem) !important;
       }
     }
 
-    &.book-content--writing-horizontal-rl {
+    &.book-content--writing-horizontal-rl.ttu-margin-manual {
       :global(p) {
         margin-top: var(--book-content-text-margin, 0rem) !important;
         margin-bottom: var(--book-content-text-margin, 0rem) !important;
@@ -182,14 +182,22 @@
    overridden. The :global() bypasses Svelte scoping so :where() can actually
    zero out the specificity of the parent selectors. See
    https://github.com/ttu-ttu/ebook-reader/issues/486 for a repro. */
-:global(:where(.book-content:not(.ttu-apply-important).book-content--writing-vertical-rl)) {
+:global(
+  :where(
+    .book-content:not(.ttu-apply-important).book-content--writing-vertical-rl.ttu-margin-manual
+  )
+) {
   :global(p) {
     margin-right: var(--book-content-text-margin, 0rem);
     margin-left: var(--book-content-text-margin, 0rem);
   }
 }
 
-:global(:where(.book-content:not(.ttu-apply-important).book-content--writing-horizontal-rl)) {
+:global(
+  :where(
+    .book-content:not(.ttu-apply-important).book-content--writing-horizontal-rl.ttu-margin-manual
+  )
+) {
   :global(p) {
     margin-top: var(--book-content-text-margin, 0rem);
     margin-bottom: var(--book-content-text-margin, 0rem);

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -57,6 +57,7 @@
     showFooterChapterCharacterCounter$,
     showFooterChapterPercentage$,
     textIndentation$,
+    textMarginMode$,
     textMarginValue$,
     theme$,
     trackerAutostartTime$,
@@ -1399,6 +1400,7 @@
     fontSize={$fontSize$}
     lineHeight={$lineHeight$}
     textIndentation={$textIndentation$}
+    textMarginMode={$textMarginMode$}
     textMarginValue={$textMarginValue$}
     hideSpoilerImage={$hideSpoilerImage$}
     furiganaStyle={$furiganaStyle$}


### PR DESCRIPTION
Ports the upstream margin-mode fix so EPUB paragraph margins are preserved unless the reader is using manual text margins.