### PR TITLE
Reserve space for sync indicator

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -36,10 +36,33 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+@utility sync-safe-px {
+  padding-inline: var(--sync-safe-inline-inset);
+}
+
+@utility sync-indicator-inset {
+  bottom: var(--sync-indicator-gap);
+  left: var(--sync-indicator-gap);
+}
+
+@utility sync-indicator-size {
+  block-size: var(--sync-indicator-size);
+  inline-size: var(--sync-indicator-size);
+}
+
 :root {
   --font-color: rgba(0, 0, 0, 0.87);
   --background-color: #eceff1;
+  --sync-indicator-gap: 0.25rem;
+  --sync-indicator-size: 2rem;
+  --sync-safe-inline-inset: calc(var(--sync-indicator-size) + var(--sync-indicator-gap) * 2);
   scrollbar-color: #c1c1c1 #c1c1c100;
+}
+
+@media (width >= 40rem) {
+  :root {
+    --sync-indicator-gap: 0.75rem;
+  }
 }
 
 .book-cover {

--- a/src/lib/components/bottom-left-cluster.svelte
+++ b/src/lib/components/bottom-left-cluster.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   // Bottom-left controls cluster — always shows the sync status pill;
   // in reader mode, stacks a play/pause and a stats-menu button above
-  // it. The sync pill stays anchored at bottom-3 left-3 across every
-  // route so users always know where to find it.
+  // it. The sync pill stays anchored in the lower-left corner across every route so users always know where to find it.
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
@@ -139,11 +138,10 @@
     );
   }
 
-  // 32px hit target, 16-18px icon. Hover dabs a faint translucent
-  // backdrop in so users get a "this is interactive" affordance
-  // without a permanent button surface.
+  // The hit target size comes from the shared sync-indicator CSS variables.
+  // Hover dabs a faint translucent backdrop in so users get a "this is interactive" affordance without a permanent button surface.
   const buttonClass =
-    'flex h-8 w-8 items-center justify-center rounded-full text-base sm:text-lg transition-colors hover:bg-black/5';
+    'sync-indicator-size flex items-center justify-center rounded-full text-base transition-colors hover:bg-black/5 sm:text-lg';
 </script>
 
 {#snippet clusterButton(
@@ -179,7 +177,7 @@
   </Popover>
 {/snippet}
 
-<div class="writing-horizontal-tb fixed bottom-3 left-3 z-40 flex flex-col-reverse gap-2">
+<div class="sync-indicator-inset writing-horizontal-tb fixed z-40 flex flex-col-reverse gap-2">
   {@render clusterButton(syncLabel, icons[indicator.kind], {
     onClick: onSyncClick,
     clickable: syncClickable,

--- a/src/lib/css-classes.ts
+++ b/src/lib/css-classes.ts
@@ -1,5 +1,5 @@
 export const baseHeaderClasses = 'relative h-12 bg-gray-700 text-white';
-export const pxScreen = 'px-4 max-w-6xl mx-auto';
+export const pxScreen = 'sync-safe-px max-w-6xl mx-auto';
 export const inputClasses =
   'mt-1 block w-full px-0.5 bg-background-color border-0 border-b-2 border-b-gray-400/50 focus:ring-0 focus:border-b-black focus:outline-hidden transition-colors';
 export const buttonClasses =

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,4 +1,4 @@
-<div class="mx-auto max-w-2xl p-8">
+<div class="sync-safe-px mx-auto max-w-2xl py-8">
   <h1 class="mb-6 text-2xl font-bold">Privacy Policy</h1>
 
   <p class="mb-4">

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -2,7 +2,7 @@
   import { resolve } from '$app/paths';
 </script>
 
-<div class="mx-auto max-w-2xl p-8">
+<div class="sync-safe-px mx-auto max-w-2xl py-8">
   <h1 class="mb-6 text-2xl font-bold">Terms of Service</h1>
 
   <p class="mb-4">


### PR DESCRIPTION
Adds shared sync indicator spacing utilities so page containers reserve equal space around the fixed bottom-left sync indicator.