### PR TITLE
Replace database UI streams with Svelte runes

### DIFF
--- a/src/lib/components/header-nav-tabs.svelte
+++ b/src/lib/components/header-nav-tabs.svelte
@@ -7,7 +7,6 @@
   import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
   import HeaderButton from '$lib/components/header-button.svelte';
   import { database } from '$lib/data/store';
-  import { map, share } from 'rxjs';
 
   type HeaderRouteId = Extract<RouteId, '/b' | '/statistics' | '/settings' | '/manage'>;
   type HeaderRouteWithQuery = HeaderRouteId | `${HeaderRouteId}?${string}`;
@@ -19,11 +18,6 @@
   }
 
   let { disableNavigation = false, onnavigate }: Props = $props();
-
-  const currentBookId$ = database.lastItem$.pipe(
-    map((item) => item?.dataId),
-    share()
-  );
 
   const tabs = [
     { routeId: '/statistics', label: 'Statistics', icon: faChartLine },
@@ -48,13 +42,13 @@
   }
 </script>
 
-{#if $currentBookId$}
+{#if database.lastItemId !== undefined}
   <HeaderButton
     faIcon={faBookOpen}
     label="Book"
     selected={page.route.id === '/b'}
     variant="tab"
-    onclick={() => handleClick('/b', `?id=${$currentBookId$}`)}
+    onclick={() => handleClick('/b', `?id=${database.lastItemId}`)}
   />
 {/if}
 {#each tabs as tab (tab.routeId)}

--- a/src/lib/data/database/books-db/database.service.svelte.ts
+++ b/src/lib/data/database/books-db/database.service.svelte.ts
@@ -5,7 +5,7 @@ import type {
   BooksDbStatistic,
   BooksDbStorageSource
 } from '$lib/data/database/books-db/versions/books-db';
-import { Observable, Subject, from } from 'rxjs';
+import { browser } from '$app/environment';
 import { StorageDataType } from '$lib/data/storage/storage-types';
 import {
   advanceDateDays,
@@ -14,7 +14,6 @@ import {
   mergeStatistics,
   updateStatisticToStore
 } from '$lib/functions/statistic-util';
-import { catchError, map, shareReplay, startWith, switchMap } from 'rxjs/operators';
 import {
   getCurrentReadingGoal,
   mergeReadingGoals,
@@ -32,102 +31,162 @@ import type { MergeMode } from '$lib/data/merge-mode';
 import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
 import { getDefaultStatistic } from '$lib/components/book-reader/book-reading-tracker/tracker-domain';
 import { handleErrorDuringReplication } from '$lib/functions/replication/error-handler';
-import { iffBrowser } from '$lib/functions/rxjs/iff-browser';
 import { logger } from '$lib/data/logger';
 import pLimit from 'p-limit';
 import { replicationProgress$ } from '$lib/functions/replication/replication-progress';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
 const LAST_ITEM_KEY = 0;
 
 export class DatabaseService {
-  private db$: Observable<Awaited<typeof this.db>>;
-
-  isReady$: Observable<boolean>;
-
-  listLoading$ = new Subject<boolean>();
-
-  dataListChanged$ = new Subject<void>();
+  #state = $state({
+    isReady: false,
+    listLoading: browser,
+    dataList: [] as BookCardProps[],
+    bookmarks: [] as BooksDbBookmarkData[],
+    lastItemId: undefined as number | undefined,
+    lastItemLoaded: false
+  });
 
   /**
    * The unified library view — every BookCardProps row /manage shows.
    * Reads IndexedDB directly; no storage-handler involvement, since
    * cloud/fs handlers are sync endpoints, not library data sources.
-   * Subscribers debounce their own work; this just emits BookCardProps[]
-   * whenever someone calls notifyDataListChanged() or fires
-   * dataListChanged$.next().
+   * Call notifyDataListChanged() after direct writes so this state refreshes
+   * from IndexedDB.
    */
-  dataList$ = iffBrowser(() =>
-    this.dataListChanged$.pipe(
-      startWith(undefined),
-      switchMap(() =>
-        from(this.fetchBookCards()).pipe(
-          catchError((error: unknown) => {
-            showErrorDialog({ title: 'Error loading books', error });
-            return [[]];
-          })
-        )
-      ),
-      shareReplay({ refCount: true, bufferSize: 1 })
-    )
-  );
-
-  private async fetchBookCards(): Promise<BookCardProps[]> {
-    this.listLoading$.next(true);
-    try {
-      logger.clearHistory();
-      const db = await this.db;
-      const data = await db.getAll('data');
-      return data.map((book) => ({
-        id: book.id,
-        title: book.title,
-        imagePath: book.coverImage || '',
-        characters: BaseStorageHandler.getBookCharacters(book.characters || 0, book.sections || []),
-        lastBookModified: book.lastBookModified || 0,
-        lastBookOpen: book.lastBookOpen || 0,
-        isPlaceholder: !book.elementHtml,
-        // Overlaid by /manage's bookCards$ pipeline from the bookmark store.
-        progress: 0,
-        completed: false,
-        lastBookmarkModified: 0
-      }));
-    } finally {
-      this.listLoading$.next(false);
-    }
+  get dataList() {
+    return this.#state.dataList;
   }
 
-  bookmarksChanged$ = new Subject<void>();
+  get bookmarks() {
+    return this.#state.bookmarks;
+  }
 
-  bookmarks$ = this.bookmarksChanged$.pipe(
-    startWith(0),
-    switchMap(() => this.db$),
-    switchMap((db) => db.getAll('bookmark')),
-    shareReplay({ refCount: true, bufferSize: 1 })
-  );
+  get lastItemId() {
+    return this.#state.lastItemId;
+  }
 
-  lastItemChanged$ = new Subject<void>();
+  get lastItemLoaded() {
+    return this.#state.lastItemLoaded;
+  }
 
-  lastItem$ = this.lastItemChanged$.pipe(
-    startWith(0),
-    switchMap(() => this.db$),
-    switchMap((db) => db.get('lastItem', LAST_ITEM_KEY)),
-    shareReplay({ refCount: true, bufferSize: 1 })
-  );
+  get listLoading() {
+    return this.#state.listLoading;
+  }
 
-  storageSourcesChanged$ = new Subject<BooksDbStorageSource[]>();
+  get isReady() {
+    return this.#state.isReady;
+  }
+
+  #dataListRefreshId = 0;
+
+  #bookmarksRefreshId = 0;
+
+  #lastItemRefreshId = 0;
+
+  async #fetchBookCards(): Promise<BookCardProps[]> {
+    logger.clearHistory();
+    const db = await this.db;
+    const data = await db.getAll('data');
+    return data.map((book) => ({
+      id: book.id,
+      title: book.title,
+      imagePath: book.coverImage || '',
+      characters: BaseStorageHandler.getBookCharacters(book.characters || 0, book.sections || []),
+      lastBookModified: book.lastBookModified || 0,
+      lastBookOpen: book.lastBookOpen || 0,
+      isPlaceholder: !book.elementHtml,
+      // Overlaid by /manage's book-card derivation from bookmark state.
+      progress: 0,
+      completed: false,
+      lastBookmarkModified: 0
+    }));
+  }
 
   constructor(public db: Promise<IDBPDatabase<BooksDb>>) {
-    this.db$ = from(db).pipe(shareReplay({ refCount: true, bufferSize: 1 }));
-    this.isReady$ = this.db$.pipe(map((x) => !!x));
+    db.then(
+      () => (this.#state.isReady = true),
+      (error: unknown) => showErrorDialog({ title: 'Error opening database', error })
+    );
+
+    if (browser) {
+      this.notifyDataListChanged();
+      this.notifyBookmarksChanged();
+      void this.#refreshLastItem();
+    }
   }
 
   /**
    * Use this when something has mutated the `data` store directly
-   * (sync engine seeding placeholders, importers, etc.). dataList$
-   * reads IndexedDB on every emission so no handler-cache
-   * invalidation is needed — just kick the pipeline.
+   * (sync engine seeding placeholders, importers, etc.). `dataList`
+   * reads IndexedDB on every refresh so no handler-cache invalidation is
+   * needed.
    */
   notifyDataListChanged(): void {
-    this.dataListChanged$.next();
+    void this.#refreshBookCards();
+  }
+
+  notifyBookmarksChanged(): void {
+    void this.#refreshBookmarks();
+  }
+
+  async #refreshBookCards() {
+    const refreshId = ++this.#dataListRefreshId;
+
+    this.#state.listLoading = true;
+
+    try {
+      const bookCards = await this.#fetchBookCards();
+      if (refreshId === this.#dataListRefreshId) {
+        this.#state.dataList = bookCards;
+      }
+    } catch (error) {
+      if (refreshId === this.#dataListRefreshId) {
+        showErrorDialog({ title: 'Error loading books', error });
+        this.#state.dataList = [];
+      }
+    } finally {
+      if (refreshId === this.#dataListRefreshId) {
+        this.#state.listLoading = false;
+      }
+    }
+  }
+
+  async #refreshBookmarks() {
+    const refreshId = ++this.#bookmarksRefreshId;
+
+    try {
+      const db = await this.db;
+      const bookmarks = await db.getAll('bookmark');
+      if (refreshId === this.#bookmarksRefreshId) {
+        this.#state.bookmarks = bookmarks;
+      }
+    } catch (error) {
+      if (refreshId === this.#bookmarksRefreshId) {
+        showErrorDialog({ title: 'Error loading bookmarks', error });
+        this.#state.bookmarks = [];
+      }
+    }
+  }
+
+  async #refreshLastItem() {
+    const refreshId = ++this.#lastItemRefreshId;
+
+    try {
+      const db = await this.db;
+      const lastItem = await db.get('lastItem', LAST_ITEM_KEY);
+      if (refreshId === this.#lastItemRefreshId) {
+        this.#state.lastItemId = lastItem?.dataId;
+        this.#state.lastItemLoaded = true;
+      }
+    } catch (error) {
+      if (refreshId === this.#lastItemRefreshId) {
+        showErrorDialog({ title: 'Error loading last-opened book', error });
+        this.#state.lastItemId = undefined;
+        this.#state.lastItemLoaded = true;
+      }
+    }
   }
 
   async getLastModifiedForType(title: string, dataType: string) {
@@ -276,7 +335,7 @@ export class DatabaseService {
     const lastItemObj = await db.get('lastItem', LAST_ITEM_KEY);
     const bookmarkIdData = await db.getAllKeys('bookmark');
     const lastItem = lastItemObj?.dataId;
-    const bookmarkIds = new Set(bookmarkIdData);
+    const bookmarkIds = new SvelteSet(bookmarkIdData);
     const deleted: number[] = [];
     const errors: Error[] = [];
     const limiter = pLimit(1);
@@ -290,7 +349,7 @@ export class DatabaseService {
           try {
             signal.throwIfAborted();
             deleted.push(
-              await this.deleteSingleData(
+              await this.#deleteSingleData(
                 db,
                 id,
                 idsToTitles.get(id),
@@ -324,24 +383,26 @@ export class DatabaseService {
   async putBookmark(bookmarkData: BooksDbBookmarkData) {
     const db = await this.db;
     const result = await db.put('bookmark', bookmarkData);
-    this.bookmarksChanged$.next();
+    await this.#refreshBookmarks();
     return result;
   }
 
   async putLastItem(dataId: number) {
     const db = await this.db;
     const result = await db.put('lastItem', { dataId }, LAST_ITEM_KEY);
-    this.lastItemChanged$.next();
+    this.#state.lastItemId = dataId;
+    this.#state.lastItemLoaded = true;
     return result;
   }
 
   async deleteLastItem() {
     const db = await this.db;
     await db.delete('lastItem', LAST_ITEM_KEY);
-    this.lastItemChanged$.next();
+    this.#state.lastItemId = undefined;
+    this.#state.lastItemLoaded = true;
   }
 
-  private async deleteSingleData(
+  async #deleteSingleData(
     db: IDBPDatabase<BooksDb>,
     dataId: number,
     title: string | undefined,
@@ -393,7 +454,8 @@ export class DatabaseService {
       await tx.done;
 
       if (shouldDeleteLastItem) {
-        this.lastItemChanged$.next();
+        this.#state.lastItemId = undefined;
+        this.#state.lastItemLoaded = true;
       }
     } catch (error: any) {
       try {
@@ -608,11 +670,11 @@ export class DatabaseService {
   async clearZombieStatistics() {
     const db = await this.db;
     const books = await db.getAll('data');
-    const titles = new Set(books.map((book) => book.title));
+    const titles = new SvelteSet(books.map((book) => book.title));
     const statistics = await db.getAll('statistic');
     const lastModifiedForStatistics = await db.getAll('lastModified');
     const statisticsToDelete: BooksDbStatistic[] = [];
-    const lastModifiedItemsToDelete = new Set<string>();
+    const lastModifiedItemsToDelete = new SvelteSet<string>();
 
     for (let index = 0, { length } = statistics; index < length; index += 1) {
       const entry = statistics[index];
@@ -640,7 +702,7 @@ export class DatabaseService {
 
     const db = await this.db;
     const tx = db.transaction(['statistic', 'lastModified'], 'readwrite');
-    const titlesToDelete = new Set<string>();
+    const titlesToDelete = new SvelteSet<string>();
 
     try {
       const statisticsStore = tx.objectStore('statistic');
@@ -715,7 +777,7 @@ export class DatabaseService {
       const tasks: Promise<void>[] = [];
       const dates: string[] = [];
       const lastModifiedValue = Date.now();
-      const hadDataMap = new Map<string, boolean>();
+      const hadDataMap = new SvelteMap<string, boolean>();
 
       if (startDateString) {
         // eslint-disable-next-line prefer-const

--- a/src/lib/data/library.ts
+++ b/src/lib/data/library.ts
@@ -164,8 +164,8 @@ export async function userImportBooks(
             }
           });
 
-          // The library always drives /manage's view; emit unconditionally.
-          database.dataListChanged$.next();
+          // The library always drives /manage's view; refresh unconditionally.
+          database.notifyDataListChanged();
 
           checkCancelAndProgress(signal, true, !bookContent.coverImage);
         } catch (error: any) {
@@ -297,9 +297,9 @@ export async function userDeleteBooks(
 ): Promise<void> {
   const local = getLocalEndpoint();
   // Local delete throws on any per-id failure; the surviving deleted
-  // ids stay in IDB and `dataListChanged$` already fired, so the UI
-  // re-renders from the new book list without needing the partial set
-  // threaded through the return.
+  // ids stay in IDB and the book-card list already refreshed, so the
+  // UI re-renders without needing the partial set threaded through the
+  // return.
   await local.deleteBookData(titles, signal, keepLocalStatistics);
 
   await syncAfterLocalMutation({ kind: 'books-deleted', titles, signal });

--- a/src/lib/data/storage/handler/api-handler.ts
+++ b/src/lib/data/storage/handler/api-handler.ts
@@ -138,7 +138,7 @@ export abstract class ApiStorageHandler extends BaseStorageHandler {
       this.titleToFiles.delete(title);
       this.titleToId.delete(title);
       this.titleToBookCard.delete(title);
-      database.dataListChanged$.next();
+      database.notifyDataListChanged();
       return deletedId;
     });
   }

--- a/src/lib/data/storage/handler/local-replication-endpoint.ts
+++ b/src/lib/data/storage/handler/local-replication-endpoint.ts
@@ -57,10 +57,10 @@ export class LocalReplicationEndpoint implements LocalReplicationEndpointRole {
     } finally {
       // On partial failure the AggregateError loses the per-id
       // deleted list, but IDB still reflects whatever got through.
-      // Fire dataListChanged$ unconditionally so the UI re-renders
-      // off the actual book set rather than a stale snapshot. The
-      // redundant fire on 0-id success is one cheap no-op rerender.
-      database.dataListChanged$.next();
+      // Refresh unconditionally so the UI re-renders off the actual
+      // book set rather than a stale snapshot. The redundant refresh on
+      // 0-id success is one cheap no-op rerender.
+      database.notifyDataListChanged();
     }
   }
 

--- a/src/lib/data/store.ts
+++ b/src/lib/data/store.ts
@@ -31,7 +31,7 @@ import { AutoReplicationType } from '$lib/functions/replication/replication-opti
 import { writableSubject } from '$lib/functions/svelte/store';
 import { map } from 'rxjs';
 import { BookReaderAvailableKeybind, type BookReaderKeybindMap } from './book-reader-keybind';
-import { DatabaseService } from './database/books-db/database.service';
+import { DatabaseService } from './database/books-db/database.service.svelte';
 import { createBooksDb } from './database/books-db/factory';
 import { FuriganaStyle } from './furigana-style';
 import { ImportHTMLFixMode } from './import-html-fix-mode';

--- a/src/lib/data/sync/backup-service.ts
+++ b/src/lib/data/sync/backup-service.ts
@@ -360,8 +360,8 @@ export async function importBackup(
 /**
  * Clear every IndexedDB store + all localStorage, then reload to a
  * fresh boot. Doesn't deleteDatabase: that races with in-flight
- * transactions from RxJS subscribers (dataList$, bookmarks$) and
- * surfaces a misleading "still open in another tab" error. Clearing
+ * transactions from live store refreshes and surfaces a misleading
+ * "still open in another tab" error. Clearing
  * stores is atomic in one transaction and leaves the schema intact —
  * the next boot finds empty stores and behaves identically to a
  * fresh install.

--- a/src/lib/data/sync/sync-engine.ts
+++ b/src/lib/data/sync/sync-engine.ts
@@ -808,7 +808,7 @@ export async function reconcileForBookOpen(context: ReplicationContext): Promise
       library: local,
       endpoint: handler,
       direction: 'pull',
-      refreshDataList: false,
+      refreshDataList: isPlaceholder,
       contexts: [context],
       dataToReplicate: types,
       settings: scopedSettings()

--- a/src/lib/functions/replication/replicator.ts
+++ b/src/lib/functions/replication/replicator.ts
@@ -38,16 +38,15 @@ export type ReplicationDirection = 'push' | 'pull';
  * `scopedSettings({ winnerTakesAll })` rather than wiring knobs.
  *
  * Resolves on success. Throws on any failure (including AbortError on
- * cancel). Per-book partial successes are observable via IDB side
- * effects (dataListChanged$ / bookmarksChanged$); callers that care
- * about which book worked should subscribe to those rather than parse
- * the thrown error.
+ * cancel). Per-book partial successes are observable via refreshed IDB
+ * stores; callers that care about which book worked should read those
+ * rather than parse the thrown error.
  */
 export interface ReplicateDataOptions {
   library: LocalReplicationEndpoint;
   endpoint: SyncEndpoint;
   direction: ReplicationDirection;
-  /** Whether to fire dataListChanged$ after writes; true for flows
+  /** Whether to refresh the book-card list after writes; true for flows
    *  that affect /manage's view (force-resync, backup-import). */
   refreshDataList: boolean;
   contexts: ReplicationContext[];
@@ -174,10 +173,10 @@ export async function replicateData(opts: ReplicateDataOptions) {
 
             if (direction === 'pull') {
               if (refreshDataList) {
-                database.dataListChanged$.next();
+                database.notifyDataListChanged();
               }
               if (processProgressData) {
-                database.bookmarksChanged$.next();
+                database.notifyBookmarksChanged();
               }
             }
           } else {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,17 +3,16 @@
   import { resolve } from '$app/paths';
   import { database } from '$lib/data/store';
   import { formatPageTitle } from '$lib/functions/format-page-title';
-  import { observe } from '$lib/functions/rxjs/use-observable';
-  import { map, tap } from 'rxjs';
 
-  const autoNavigate$ = database.lastItem$.pipe(
-    map((lastItem) => resolve(lastItem ? `/b?id=${lastItem.dataId}` : '/manage')),
-    tap(goto)
-  );
+  $effect(() => {
+    if (!database.lastItemLoaded) return;
+
+    void goto(
+      resolve(database.lastItemId === undefined ? '/manage' : `/b?id=${database.lastItemId}`)
+    );
+  });
 </script>
 
 <svelte:head>
   <title>{formatPageTitle('Home')}</title>
 </svelte:head>
-
-<div use:observe={autoNavigate$}></div>

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -36,24 +36,12 @@
   import { onDestroy, tick } from 'svelte';
   import Fa from 'svelte-fa';
 
-  const { dataList$, bookmarks$, lastItem$, listLoading$ } = database;
-
   // The unified library view always reads from the local IndexedDB
   // (browser storage). Placeholder books (not-yet-downloaded cloud
   // content) stay in the list with a cloud-icon marker and are
   // downloaded transparently when clicked; see onBookClick below.
-  let bookCards = $derived.by(() => {
-    const dataList = $dataList$;
-    const bookmarks = $bookmarks$;
-    // Svelte's RxJS auto-subscription yields `undefined` before the observables emit. Remove this
-    // guard once the database streams become native Svelte stores/state.
-    if (dataList === undefined || bookmarks === undefined) return [];
-
-    return getBookCards(dataList, bookmarks, $booklistSortOptions$);
-  });
-  let currentBookId = $derived($lastItem$?.dataId);
-  let bookCardsAreLoading = $derived(
-    $dataList$ === undefined || $bookmarks$ === undefined || $listLoading$ === true
+  let bookCards = $derived(
+    getBookCards(database.dataList, database.bookmarks, $booklistSortOptions$)
   );
 
   let selectedBookIds: ReadonlySet<number> = $state(new Set());
@@ -413,11 +401,11 @@
     getDropEventFiles(ev).then(onFilesChange);
   }}
 >
-  {#if bookCardsAreLoading}
+  {#if database.listLoading}
     Loading...
   {:else if bookCards.length}
     <BookCardList
-      {currentBookId}
+      currentBookId={database.lastItemId}
       {selectedBookIds}
       {bookCards}
       onbookClick={({ id }) => onBookClick(id)}

--- a/tests/integration/navigation.spec.ts
+++ b/tests/integration/navigation.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from './helpers/harness.ts';
+import {
+  expectBookReaderText,
+  importBookFixtures,
+  openBookFromManage,
+  PLAIN_TEXT_BOOK
+} from './helpers/fixtures.ts';
+
+test('home route opens the manager when there is no last-opened book', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveURL('/manage');
+});
+
+test('home route and Book tab open the last-opened book', async ({ page }) => {
+  await importBookFixtures(page, [PLAIN_TEXT_BOOK]);
+  await openBookFromManage(page, PLAIN_TEXT_BOOK);
+  await expectBookReaderText(page, PLAIN_TEXT_BOOK);
+
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/b\?id=\d+$/);
+  await expectBookReaderText(page, PLAIN_TEXT_BOOK);
+
+  await page.goto('/settings/reader');
+  await page.getByRole('button', { name: 'Book', exact: true }).click();
+  await expect(page).toHaveURL(/\/b\?id=\d+$/);
+  await expectBookReaderText(page, PLAIN_TEXT_BOOK);
+});


### PR DESCRIPTION
Replaces the database-backed manager/navigation UI streams with rune-backed service state while preserving placeholder hydration freshness and adding navigation coverage.