### PR TITLE
Simplify statistics summary and heatmap layout

### DIFF
--- a/src/lib/components/statistics/statistics-heatmap/statistics-heatmap.svelte
+++ b/src/lib/components/statistics/statistics-heatmap/statistics-heatmap.svelte
@@ -39,7 +39,6 @@
     lastStatisticsStartDate$,
     startDayHoursForTracker$
   } from '$lib/data/store';
-  import { reduceToEmptyString } from '$lib/functions/rxjs/reduce-to-empty-string';
   import {
     advanceDateDays,
     getDate,
@@ -50,7 +49,6 @@
     secondsToMinutes
   } from '$lib/functions/statistic-util';
   import { caluclatePercentage, dummyFn, limitToRange, pluralize } from '$lib/functions/utils';
-  import { debounceTime, fromEvent, tap } from 'rxjs';
   import { onMount, tick, untrack } from 'svelte';
   import { SvelteDate, SvelteMap, SvelteSet } from 'svelte/reactivity';
   import Fa from 'svelte-fa';
@@ -74,18 +72,18 @@
   let today = $derived(getStartHoursDate($startDayHoursForTracker$));
   let todayKey = $derived(getDateString(today));
 
-  const resizeHandler$ = fromEvent(window, 'resize').pipe(
-    debounceTime(250),
-    tap(updateHeatmapDimensions),
-    reduceToEmptyString()
-  );
-
+  const heatmapArrowButtonsWidth = 30;
+  const heatmapColumnsPerYear = 54;
+  const heatmapLabelColumns = 3;
+  const heatmapGridGapsWidth = heatmapGridGapValue * 2 * heatmapColumnsPerYear;
+  const heatmapCellSize = `max(${heatmapDayElementSize}px, calc((100cqw - ${heatmapArrowButtonsWidth}px - ${heatmapGridGapsWidth}px) / ${heatmapColumnsPerYear + heatmapLabelColumns}))`;
+  const heatmapGridTemplateRows =
+    'calc(var(--heatmap-cell-size) + 4px) repeat(7, var(--heatmap-cell-size))';
   const colorRanges: HeatmapColorRange[] = [];
 
   let heatmapElement: HTMLElement = $state()!;
   let heatmapDetailDataPopover: Popover = $state()!;
   let monthLabels: HeatmapMonthLabel[] = $state([...monthLabelList]);
-  let dayElementSize = $state(heatmapDayElementSize);
   let heatmapYear = $state(getStartHoursDate($startDayHoursForTracker$).getFullYear());
   let globalHeatmapData: StatisticsHeatmapData | ReadingGoalsHeatmapData = $state()!;
   const globalHeatmapDayData = new SvelteMap<
@@ -155,8 +153,6 @@
         ...getColorRanges(1, 100, 100)
       );
     }
-
-    updateHeatmapDimensions();
   });
 
   function checkIsStatisticsHeatmapData(
@@ -258,25 +254,6 @@
 
       heatmapElement.scrollTo(middle, 0);
     }
-  }
-
-  function updateHeatmapDimensions() {
-    if (!heatmapElement?.parentElement) {
-      return;
-    }
-
-    const containerWidth = heatmapElement.parentElement.clientWidth;
-    const arrowElementsWidth = 30;
-    const gridGap = heatmapGridGapValue * 2;
-    const gridColumnsPerYear = 54;
-    const gridColumnsWidth = gridColumnsPerYear * gridGap;
-    const dayGridColums = 3;
-    const allGridColumns = gridColumnsPerYear + dayGridColums;
-
-    dayElementSize = Math.max(
-      dayElementSize,
-      Math.ceil((containerWidth - arrowElementsWidth - gridColumnsWidth) / allGridColumns)
-    );
   }
 
   function updateHeatmapDataAfterFilterChange() {
@@ -1097,7 +1074,6 @@
   }
 </script>
 
-{$resizeHandler$ ?? ''}
 <div class="mb-4 flex justify-center">
   {heatmapLabel}
   <button
@@ -1119,7 +1095,7 @@
     <Fa icon={faLayerGroup} />
   </button>
 </div>
-<div class="flex justify-between">
+<div class="flex justify-between" style:container-type="inline-size">
   <button
     title="Move backward"
     class="hover:text-red-500"
@@ -1138,10 +1114,13 @@
     <Fa icon={faChevronLeft} />
   </button>
   <div
+    role="grid"
+    aria-label={heatmapLabel}
     class="grid items-center overflow-x-auto py-1"
-    style:grid-auto-columns={`${dayElementSize}px`}
-    style:grid-auto-rows={`${dayElementSize}px`}
-    style:grid-template-rows={`${dayElementSize + 4}px repeat(7, ${dayElementSize}px)`}
+    style:--heatmap-cell-size={heatmapCellSize}
+    style:grid-auto-columns="var(--heatmap-cell-size)"
+    style:grid-auto-rows="var(--heatmap-cell-size)"
+    style:grid-template-rows={heatmapGridTemplateRows}
     style:gap={`${heatmapGridGapValue}px`}
     style:margin={`0 ${heatmapDayMargins}px`}
     bind:this={heatmapElement}
@@ -1190,8 +1169,8 @@
         class:border-red-500={isToday}
         class:highlight={selectedStreakDates.has(heatmapDay.dateString)}
         style:animation-delay={`${3 * heatmapDay.heatmapColumn}ms`}
-        style:height={`${dayElementSize}px`}
-        style:width={`${dayElementSize}px`}
+        style:height="var(--heatmap-cell-size)"
+        style:width="var(--heatmap-cell-size)"
         style:grid-row={`${heatmapDay.heatmapRow}/${heatmapDay.heatmapRow}`}
         style:grid-column={`${heatmapDay.heatmapColumn}/${heatmapDay.heatmapColumn}`}
         style:background-color={heatmapDay.color || null}

--- a/src/lib/components/statistics/statistics-summary/statistics-summary-header.svelte
+++ b/src/lib/components/statistics/statistics-summary/statistics-summary-header.svelte
@@ -20,7 +20,6 @@
     statisticsSummaryKey: StatisticsSummaryKey;
     options: StatisticsDataSource[];
     selectionKey: keyof BookStatistic;
-    gridRow?: number;
     hasRowInEdit: boolean;
     isHidden?: boolean;
     title?: string;
@@ -31,7 +30,6 @@
     statisticsSummaryKey,
     options,
     selectionKey,
-    gridRow,
     hasRowInEdit,
     isHidden = false,
     title = '',
@@ -39,7 +37,7 @@
   }: Props = $props();
 
   const tableHeaderClasses =
-    'flex items-center py-2.5 px-0 text-sm w-full bg-transparent border-0 md:border-b-2 border-gray-200 appearance-none focus:outline-hidden focus:ring-0 focus:border-gray-200 peer lg:text-base';
+    'flex h-full w-full items-center px-0 py-2.5 text-sm appearance-none border-0 bg-transparent focus:outline-hidden focus:ring-0 peer lg:text-base';
 
   let summaryHeaderPopover = $state<Popover>();
 
@@ -50,13 +48,7 @@
   let selectedOption = $derived(options.find((option) => option.key === selectionKey)!);
 </script>
 
-<div
-  tabindex="0"
-  role="button"
-  class={tableHeaderClasses}
-  class:hidden={isHidden}
-  style:grid-row={gridRow ? `${gridRow}/${gridRow}` : null}
->
+<div tabindex="0" role="button" class={tableHeaderClasses} class:hidden={isHidden}>
   {#if options.length > 1 && !hasRowInEdit}
     <Popover
       placement="bottom-start"

--- a/src/lib/components/statistics/statistics-summary/statistics-summary.svelte
+++ b/src/lib/components/statistics/statistics-summary/statistics-summary.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import {
-    faChevronLeft,
-    faChevronRight,
     faClose,
     faFloppyDisk,
     faPen,
@@ -25,7 +23,6 @@
     dateDataSources,
     titleDataSources
   } from '$lib/components/statistics/statistics-types';
-  import { CLOSE_POPOVER } from '$lib/data/events';
   import { SortDirection } from '$lib/data/sort-types';
   import { japaneseLangIfNeeded } from '$lib/functions/japanese-language';
   import {
@@ -40,9 +37,6 @@
     lastStatisticsSummarySortProperty$
   } from '$lib/data/store';
   import { getNumberFromObject, secondsToMinutes } from '$lib/functions/statistic-util';
-  import { reduceToEmptyString } from '$lib/functions/rxjs/reduce-to-empty-string';
-  import { convertRemToPixels, getFullHeight, limitToRange } from '$lib/functions/utils';
-  import { debounceTime, fromEvent, tap } from 'rxjs';
   import { tick, untrack } from 'svelte';
   import Fa from 'svelte-fa';
 
@@ -58,31 +52,12 @@
   const statisticsSummaryBaseRowRem = 3;
   const statisticsSummaryBaseRowGap = 1.5;
 
-  let renderFullStatisticsSummaryTable = $state(
-    window && window.matchMedia('(min-width: 768px)').matches
-  );
-  let statisticsSummaryTableContainerElm = $state<HTMLElement>();
   let statisticsSummaryPopover = $state<Popover>();
-  let statisticsSummaryButtonContainer = $state<HTMLElement>();
-  let statisticsSummaryGridRowMod = $state(0);
-  let currentStatisticsSummaryPage = $state(1);
-  let rowsPerStatisticsSummaryPage = $state(0);
-  const statisticsSummaryPageRefs: HTMLButtonElement[] = $state([]);
-  let statisticsSummaryPagesContainer = $state<HTMLElement>();
   let statisticsSummaryPopoverDetails: string[] = $state([]);
   let rowInEdit = $state<BookStatistic>();
   let rowInEditTime = $state(0);
   let rowInEditCharacters = $state(0);
   let rowInEditResetMinMaxValues = $state(false);
-
-  const resizeHandler$ = fromEvent(window, 'resize').pipe(
-    debounceTime(250),
-    tap(() => {
-      renderFullStatisticsSummaryTable = window && window.matchMedia('(min-width: 768px)').matches;
-      updateRowsPerPage();
-    }),
-    reduceToEmptyString()
-  );
 
   // Derive sorted data from the raw statistics + sort settings
   let sortedData = $derived.by(() => {
@@ -91,31 +66,11 @@
     return data;
   });
 
-  let statisticsSummaryMaxPages = $derived(
-    rowsPerStatisticsSummaryPage ? Math.ceil(sortedData.length / rowsPerStatisticsSummaryPage) : 0
-  );
-
-  let currentStatisticsSummaryRows = $derived.by(() => {
-    if (!rowsPerStatisticsSummaryPage) return [];
-    const page = limitToRange(1, statisticsSummaryMaxPages || 1, currentStatisticsSummaryPage);
-    const start = (page - 1) * rowsPerStatisticsSummaryPage;
-    return sortedData.slice(start, start + rowsPerStatisticsSummaryPage);
-  });
-
-  let statisticsSummaryPageLabel = $derived(
-    `PAGE ${currentStatisticsSummaryPage} / ${statisticsSummaryMaxPages}`
-  );
-
-  let statisticsSummaryPages = $derived(
-    Array.apply(null, Array(statisticsSummaryMaxPages)).map((_, index) => index + 1)
-  );
-
-  // When new data arrives, reset edit mode and recalculate rows per page
+  // When new data arrives, reset edit mode.
   $effect(() => {
     if (aggregatedStatistics) {
       untrack(() => {
         setRowInEditMode();
-        updateRowsPerPage();
       });
     }
   });
@@ -141,8 +96,6 @@
           $lastReadingTimeDataSource$ = 'readingTime';
           break;
       }
-
-      statisticsSummaryGridRowMod = mode === StatisticsReadingDataAggregationMode.NONE ? 0 : 1;
     });
   });
 
@@ -236,36 +189,6 @@
     $lastStatisticsSummarySortProperty$ = property;
   }
 
-  function updateRowsPerPage() {
-    tick().then(() => {
-      const tableContainer = statisticsSummaryTableContainerElm;
-      const buttonContainer = statisticsSummaryButtonContainer;
-
-      if (renderFullStatisticsSummaryTable) {
-        if (!tableContainer || !buttonContainer) {
-          return;
-        }
-
-        rowsPerStatisticsSummaryPage = Math.max(
-          1,
-          Math.ceil(
-            (getFullHeight(window, tableContainer) - getFullHeight(window, buttonContainer, true)) /
-              convertRemToPixels(
-                window,
-                statisticsSummaryBaseRowRem + statisticsSummaryBaseRowGap + 0.4
-              )
-          )
-        );
-      } else {
-        rowsPerStatisticsSummaryPage = 1;
-      }
-
-      // Clamp page to valid range after rows-per-page changes
-      const maxPages = Math.ceil(sortedData.length / rowsPerStatisticsSummaryPage);
-      currentStatisticsSummaryPage = limitToRange(1, maxPages || 1, currentStatisticsSummaryPage);
-    });
-  }
-
   function sortTable(row1: BookStatistic, row2: BookStatistic) {
     const isTitleSort = $lastStatisticsSummarySortProperty$ === 'title';
     const isDateKeySort = $lastStatisticsSummarySortProperty$ === 'dateKey';
@@ -320,17 +243,17 @@
   }
 </script>
 
-{$resizeHandler$ ?? ''}
 <div class="my-4" class:hidden={!aggregatedStatistics.length}>
   Data for {statisticsDateRangeLabel}
 </div>
 <div
-  class="grow p-2 overflow-auto"
+  role="region"
+  aria-label="Statistics summary"
+  class="p-2"
   class:flex={!sortedData.length}
   class:justify-center={!sortedData.length}
   class:items-center={!sortedData.length}
   class:text-4xl={!sortedData.length}
-  bind:this={statisticsSummaryTableContainerElm}
 >
   {#if sortedData.length}
     {@const isNoneAggregation =
@@ -340,26 +263,19 @@
     {@const isTitleAggregation =
       $lastPrimaryReadingDataAggregationMode$ === StatisticsReadingDataAggregationMode.TITLE}
     <div
-      class="grid grid-cols-[0.75fr_1fr] gap-x-8 items-center"
-      class:md:grid-cols-[0.31fr_0.6fr_0.77fr_0.74fr_0.6fr_0.57fr]={isNoneAggregation}
-      class:lg:grid-cols-[0.14fr_0.26fr_0.85fr_repeat(2,0.59fr)_0.45fr]={isNoneAggregation}
-      class:md:grid-cols-[0.1fr_0.6fr_1fr_1.1fr_0.85fr]={isDateAggregation}
-      class:lg:grid-cols-[0.1fr_repeat(4,1fr)]={isDateAggregation}
-      class:md:grid-cols-[0.1fr_1fr_repeat(3,0.45fr)]={isTitleAggregation}
-      class:lg:grid-cols-[0.1fr_0.93fr_0.35fr_0.42fr_0.3fr]={isTitleAggregation}
+      class="sticky top-12 z-20 grid w-full min-w-232 gap-x-8 items-center border-b-2 border-gray-200 bg-(--background-color)"
+      class:grid-cols-[3rem_8rem_minmax(12rem,1fr)_8rem_8rem_8rem]={isNoneAggregation}
+      class:grid-cols-[3rem_8rem_8rem_8rem_8rem]={isDateAggregation}
+      class:grid-cols-[3rem_minmax(14rem,1fr)_8rem_8rem_8rem]={isTitleAggregation}
       style:grid-auto-rows={`${statisticsSummaryBaseRowRem}rem`}
-      style:row-gap={`${statisticsSummaryBaseRowGap}rem`}
     >
-      {#if renderFullStatisticsSummaryTable}
-        <div></div>
-      {/if}
+      <div></div>
       <StatisticsSummaryHeader
         statisticsSummaryKey={StatisticsSummaryKey.DATE}
         options={dateDataSources}
         selectionKey={StatisticsSummaryKey.DATE}
         hasRowInEdit={rowInEdit !== undefined}
         isHidden={isTitleAggregation}
-        gridRow={renderFullStatisticsSummaryTable ? undefined : 2}
         title="Click to select/sort by this attribute"
         onpropertyChange={handlePropertyChange}
       />
@@ -369,7 +285,6 @@
         selectionKey={StatisticsSummaryKey.TITLE}
         hasRowInEdit={rowInEdit !== undefined}
         isHidden={isDateAggregation}
-        gridRow={renderFullStatisticsSummaryTable ? undefined : 3 - statisticsSummaryGridRowMod}
         title="Click to select/sort by this attribute"
         onpropertyChange={handlePropertyChange}
       />
@@ -378,7 +293,6 @@
         options={readingTimeDataSources}
         selectionKey={$lastReadingTimeDataSource$}
         hasRowInEdit={rowInEdit !== undefined}
-        gridRow={renderFullStatisticsSummaryTable ? undefined : 4 - statisticsSummaryGridRowMod}
         title="Switch between Reading Time Attributes"
         onpropertyChange={handlePropertyChange}
       />
@@ -387,7 +301,6 @@
         options={charactersDataSources}
         selectionKey={$lastCharactersDataSource$}
         hasRowInEdit={rowInEdit !== undefined}
-        gridRow={renderFullStatisticsSummaryTable ? undefined : 5 - statisticsSummaryGridRowMod}
         title="Switch between Character Attributes"
         onpropertyChange={handlePropertyChange}
       />
@@ -396,11 +309,20 @@
         options={readingSpeedDataSources}
         selectionKey={$lastReadingSpeedDataSource$}
         hasRowInEdit={rowInEdit !== undefined}
-        gridRow={renderFullStatisticsSummaryTable ? undefined : 6 - statisticsSummaryGridRowMod}
         title="Switch between Reading Speed Attributes"
         onpropertyChange={handlePropertyChange}
       />
-      {#each currentStatisticsSummaryRows as currentStatisticsSummaryRow (currentStatisticsSummaryRow.id)}
+    </div>
+    <div
+      class="grid w-full min-w-232 gap-x-8 items-center"
+      class:grid-cols-[3rem_8rem_minmax(12rem,1fr)_8rem_8rem_8rem]={isNoneAggregation}
+      class:grid-cols-[3rem_8rem_8rem_8rem_8rem]={isDateAggregation}
+      class:grid-cols-[3rem_minmax(14rem,1fr)_8rem_8rem_8rem]={isTitleAggregation}
+      style:grid-auto-rows={`${statisticsSummaryBaseRowRem}rem`}
+      style:row-gap={`${statisticsSummaryBaseRowGap}rem`}
+      style:margin-top={`${statisticsSummaryBaseRowGap}rem`}
+    >
+      {#each sortedData as currentStatisticsSummaryRow (currentStatisticsSummaryRow.id)}
         {@const currentRowInEdit = rowInEdit && rowInEdit.id === currentStatisticsSummaryRow.id}
         {@const otherRowInEdit = rowInEdit && !currentRowInEdit}
         {@const titleLang = japaneseLangIfNeeded(currentStatisticsSummaryRow.title)}
@@ -557,7 +479,7 @@
     </div>
     {#if statisticsSummaryPopoverDetails.length}
       <Popover
-        placement={renderFullStatisticsSummaryTable ? 'top-start' : 'top'}
+        placement="top-start"
         yOffset={5}
         containerStyles={`align-self:flex-start;display:${isDateAggregation ? 'none' : 'flex'}`}
         bind:this={statisticsSummaryPopover}
@@ -583,72 +505,4 @@
   {:else}
     No Data found for {statisticsDateRangeLabel}
   {/if}
-</div>
-<div
-  class="my-6 flex justify-between"
-  class:invisible={statisticsSummaryMaxPages < 2}
-  bind:this={statisticsSummaryButtonContainer}
->
-  <button
-    disabled={currentStatisticsSummaryPage === 1}
-    class:opacity-25={currentStatisticsSummaryPage === 1}
-    class:cursor-not-allowed={currentStatisticsSummaryPage === 1}
-    onclick={() => {
-      setRowInEditMode();
-      currentStatisticsSummaryPage -= 1;
-    }}
-  >
-    <Fa icon={faChevronLeft} />
-  </button>
-  <Popover
-    yOffset={5}
-    onopen={() => {
-      const currentPageElement = statisticsSummaryPageRefs[currentStatisticsSummaryPage];
-
-      if (!currentPageElement || !statisticsSummaryPagesContainer) {
-        return;
-      }
-
-      const absoluteElementTop = currentPageElement.offsetTop + currentPageElement.clientHeight / 2;
-      const middle = absoluteElementTop - statisticsSummaryPagesContainer.clientHeight / 2;
-
-      statisticsSummaryPagesContainer.scrollTo(0, middle);
-    }}
-  >
-    <div class="mx-6">{statisticsSummaryPageLabel}</div>
-    {#snippet content()}
-      <div
-        class="max-h-32 w-32 p-2 flex flex-col overflow-auto"
-        bind:this={statisticsSummaryPagesContainer}
-      >
-        {#each statisticsSummaryPages as statisticsSummaryPage, pageIndex (statisticsSummaryPage)}
-          <button
-            class="hover:opacity-50 hover:bg-slate-300 hover:text-black"
-            class:bg-slate-300={statisticsSummaryPage === currentStatisticsSummaryPage}
-            class:text-black={statisticsSummaryPage === currentStatisticsSummaryPage}
-            bind:this={statisticsSummaryPageRefs[pageIndex + 1]}
-            onclick={({ target }) => {
-              setRowInEditMode();
-
-              currentStatisticsSummaryPage = statisticsSummaryPage;
-              target?.dispatchEvent(new CustomEvent(CLOSE_POPOVER, { bubbles: true }));
-            }}
-          >
-            {statisticsSummaryPage}
-          </button>
-        {/each}
-      </div>
-    {/snippet}
-  </Popover>
-  <button
-    disabled={currentStatisticsSummaryPage === statisticsSummaryMaxPages}
-    class:opacity-25={currentStatisticsSummaryPage === statisticsSummaryMaxPages}
-    class:cursor-not-allowed={currentStatisticsSummaryPage === statisticsSummaryMaxPages}
-    onclick={() => {
-      setRowInEditMode();
-      currentStatisticsSummaryPage += 1;
-    }}
-  >
-    <Fa icon={faChevronRight} />
-  </button>
 </div>

--- a/src/lib/functions/rxjs/use-observable.ts
+++ b/src/lib/functions/rxjs/use-observable.ts
@@ -1,9 +1,0 @@
-import type { Observable } from 'rxjs';
-
-export function observe<T>(node: Node, obs: Observable<T>) {
-  const subscription = obs.subscribe();
-
-  return {
-    destroy: () => subscription.unsubscribe()
-  };
-}

--- a/src/routes/statistics/+page.svelte
+++ b/src/routes/statistics/+page.svelte
@@ -136,7 +136,7 @@
   onselecttab={navigateToStatisticsTab}
 />
 
-<div class="{pxScreen} flex h-full flex-col pt-16">
+<div class="{pxScreen} flex min-h-full flex-col pt-16">
   {#if controller.isLoading}
     <div class="fixed inset-0 flex size-full items-center justify-center text-7xl">
       <Fa icon={faSpinner} spin />

--- a/tests/integration/statistics/actions.spec.ts
+++ b/tests/integration/statistics/actions.spec.ts
@@ -141,6 +141,98 @@ test('reader statistics navigation preserves the active tab and filters to the c
   await expectSummaryBookHidden(page, VALID_BOOK);
 });
 
+test('statistics summary headers stay sticky while the page scrolls', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 360 });
+  await page.clock.install({ time: new Date(`${LATER_STAT_DATE}T11:59:00Z`) });
+  await enableStatistics(page);
+  await importBookFixtures(page, [VALID_BOOK]);
+
+  for (let day = 1; day <= 6; day += 1) {
+    await recordStatisticForBook(page, VALID_BOOK, `2026-05-${day.toString().padStart(2, '0')}`);
+  }
+
+  await navigateToStatisticsSummary(page);
+  const settings = await openStatisticsSettings(page);
+  await settings.getByRole('button', { name: 'Set to all time for the selected books' }).click();
+  await settings.getByTitle('Close statistics settings').click();
+  await expect(settings).toHaveCount(0, { timeout: SYNC_ASSERTION_TIMEOUT });
+
+  const summary = page.getByRole('region', { name: 'Statistics summary' });
+  await expect
+    .poll(() => page.evaluate(() => document.scrollingElement!.scrollHeight > window.innerHeight), {
+      timeout: SYNC_ASSERTION_TIMEOUT
+    })
+    .toBe(true);
+  await expect
+    .poll(() => summary.evaluate((el) => el.scrollHeight - el.clientHeight), {
+      timeout: SYNC_ASSERTION_TIMEOUT
+    })
+    .toBeLessThanOrEqual(1);
+
+  const readingTimeHeader = summary.getByText('Total Time', { exact: true });
+  const headerTop = await readingTimeHeader.evaluate((el) =>
+    Math.round(el.getBoundingClientRect().top)
+  );
+
+  await page.evaluate(() => window.scrollTo(0, document.scrollingElement!.scrollHeight));
+
+  await expect
+    .poll(() => readingTimeHeader.evaluate((el) => Math.round(el.getBoundingClientRect().top)), {
+      timeout: SYNC_ASSERTION_TIMEOUT
+    })
+    .toBeLessThan(headerTop);
+  await expect
+    .poll(() => readingTimeHeader.evaluate((el) => Math.round(el.getBoundingClientRect().top)), {
+      timeout: SYNC_ASSERTION_TIMEOUT
+    })
+    .toBeGreaterThanOrEqual(48);
+  await expect
+    .poll(() => readingTimeHeader.evaluate((el) => Math.round(el.getBoundingClientRect().top)), {
+      timeout: SYNC_ASSERTION_TIMEOUT
+    })
+    .toBeLessThanOrEqual(72);
+});
+
+test('statistics heatmap expands day cells to fill desktop width', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.clock.install({ time: new Date(`${LATER_STAT_DATE}T11:59:00Z`) });
+  await enableStatistics(page);
+  await importBookFixtures(page, [VALID_BOOK]);
+  await recordStatisticForBook(page, VALID_BOOK, LATER_STAT_DATE);
+
+  await navigateToStatisticsSummary(page);
+  await page.getByRole('button', { name: 'Heatmap', exact: true }).click();
+
+  const heatmap = page.getByRole('grid', { name: 'Reading Data for 2026' });
+  const dayCell = heatmap.getByRole('cell', { name: new RegExp(`^${LATER_STAT_DATE},`) });
+  await expect(dayCell).toBeVisible({ timeout: SYNC_ASSERTION_TIMEOUT });
+
+  const { actualWidth, expectedWidth } = await dayCell.evaluate((el) => {
+    const heatmapGrid = el.closest('[role="grid"]');
+    if (!(heatmapGrid instanceof HTMLElement) || !heatmapGrid.parentElement) {
+      throw new Error('Could not find heatmap container');
+    }
+
+    const containerWidth = heatmapGrid.parentElement.clientWidth;
+    const arrowElementsWidth = 30;
+    const gridGap = 2;
+    const gridColumnsPerYear = 54;
+    const gridColumnsWidth = gridColumnsPerYear * gridGap;
+    const dayGridColumns = 3;
+    const allGridColumns = gridColumnsPerYear + dayGridColumns;
+
+    return {
+      actualWidth: el instanceof HTMLElement ? el.offsetWidth : el.getBoundingClientRect().width,
+      expectedWidth: Math.max(
+        15,
+        (containerWidth - arrowElementsWidth - gridColumnsWidth) / allGridColumns
+      )
+    };
+  });
+
+  expect(actualWidth).toBeGreaterThanOrEqual(expectedWidth - 1);
+});
+
 async function openStatisticsFilter(page: Page) {
   await page.getByRole('button', { name: 'Filter', exact: true }).click();
   const filter = page.locator('dialog.sidebar-overlay[open]').filter({


### PR DESCRIPTION
This removes the statistics resize RxJS paths, moves summary scrolling to the page with a sticky header band, and keeps heatmap sizing CSS-driven.