### PR TITLE
Refresh synced progress for downloaded books

### DIFF
--- a/src/lib/data/database/books-db/versions/v7/books-db-v7.ts
+++ b/src/lib/data/database/books-db/versions/v7/books-db-v7.ts
@@ -45,12 +45,11 @@ interface BooksDbV7BookmarkData {
   completed?: boolean;
   lastBookmarkModified: number;
   /**
-   * Set when the row was seeded by ensurePlaceholders from a sync
-   * source's progress_* filename. The reading position is unknown
-   * (no scrollY / exploredCharCount), so LocalReplicationEndpoint's
-   * up-to-date check treats it as missing and the open-flow pulls
-   * the real bookmark. Cleared on first overwrite by replicator →
-   * saveProgress.
+   * Set when the row was seeded from a sync source's progress_*
+   * filename. The reading position is unknown (no scrollY /
+   * exploredCharCount), so LocalReplicationEndpoint's up-to-date
+   * check treats it as missing and the open-flow pulls the real
+   * bookmark. Cleared on first overwrite by replicator → saveProgress.
    */
   placeholder?: boolean;
 }

--- a/src/lib/data/sync/placeholder-reconciler.ts
+++ b/src/lib/data/sync/placeholder-reconciler.ts
@@ -152,17 +152,16 @@ async function ensurePlaceholders(
         });
         if (coverChanged) touched += 1;
       }
-      // Refresh the placeholder bookmark so /manage's progress /
-      // bookmarked sort reflects what the source advertises. Real
-      // bookmarks (placeholder !== true) represent the user's actual
-      // reading position and are reconciled by the replicator, not
-      // here.
-      if (!existing.elementHtml) {
-        const bookmark = await database.getBookmark(existing.id);
-        if (!bookmark || bookmark.placeholder) {
-          await maybeWritePlaceholderBookmark(existing.id, card, bookmark);
-        }
-      }
+      // Refresh source-advertised bookmark metadata so /manage's
+      // progress / bookmarked sort reflects remote progress before
+      // the user opens the book. The row stays marked as placeholder,
+      // so the book-open path still pulls the full bookmark JSON with
+      // exact reading position.
+      await maybeWritePlaceholderBookmark(
+        existing.id,
+        card,
+        await database.getBookmark(existing.id)
+      );
       continue;
     }
 
@@ -198,23 +197,36 @@ async function maybeWritePlaceholderBookmark(
   card: SyncTitle,
   existing?: BooksDbBookmarkData
 ) {
-  if (!card.lastBookmarkModified && !card.progress && !card.completed) {
+  const progress = card.progress ?? 0;
+  const lastBookmarkModified = card.lastBookmarkModified ?? 0;
+  const completed = !!card.completed;
+  if (!lastBookmarkModified && !progress && !completed) {
     // Source has no progress file for this title — nothing to seed.
     return;
   }
-  if (
-    existing &&
-    existing.progress === (card.progress ?? 0) &&
-    existing.lastBookmarkModified === (card.lastBookmarkModified ?? 0)
-  ) {
-    // Already in sync with what the source advertises.
-    return;
+
+  if (existing) {
+    if (
+      existing.progress === progress &&
+      existing.lastBookmarkModified === lastBookmarkModified &&
+      !!existing.completed === completed
+    ) {
+      // Already in sync with what the source advertises.
+      return;
+    }
+
+    if (!existing.placeholder && existing.lastBookmarkModified >= lastBookmarkModified) {
+      // Real local bookmarks keep their exact reading position unless
+      // the source advertises newer progress.
+      return;
+    }
   }
+
   await database.putBookmark({
     dataId,
-    progress: card.progress ?? 0,
-    lastBookmarkModified: card.lastBookmarkModified ?? 0,
-    completed: !!card.completed,
+    progress,
+    lastBookmarkModified,
+    completed,
     placeholder: true
   });
 }

--- a/tests/integration/fs/boot-reconcile-picks-up-source-changes-after-reload.spec.ts
+++ b/tests/integration/fs/boot-reconcile-picks-up-source-changes-after-reload.spec.ts
@@ -2,16 +2,19 @@ import type { Browser, Page, TestInfo } from '@playwright/test';
 import { copySyncRoot, expect, newPageInTestContext, test } from '../helpers/harness.ts';
 import { loadApp } from '../helpers/navigation.ts';
 import {
+  bookmarkFixturePartway,
   bookProgressBar,
   deleteBookFromManage,
+  expectBookPartwayProgress,
   expectBooksInManage,
   importBookFixtures,
+  type LibraryBookFixture,
   LONG_BOOK,
   openBookFromManage,
   VALID_BOOK
 } from '../helpers/fixtures.ts';
 import { completeCurrentBook } from '../helpers/reader.ts';
-import { connectFS, waitForSyncIdle } from '../helpers/workflows.ts';
+import { connectFS, waitForSuccessfulSync, waitForSyncIdle } from '../helpers/workflows.ts';
 
 test('boot reconcile picks up another context adding, completing, and deleting books after reload', async ({
   browser,
@@ -50,8 +53,46 @@ test('boot reconcile picks up another context adding, completing, and deleting b
   await expectBooksInManage(observer.page, { placeholders: [VALID_BOOK], downloaded: [] });
 });
 
-async function connectedObserver(browser: Browser, testInfo: TestInfo, sourcePage: Page) {
-  await importBookFixtures(sourcePage, [VALID_BOOK]);
+test('boot reconcile refreshes downloaded book progress from another context', async ({
+  browser,
+  page
+}, testInfo) => {
+  await using observer = await connectedObserver(browser, testInfo, page, [VALID_BOOK, LONG_BOOK]);
+  await openBookFromManage(observer.page, LONG_BOOK);
+  await waitForSyncIdle(observer.page);
+  await openBookFromManage(observer.page, VALID_BOOK);
+  await waitForSyncIdle(observer.page);
+  await expectBooksInManage(observer.page, {
+    placeholders: [],
+    downloaded: [VALID_BOOK, LONG_BOOK]
+  });
+
+  await bookmarkFixturePartway(page, LONG_BOOK);
+  await waitForSuccessfulSync(page);
+
+  await openBookFromManage(page, VALID_BOOK);
+  await completeCurrentBook(page);
+  await waitForSuccessfulSync(page);
+
+  await copySyncRoot(page, observer.page);
+  await observer.page.reload();
+  await waitForSyncIdle(observer.page);
+
+  await expectBooksInManage(observer.page, {
+    placeholders: [],
+    downloaded: [VALID_BOOK, LONG_BOOK]
+  });
+  await expectBookPartwayProgress(observer.page, LONG_BOOK);
+  await expect(bookProgressBar(observer.page, VALID_BOOK)).toHaveAttribute('value', '100');
+});
+
+async function connectedObserver(
+  browser: Browser,
+  testInfo: TestInfo,
+  sourcePage: Page,
+  fixtures: readonly LibraryBookFixture[] = [VALID_BOOK]
+) {
+  await importBookFixtures(sourcePage, fixtures);
   await connectFS(sourcePage);
 
   const observer = await newPageInTestContext(browser, testInfo);
@@ -59,7 +100,7 @@ async function connectedObserver(browser: Browser, testInfo: TestInfo, sourcePag
     await loadApp(observer.page);
     await copySyncRoot(sourcePage, observer.page);
     await connectFS(observer.page);
-    await expectBooksInManage(observer.page, { placeholders: [VALID_BOOK], downloaded: [] });
+    await expectBooksInManage(observer.page, { placeholders: fixtures, downloaded: [] });
     return observer;
   } catch (error) {
     await observer[Symbol.asyncDispose]();


### PR DESCRIPTION
Boot reconcile now refreshes downloaded-book progress from the sync source so the manager reflects cross-device progress and completion updates.