### PR TITLE
Remove continuous reader resize RxJS

### DIFF
--- a/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -18,18 +18,6 @@
   import { getReferencePoints } from '$lib/functions/range-util';
   import { getExternalTargetElement } from '$lib/functions/utils';
   import { faBookmark, faSpinner } from '@fortawesome/free-solid-svg-icons';
-  import {
-    animationFrameScheduler,
-    combineLatest,
-    debounceTime,
-    distinctUntilChanged,
-    filter,
-    map,
-    observeOn,
-    skip,
-    Subject,
-    takeUntil
-  } from 'rxjs';
   import { onDestroy, onMount, untrack } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
   import Fa from 'svelte-fa';
@@ -152,12 +140,6 @@
     ? horizontalMouseWheel(4, document.documentElement, requestAnimationFrame)
     : () => 0;
 
-  const width$ = new Subject<number>();
-
-  const height$ = new Subject<number>();
-
-  const destroy$ = new Subject<void>();
-
   const sectionToElement = new SvelteMap<string, HTMLElement>();
 
   const sectionData = new SvelteMap<string, SectionWithProgress>();
@@ -169,6 +151,12 @@
   let stopAutoBookmark: (() => void) | undefined;
 
   let stopSectionProgressTracking: (() => void) | undefined;
+
+  let lastAutoPositionDimension: number | undefined;
+
+  let autoPositionTimer: number | undefined;
+
+  let autoPositionFrame: number | undefined;
 
   let fullLengthDimension = $derived(verticalMode ? 'height' : 'width');
 
@@ -196,15 +184,6 @@
     }
 
     return base;
-  });
-
-  // Push width/height changes to subjects
-  $effect(() => {
-    width$.next(width);
-  });
-
-  $effect(() => {
-    height$.next(height);
   });
 
   // Initialize content when htmlContent changes (or on first mount).
@@ -286,26 +265,27 @@
 
   onMount(() => bookTOCState.onChapterNavigation(scrollToChapter));
 
-  // Resize scroll subscription
-  combineLatest([width$, height$])
-    .pipe(
-      filter(() => autoPositionOnResize),
-      skip(1),
-      map(([w, h]) => (verticalMode ? h : w)),
-      distinctUntilChanged(),
-      debounceTime(10),
-      observeOn(animationFrameScheduler),
-      takeUntil(destroy$)
-    )
-    .subscribe(() => {
-      if (!calculator || !pageManager) return;
+  $effect(() => {
+    const dimension = verticalMode ? height : width;
 
-      const scrollPos =
-        calculator.getScrollPosByCharCount(prevIntendedCharCount) +
-        (verticalMode ? customReadingPointScrollOffset : -customReadingPointScrollOffset);
-      isResizeScroll = true;
-      pageManager.scrollTo(scrollPos);
-    });
+    if (!autoPositionOnResize) {
+      lastAutoPositionDimension = dimension;
+      clearScheduledAutoPosition();
+      return;
+    }
+
+    if (lastAutoPositionDimension === undefined) {
+      lastAutoPositionDimension = dimension;
+      return;
+    }
+
+    if (dimension === lastAutoPositionDimension) {
+      return;
+    }
+
+    lastAutoPositionDimension = dimension;
+    scheduleAutoPositionAfterResize();
+  });
 
   /** Experimental Code - May be removed any time without warning */
   onMount(() => {
@@ -422,9 +402,39 @@
 
     stopAutoBookmark?.();
     stopSectionProgressTracking?.();
-    destroy$.next();
-    destroy$.complete();
+    clearScheduledAutoPosition();
   });
+
+  function scheduleAutoPositionAfterResize() {
+    clearScheduledAutoPosition();
+
+    autoPositionTimer = window.setTimeout(() => {
+      autoPositionTimer = undefined;
+      autoPositionFrame = requestAnimationFrame(() => {
+        autoPositionFrame = undefined;
+        autoPositionAfterResize();
+      });
+    }, 10);
+  }
+
+  function clearScheduledAutoPosition() {
+    window.clearTimeout(autoPositionTimer);
+    if (autoPositionFrame !== undefined) {
+      cancelAnimationFrame(autoPositionFrame);
+      autoPositionFrame = undefined;
+    }
+    autoPositionTimer = undefined;
+  }
+
+  function autoPositionAfterResize() {
+    if (!calculator || !pageManager) return;
+
+    const scrollPos =
+      calculator.getScrollPosByCharCount(prevIntendedCharCount) +
+      (verticalMode ? customReadingPointScrollOffset : -customReadingPointScrollOffset);
+    isResizeScroll = true;
+    pageManager.scrollTo(scrollPos);
+  }
 
   function updateCustomReadingPointPosition() {
     if (!$customReadingPointEnabled$ || !contentEl) {

--- a/tests/integration/helpers/workflows.ts
+++ b/tests/integration/helpers/workflows.ts
@@ -15,6 +15,7 @@ import { expectBooksInSyncRoot, importBookFixtures, type LibraryBookFixture } fr
 interface ReaderSettings {
   autoBookmark?: string;
   autoBookmarkTime?: string;
+  autoPositionOnResize?: string;
   blurImage?: string;
   furigana?: string;
   showFooterChapterCharacters?: string;
@@ -124,6 +125,9 @@ export async function useReaderSettings(page: Page, settings: ReaderSettings) {
   }
   if (settings.autoBookmarkTime) {
     await fillReaderNumberSetting(page, /^Auto Bookmark Time$/i, settings.autoBookmarkTime);
+  }
+  if (settings.autoPositionOnResize) {
+    await selectReaderSetting(page, /^Auto position on resize$/i, settings.autoPositionOnResize);
   }
 }
 

--- a/tests/integration/reader/book-toc-navigation.spec.ts
+++ b/tests/integration/reader/book-toc-navigation.spec.ts
@@ -63,15 +63,38 @@ test('continuous reader updates chapter progress after scrolling', async ({ page
   await expectFooterChapterProgress(page, { charactersRead: 8, percentage: 80.59 });
 });
 
+test('continuous reader preserves chapter progress after resizing', async ({ page }) => {
+  await page.setViewportSize({ width: 1_000, height: 700 });
+  await useProgressReaderSettings(page, {
+    autoPositionOnResize: 'On',
+    viewMode: 'Continuous'
+  });
+  await importBookFixtures(page, [LONG_BOOK]);
+  await openBookFromManage(page, LONG_BOOK);
+  await expectBookReaderText(page, LONG_BOOK);
+
+  await page.mouse.wheel(0, 2_000);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  const progressBeforeResize = await footerChapterProgressText(page);
+  expect(progressBeforeResize).toMatch(/^\d+ \/ \d+ \d+\.\d{2}% C$/);
+  expect(progressBeforeResize).not.toBe(
+    formatChapterProgress({ charactersRead: 0, percentage: 0 })
+  );
+
+  await page.setViewportSize({ width: 700, height: 700 });
+  await expect.poll(() => footerChapterProgressText(page)).toBe(progressBeforeResize);
+});
+
 function chapterRow(page: Page, chapterLabel: string) {
   return page.getByTitle(`Go to ${chapterLabel}`).locator('xpath=..');
 }
 
 async function useProgressReaderSettings(
   page: Page,
-  settings: { tapToFlip?: string; viewMode?: string } = {}
+  settings: { autoPositionOnResize?: string; tapToFlip?: string; viewMode?: string } = {}
 ) {
   await useReaderSettings(page, {
+    autoPositionOnResize: settings.autoPositionOnResize,
     showFooterChapterCharacters: 'On',
     showFooterChapterPercentage: 'On',
     viewMode: settings.viewMode ?? 'Paginated',
@@ -99,14 +122,16 @@ async function expectTOCChapterProgress(page: Page, progress: ChapterProgress) {
 }
 
 async function expectFooterChapterProgress(page: Page, progress: ChapterProgress) {
-  await expect(page.locator('#miwake-page-footer')).toContainText(
-    formatChapterProgress(progress, 'footer')
-  );
+  await expect.poll(() => footerChapterProgressText(page)).toBe(formatChapterProgress(progress));
+}
+
+async function footerChapterProgressText(page: Page) {
+  return page.locator('#miwake-page-footer span').first().innerText();
 }
 
 function formatChapterProgress(
   { charactersRead, percentage }: ChapterProgress,
-  location: 'footer' | 'toc'
+  location: 'footer' | 'toc' = 'footer'
 ) {
   const progress = `${charactersRead} / ${LONG_BOOK_CHAPTER_CHARACTERS}`;
   const percentageText = `${percentage.toFixed(2)}%`;


### PR DESCRIPTION
Replaces the continuous reader resize auto-position stream with native Svelte state and browser timers, and adds a regression covering progress preservation across viewport resizing.