### PR TITLE
test: cover paginated reader max width

### DIFF
--- a/tests/integration/helpers/workflows.ts
+++ b/tests/integration/helpers/workflows.ts
@@ -18,6 +18,7 @@ interface ReaderSettings {
   autoPositionOnResize?: string;
   blurImage?: string;
   furigana?: string;
+  readerMaxWidth?: string;
   showFooterChapterCharacters?: string;
   showFooterChapterPercentage?: string;
   tapToFlip?: string;
@@ -102,6 +103,9 @@ export async function useReaderSettings(page: Page, settings: ReaderSettings) {
   }
   if (settings.blurImage) {
     await selectReaderSetting(page, /Blur image/i, settings.blurImage);
+  }
+  if (settings.readerMaxWidth) {
+    await fillReaderNumberSetting(page, /^Reader Max width$/i, settings.readerMaxWidth);
   }
   if (settings.showFooterChapterCharacters) {
     await selectReaderSetting(

--- a/tests/integration/reader/paginated-reader.spec.ts
+++ b/tests/integration/reader/paginated-reader.spec.ts
@@ -63,9 +63,19 @@ test('paginated reader preserves progress after resizing', async ({ page }) => {
   await expect.poll(() => footerTotalProgressText(page)).toBe(progressBeforeResize);
 });
 
+test('paginated reader applies max width to content', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await usePaginatedReader(page, { readerMaxWidth: '420' });
+  await importBookFixtures(page, [LONG_BOOK]);
+  await openBookFromManage(page, LONG_BOOK);
+  await expectBookReaderText(page, LONG_BOOK);
+
+  await expect.poll(() => bookContentWidth(page)).toBe(420);
+});
+
 async function usePaginatedReader(
   page: Page,
-  settings: { autoBookmark?: string; autoBookmarkTime?: string } = {}
+  settings: { autoBookmark?: string; autoBookmarkTime?: string; readerMaxWidth?: string } = {}
 ) {
   await useReaderSettings(page, {
     ...settings,
@@ -84,4 +94,8 @@ async function expectTotalProgressChangedFromStart(page: Page) {
 
 async function footerTotalProgressText(page: Page) {
   return page.locator('#miwake-page-footer span').nth(1).innerText();
+}
+
+async function bookContentWidth(page: Page) {
+  return page.locator('.book-content').evaluate((el) => el.getBoundingClientRect().width);
 }


### PR DESCRIPTION
Adds integration coverage that sets Reader Max width through the settings UI and verifies paginated reader content honors the configured width.