### PR TITLE
Remove experimental miwake event API

### DIFF
--- a/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -16,7 +16,6 @@
     userFonts$
   } from '$lib/data/store';
   import { getReferencePoints } from '$lib/functions/range-util';
-  import { getExternalTargetElement } from '$lib/functions/utils';
   import { faBookmark, faSpinner } from '@fortawesome/free-solid-svg-icons';
   import { onDestroy, onMount, untrack } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
@@ -68,7 +67,6 @@
     onbookcharcountchange?: (count: number) => void;
     onbookmark?: () => void;
     oncontentchange?: (el: HTMLElement) => void;
-    ontrackerPause?: () => void;
   }
 
   let {
@@ -110,8 +108,7 @@
     readerController,
     onbookcharcountchange,
     onbookmark,
-    oncontentchange,
-    ontrackerPause
+    oncontentchange
   }: Props = $props();
 
   let allowDisplay = $state(false);
@@ -280,10 +277,7 @@
     scheduleAutoPositionAfterResize();
   });
 
-  /** Experimental Code - May be removed any time without warning */
   onMount(() => {
-    document.addEventListener('miwake-action', handleAction, false);
-
     // Register wheel handler with { passive: false } since Svelte 5 doesn't support |nonpassive
     document.body.addEventListener('wheel', onWheel, { passive: false });
 
@@ -296,103 +290,7 @@
     };
   });
 
-  function handleAction({ detail }: any) {
-    if (!detail.type) {
-      return;
-    }
-
-    if (detail.type === 'cue') {
-      const { scroll, rect } = needScroll(detail.selector, detail.scrollMode);
-
-      if (!scroll) {
-        return;
-      }
-
-      willNavigate = true;
-
-      if (verticalMode) {
-        window.scrollBy({
-          left: -(
-            window.innerWidth -
-            rect.right -
-            (firstDimensionMargin || 0) -
-            customReadingPointScrollOffset -
-            (!customReadingPointScrollOffset ||
-            (customReadingPointScrollOffset && scrollAdjustment > customReadingPointScrollOffset)
-              ? scrollAdjustment
-              : 0)
-          ),
-          top: 0,
-          behavior: detail.scrollBehavior || 'instant'
-        });
-      } else {
-        window.scrollBy({
-          left: 0,
-          top:
-            rect.top -
-            (firstDimensionMargin || 0) -
-            customReadingPointScrollOffset -
-            (!customReadingPointScrollOffset ||
-            (customReadingPointScrollOffset && scrollAdjustment > customReadingPointScrollOffset)
-              ? scrollAdjustment
-              : 0),
-          behavior: detail.scrollBehavior || 'instant'
-        });
-      }
-    } else if (
-      detail.type === 'pauseTracker' &&
-      needScroll(detail.selector, detail.scrollMode).scroll
-    ) {
-      ontrackerPause?.();
-    }
-  }
-
-  function needScroll(selector: string, scrollMode: string) {
-    const targetElement = getExternalTargetElement(document, selector, !verticalMode);
-
-    if (!targetElement || !contentEl) {
-      return { scroll: false, rect: { top: 0, right: 0, bottom: 0, left: 0 } };
-    }
-
-    const rect = targetElement.getBoundingClientRect();
-
-    if (!scrollMode || scrollMode === 'Always') {
-      return { scroll: true, rect };
-    }
-
-    const footerElement = verticalMode ? null : document.getElementById('miwake-page-footer');
-    const {
-      elTopReferencePoint,
-      elLeftReferencePoint,
-      elBottomReferencePoint,
-      elRightReferencePoint
-    } = getReferencePoints(
-      window,
-      contentEl,
-      verticalMode,
-      firstDimensionMargin,
-      !verticalMode && footerElement
-        ? Number.parseFloat(getComputedStyle(footerElement).height.replace('px', ''))
-        : 0
-    );
-
-    if (verticalMode) {
-      return {
-        scroll: rect.left <= elLeftReferencePoint || rect.right >= elRightReferencePoint,
-        rect
-      };
-    }
-
-    return {
-      scroll: rect.top <= elTopReferencePoint || rect.bottom >= elBottomReferencePoint,
-      rect
-    };
-  }
-  /** Experimental Code - May be removed any time without warning */
-
   onDestroy(() => {
-    document.removeEventListener('miwake-action', handleAction, false);
-
     stopAutoBookmark?.();
     stopSectionProgressTracking?.();
     clearScheduledAutoPosition();

--- a/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -2,7 +2,6 @@
   import { browser } from '$app/environment';
   import { bookTOCState } from '$lib/components/book-reader/book-toc/book-toc-state.svelte';
   import type { BooksDbBookmarkData } from '$lib/data/database/books-db/versions/books-db';
-  import { SECTION_CHANGE } from '$lib/data/events';
   import { isStoredFont } from '$lib/data/fonts';
   import { FuriganaStyle } from '$lib/data/furigana-style';
   import { logger } from '$lib/data/logger';
@@ -16,7 +15,7 @@
     userFonts$
   } from '$lib/data/store';
   import { clearRange, createRange, pulseElement } from '$lib/functions/range-util';
-  import { getExternalTargetElement, isMobile$ } from '$lib/functions/utils';
+  import { isMobile$ } from '$lib/functions/utils';
   import { faBookmark, faSpinner } from '@fortawesome/free-solid-svg-icons';
   import Fa from 'svelte-fa';
   import { useSwipe, type SwipeCustomEvent } from 'svelte-gestures';
@@ -64,7 +63,6 @@
     onisbookmarkscreenchange?: (value: boolean) => void;
     onbookmark?: () => void;
     oncontentchange?: (el: HTMLElement) => void;
-    ontrackerPause?: () => void;
   }
 
   let {
@@ -104,8 +102,7 @@
     onbookcharcountchange,
     onisbookmarkscreenchange,
     onbookmark,
-    oncontentchange,
-    ontrackerPause
+    oncontentchange
   }: Props = $props();
 
   let scrollEl = $state<HTMLElement>();
@@ -280,106 +277,16 @@
     updateSectionData(customReadingPointRange);
   });
 
-  /** Experimental Code - May be removed any time without warning */
   onMount(() => {
-    document.addEventListener('miwake-action', handleAction, false);
-
     // because Yomitan popup creates overflow on vertical-rl
     document.body.classList.add('overflow-hidden');
 
     return () => {
-      document.removeEventListener('miwake-action', handleAction, false);
       document.body.classList.remove('overflow-hidden');
     };
   });
 
   onMount(() => readerController.registerChapterNavigator(goToChapter));
-
-  async function handleAction({ detail }: any) {
-    if (!detail.type || !calculator || !pageManager) {
-      return;
-    }
-
-    if (detail.type === 'cue') {
-      const targetSection = getTargetSection(detail.selector);
-
-      if (targetSection === -1) {
-        return;
-      }
-
-      const currentSection = readerState.sectionIndex;
-      let updatedCalculator = calculator;
-
-      if (currentSection !== targetSection) {
-        updatedCalculator = await setSectionIndexAndWait(targetSection);
-        pageManager?.scrollTo(0, false);
-      }
-
-      const updatedPageManager = pageManager;
-      if (!updatedCalculator || !updatedPageManager) return;
-
-      const scrollPos = getTargetScrollPos(updatedCalculator, detail.selector);
-
-      if (scrollPos < 0) {
-        return;
-      }
-
-      updatedPageManager.scrollTo(scrollPos, true);
-
-      if (currentSection !== targetSection) {
-        document.dispatchEvent(new CustomEvent(SECTION_CHANGE));
-      }
-    } else if (detail.type === 'pauseTracker') {
-      const targetSection = getTargetSection(detail.selector);
-
-      if (targetSection === -1) {
-        return;
-      }
-
-      if (targetSection !== readerState.sectionIndex) {
-        ontrackerPause?.();
-        return;
-      }
-
-      const scrollPos = getTargetScrollPos(calculator, detail.selector);
-
-      if (scrollPos < 0) {
-        return;
-      }
-
-      const currentScrollPos = calculator.getScrollPosByCharCount(
-        calculator.calcExploredCharCount(customReadingPointRange)
-      );
-
-      if (scrollPos !== currentScrollPos) {
-        ontrackerPause?.();
-      }
-    }
-  }
-
-  function getTargetSection(selector: string) {
-    return sections.findIndex((section) => getExternalTargetElement(section, selector));
-  }
-
-  function getTargetScrollPos(
-    calculatorInstance: SectionCharacterStatsCalculator,
-    selector: string
-  ) {
-    const targetElement = getExternalTargetElement(document, selector);
-
-    if (!targetElement) {
-      return -1;
-    }
-
-    const nodeRange = document.createRange();
-    nodeRange.setStart(targetElement, 0);
-    nodeRange.setEnd(targetElement, targetElement.childNodes.length);
-
-    return calculatorInstance.getScrollPosByCharCount(
-      calculatorInstance.calcExploredCharCount(nodeRange)
-    );
-  }
-  /** Experimental Code - May be removed or changed any time without warning */
 
   let hasMeasuredSize = false;
   $effect(() => {

--- a/src/lib/components/book-reader/book-reader.svelte
+++ b/src/lib/components/book-reader/book-reader.svelte
@@ -65,7 +65,6 @@
     onbookcharcountchange?: (count: number) => void;
     onisbookmarkscreenchange?: (value: boolean) => void;
     onbookmark?: () => void;
-    ontrackerPause?: () => void;
   }
 
   let {
@@ -111,8 +110,7 @@
     onhideCustomReadingPoint,
     onbookcharcountchange,
     onisbookmarkscreenchange,
-    onbookmark,
-    ontrackerPause
+    onbookmark
   }: Props = $props();
 
   let showBlurMessage = $state(false);
@@ -334,7 +332,6 @@
       {onbookcharcountchange}
       oncontentchange={handleContentChange}
       {onbookmark}
-      {ontrackerPause}
     />
   {:else}
     <BookReaderPaginated
@@ -375,7 +372,6 @@
       {onisbookmarkscreenchange}
       oncontentchange={handleContentChange}
       {onbookmark}
-      {ontrackerPause}
     />
   {/if}
 </div>

--- a/src/lib/components/popover/popover.svelte
+++ b/src/lib/components/popover/popover.svelte
@@ -2,7 +2,6 @@
   import type { Snippet } from 'svelte';
   import { browser } from '$app/environment';
   import { popovers } from '$lib/components/popover/popover';
-  import { CLOSE_POPOVER } from '$lib/data/events';
   import { clickOutside } from '$lib/functions/use-click-outside';
   import type { Instance, Placement } from '@popperjs/core';
   import flip from '@popperjs/core/lib/modifiers/flip';
@@ -159,16 +158,6 @@
     };
   }
 
-  function externalClose(node: HTMLElement) {
-    node.addEventListener(CLOSE_POPOVER, toggleOpen, false);
-
-    return {
-      destroy() {
-        node.removeEventListener(CLOSE_POPOVER, toggleOpen, false);
-      }
-    };
-  }
-
   function getTargetElement(referenceElement?: HTMLElement | Event): HTMLElement | undefined {
     let targetElement: HTMLElement | undefined;
 
@@ -206,7 +195,6 @@
   >
     <div
       style={contentStyles}
-      use:externalClose
       use:clickOutside={({ target }) => {
         if (!(target instanceof Element && target.closest('[data-popover]'))) {
           toggleOpen();

--- a/src/lib/data/events.ts
+++ b/src/lib/data/events.ts
@@ -1,13 +1,2 @@
-/** Experimental Code - May be removed any time without warning */
-export const SKIPKEYLISTENER = 'miwake:skipKeyListener';
-
-export const SYNCED = 'miwake:synced';
-
-export const DB_VERSION = 'miwake:db.version';
-
-export const SECTION_CHANGE = 'miwake:section.change';
-/** Experimental Code - May be removed any time without warning */
-
+// TODO: Replace this document-level event bus with reader state callbacks or a Svelte store.
 export const PAGE_CHANGE = 'miwake:page.change';
-
-export const CLOSE_POPOVER = 'miwake:close:popover';

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -81,12 +81,11 @@
   import SidebarOverlay from '$lib/components/sidebar-overlay.svelte';
   import { getBookStatisticsURL } from '$lib/components/statistics/statistics-view';
   import {
-    currentDbVersion,
     type BooksDbBookData,
     type BooksDbBookmarkData,
     type BooksDbStatistic
   } from '$lib/data/database/books-db/versions/books-db';
-  import { DB_VERSION, PAGE_CHANGE, SKIPKEYLISTENER, SYNCED } from '$lib/data/events';
+  import { PAGE_CHANGE } from '$lib/data/events';
   import { fullscreenManager } from '$lib/data/fullscreen-manager';
   import { logger } from '$lib/data/logger';
   import { showConfirmDialog } from '$lib/components/confirm-dialog.svelte';
@@ -117,7 +116,7 @@
   import { clickOutside } from '$lib/functions/use-click-outside';
   import { convertRemToPixels, dummyFn, isMobile$, limitToRange } from '$lib/functions/utils';
   import { onKeydownReader } from './on-keydown-reader';
-  import { onDestroy, onMount, tick, untrack } from 'svelte';
+  import { onDestroy, tick, untrack } from 'svelte';
   import Fa from 'svelte-fa';
   import {
     clearRange,
@@ -163,15 +162,11 @@
   let showReaderImageGallery = $state(false);
   let wasTOCOpen = $state(false);
   let wasTrackerMenuOpen = $state(false);
-  let syncedResolver: () => void;
   let lastReaderStatisticsSyncAt = 0;
   let readerStatisticsSyncDirty = false;
 
   const readerController = new BookReaderController();
 
-  const syncedPromise = new Promise<void>((resolver) => {
-    syncedResolver = resolver;
-  });
   let fontFeatureSettings = $derived(
     [$enableVerticalFontKerning$ && '"vkrn"', $enableFontVPAL$ && '"vpal"']
       .filter((f) => !!f && $verticalMode$)
@@ -248,11 +243,10 @@
     } finally {
       if (!signal.aborted) {
         logger.debug(
-          `reader/rawBookData: finally — syncedResolver, showSpinner=false, returning ${
+          `reader/rawBookData: finally — showSpinner=false, returning ${
             loadedBook ? `hasHtml=${!!loadedBook.elementHtml}` : 'undefined'
           }`
         );
-        syncedResolver();
         showSpinner = false;
       }
     }
@@ -509,31 +503,6 @@
     });
   });
 
-  $effect(() => {
-    if (browser) {
-      document.dispatchEvent(new CustomEvent(SKIPKEYLISTENER, { detail: $skipKeyDownListener$ }));
-    }
-  });
-
-  /** Experimental Code - May be removed any time without warning */
-  onMount(() => {
-    document.addEventListener('miwake-action', handleAction, false);
-    return () => document.removeEventListener('miwake-action', handleAction, false);
-  });
-
-  function handleAction({ detail }: any) {
-    if (!detail.type) {
-      return;
-    }
-
-    if (detail.type === 'dbVersion') {
-      document.dispatchEvent(new CustomEvent(DB_VERSION, { detail: currentDbVersion }));
-    } else if (detail.type === 'waitForSync') {
-      syncedPromise.finally(() => document.dispatchEvent(new CustomEvent(SYNCED)));
-    } else if (detail.type === 'skipKeyDownListener') {
-      skipKeyDownListener$.next(detail.params.value);
-    }
-  }
   onDestroy(() => {
     flushReaderStatisticsReplication();
     readerImageGallery.clear();
@@ -1380,7 +1349,6 @@
     onbookcharcountchange={(count) => (bookCharCount = count)}
     onisbookmarkscreenchange={(value) => (isBookmarkScreen = value)}
     onbookmark={bookmarkPage}
-    ontrackerPause={() => pauseTracker('jump', true)}
   />
 {/if}
 


### PR DESCRIPTION
Removes the unused experimental `miwake-action` bridge and related miwake event constants/listeners, leaving only `PAGE_CHANGE` with a TODO because it is still used as an internal document-level bus.