### PR TITLE
fix: preserve EPUB image proportions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _Note: the refreshed interface, especially the top bars, has not yet been adapte
 
 ### Book content presentation fixes
 
-- Inline images (fractions, symbols, decorative glyphs) are no longer broken out of text flow, or included in the image gallery.
+- Images preserve both their role and proportions: inline fractions, symbols, and decorative glyphs stay in text flow and out of the image gallery, while oversized illustrations fit within the viewport without distortion.
 - The "after table of contents" spoiler mode no longer hides cover pages in books with no table of contents.
 - Section-break margins in EPUBs are now preserved correctly in vertical writing mode.
 - Furigana on the rightmost line of text is no longer clipped in vertical paginated mode.

--- a/scripts/generate-test-fixtures.mjs
+++ b/scripts/generate-test-fixtures.mjs
@@ -127,6 +127,37 @@ await writeOut(
 );
 
 await writeOut(
+  'media-sizing-book.epub',
+  await buildEPUB({
+    title: 'Media sizing book',
+    author: 'Test Author',
+    identifier: 'urn:uuid:00000000-0000-4000-8000-000000000005',
+    language: 'en',
+    images: {
+      'images/portrait-illustration.bmp': bitmapBytes({ red: 45, green: 95, blue: 210 }, 87, 128),
+      'images/inline-glyph.bmp': bitmapBytes({ red: 65, green: 165, blue: 80 }, 16, 16)
+    },
+    chapters: [
+      {
+        title: 'Oversized media',
+        bodyHTML: `
+  <p>
+    This chapter exercises oversized media and an inline glyph
+    <img src="images/inline-glyph.bmp" alt="Inline glyph" style="width: 1em; height: 1em" />.
+  </p>
+  <figure>
+    <img
+      src="images/portrait-illustration.bmp"
+      alt="Oversized portrait illustration"
+      style="width: 43.5em; height: 64em"
+    />
+  </figure>`
+      }
+    ]
+  })
+);
+
+await writeOut(
   'plain-text-book.txt',
   enc.encode(`This plain text fixture gives the library another real imported book.
 

--- a/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -165,6 +165,14 @@
     verticalMode && secondDimensionMaxValue ? secondDimensionMaxValue : undefined
   );
 
+  let imageMaxWidth = $derived(
+    !verticalMode && secondDimensionMaxValue ? Math.min(width, secondDimensionMaxValue) : width
+  );
+
+  let imageMaxHeight = $derived(
+    verticalMode && secondDimensionMaxValue ? Math.min(height, secondDimensionMaxValue) : height
+  );
+
   let bookmarkAdjustment = $derived.by(() => {
     const base = compactViewport.current ? '0.25rem' : '0.5rem';
 
@@ -659,6 +667,8 @@
   style:--book-content-hint-furigana-font-color={hintFuriganaFontColor}
   style:--book-content-hint-furigana-shadow-color={hintFuriganaShadowColor}
   style:--book-content-child-height="{maxHeight || height}px"
+  style:--book-content-image-max-width="{imageMaxWidth}px"
+  style:--book-content-image-max-height="{imageMaxHeight}px"
   style:--book-content-text-margin="{textMarginValue ?? 0}rem"
   style:--book-content-text-intendation="{textIndentation ?? 0}rem"
   style:font-feature-settings={fontFeatureSettings}
@@ -744,7 +754,9 @@
   .book-content {
     :global(svg),
     :global(img) {
-      max-height: 100vh;
+      max-width: var(--book-content-image-max-width, 100vw);
+      max-height: var(--book-content-image-max-height, 100vh);
+      object-fit: contain;
     }
   }
 
@@ -752,10 +764,6 @@
     height: 100%;
     > :global(*) {
       margin-left: 6rem;
-    }
-
-    :global(img) {
-      max-height: var(--book-content-child-height, 100%);
     }
   }
 

--- a/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -711,6 +711,7 @@
     :global(img) {
       max-width: var(--book-content-image-max-width, 100vw);
       max-height: var(--book-content-child-height, 100vh);
+      object-fit: contain;
     }
 
     &.book-content--avoid-page-break {

--- a/tests/integration/helpers/fixtures.ts
+++ b/tests/integration/helpers/fixtures.ts
@@ -17,6 +17,7 @@ const NOT_AN_EPUB_BOOK = 'not-an-epub-book';
 export const COVER_REFRESH_BOOK = 'cover-refresh-book';
 export const LONG_BOOK = 'long-book';
 export const LONG_BOOK_CHAPTER_CHARACTERS = 7519;
+export const MEDIA_SIZING_BOOK = 'media-sizing-book';
 export const PLAIN_TEXT_BOOK = 'plain-text-book';
 export const SPOILER_IMAGE_GALLERY_BOOK = 'spoiler-image-gallery-book';
 export const VALID_BOOK = 'valid-book';
@@ -26,6 +27,7 @@ export type LibraryBookFixture =
   | typeof COVER_REFRESH_BOOK
   | typeof VALID_BOOK
   | typeof LONG_BOOK
+  | typeof MEDIA_SIZING_BOOK
   | typeof SPOILER_IMAGE_GALLERY_BOOK
   | typeof PLAIN_TEXT_BOOK;
 export type InvalidImportBookFixture = typeof NOT_A_ZIP_BOOK | typeof NOT_AN_EPUB_BOOK;
@@ -104,6 +106,14 @@ const fixtureMetadata = new Map<BookFixture, BookFixtureMetadata>([
         minimumFooterPage: 1_000,
         progressValue: '38'
       }
+    }
+  ],
+  [
+    MEDIA_SIZING_BOOK,
+    {
+      title: 'Media sizing book',
+      path: resolve(fixtureRoot, 'media-sizing-book.epub'),
+      readerText: 'This chapter exercises oversized media and an inline glyph'
     }
   ],
   [

--- a/tests/integration/reader/book-reader-sizing.spec.ts
+++ b/tests/integration/reader/book-reader-sizing.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test } from '../helpers/harness.ts';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import {
   expectBookReaderText,
   importBookFixtures,
   LONG_BOOK,
+  MEDIA_SIZING_BOOK,
   openBookFromManage
 } from '../helpers/fixtures.ts';
 import { useReaderSettings } from '../helpers/workflows.ts';
@@ -21,6 +22,45 @@ test('paginated reader content width follows viewport and reader padding', async
   await expectBookContentWidth(page, 668);
 });
 
+for (const viewMode of ['Continuous', 'Paginated']) {
+  for (const writingMode of ['Horizontal', 'Vertical']) {
+    test(`${viewMode.toLowerCase()} ${writingMode.toLowerCase()} reader contains oversized media without resizing inline glyphs`, async ({
+      page
+    }) => {
+      await page.setViewportSize({ width: 1_000, height: 700 });
+      await useReaderSettings(page, {
+        fontSize: '20',
+        theme: 'light-theme',
+        viewMode,
+        writingMode
+      });
+      await importBookFixtures(page, [MEDIA_SIZING_BOOK]);
+      await openBookFromManage(page, MEDIA_SIZING_BOOK);
+      await expectBookReaderText(page, MEDIA_SIZING_BOOK);
+
+      const illustration = page.getByAltText('Oversized portrait illustration');
+      await expect(illustration).toHaveCSS('object-fit', 'contain');
+      await expect
+        .poll(() => mediaDimensions(illustration))
+        .toMatchObject({ complete: true, naturalHeight: 128, naturalWidth: 87 });
+
+      const illustrationDimensions = await mediaDimensions(illustration);
+      expect(illustrationDimensions.width).toBeLessThanOrEqual(1_000);
+      expect(illustrationDimensions.height).toBeLessThanOrEqual(700);
+
+      await expect
+        .poll(() => mediaDimensions(page.getByAltText('Inline glyph')))
+        .toMatchObject({
+          complete: true,
+          height: 20,
+          naturalHeight: 16,
+          naturalWidth: 16,
+          width: 20
+        });
+    });
+  }
+}
+
 async function expectBookContentWidth(page: Page, width: number) {
   await expect
     .poll(async () => {
@@ -28,4 +68,18 @@ async function expectBookContentWidth(page: Page, width: number) {
       return Math.round(boundingBox?.width ?? 0);
     })
     .toBe(width);
+}
+
+function mediaDimensions(locator: Locator) {
+  return locator.evaluate((element) => {
+    const image = element as HTMLImageElement;
+    const bounds = image.getBoundingClientRect();
+    return {
+      complete: image.complete,
+      height: bounds.height,
+      naturalHeight: image.naturalHeight,
+      naturalWidth: image.naturalWidth,
+      width: bounds.width
+    };
+  });
 }


### PR DESCRIPTION
Preserves EPUB image proportions across continuous and paginated readers while retaining authored inline-image sizing, with regression coverage for horizontal and vertical writing modes.
