### PR TITLE
Redesign the library view

### DIFF
--- a/src/lib/components/book-card/book-card-actions.svelte
+++ b/src/lib/components/book-card/book-card-actions.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import {
+    faBookOpen,
+    faCalendarXmark,
+    faChartLine,
+    faCircleInfo,
+    faDownload,
+    faFlag,
+    faTrash
+  } from '@fortawesome/free-solid-svg-icons';
+  import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+  import type { BookCardProps } from '$lib/components/book-card/book-card-props';
+  import Popover from '$lib/components/popover/popover.svelte';
+  import { getDateTimeString } from '$lib/functions/statistic-util';
+  import Fa from 'svelte-fa';
+
+  interface Props {
+    bookCard: BookCardProps;
+    onread?: (data: { id: number }) => void | Promise<void>;
+    onstatistics?: (data: { id: number }) => void | Promise<void>;
+    ondownload?: (data: { id: number }) => void | Promise<void>;
+    oncomplete?: (data: { id: number; completed: boolean }) => void | Promise<void>;
+    ondeletestatistics?: (data: { id: number }) => void | Promise<void>;
+    onremove?: (data: { id: number }) => void | Promise<void>;
+  }
+
+  let {
+    bookCard,
+    onread,
+    onstatistics,
+    ondownload,
+    oncomplete,
+    ondeletestatistics,
+    onremove
+  }: Props = $props();
+
+  let detailsPopover = $state<Popover>();
+  let morePopover = $state<Popover>();
+
+  const actionButtonClasses =
+    'flex h-8 min-w-0 items-center justify-center gap-1.5 rounded-sm border border-gray-400/40 px-2 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-400/10 hover:text-gray-900';
+  const menuButtonClasses =
+    'flex w-full items-center gap-3 px-4 py-2 text-left text-sm font-normal whitespace-nowrap hover:bg-white hover:text-gray-700';
+
+  function getCardDateInfo(dateTime: number) {
+    return dateTime ? getDateTimeString(dateTime, { includeSeconds: false }) : 'No Data';
+  }
+
+  let detailRows = $derived([
+    {
+      label: 'Characters',
+      value: bookCard.characters ? bookCard.characters.toLocaleString() : 'No Data'
+    },
+    { label: 'Last read', value: getCardDateInfo(bookCard.lastBookOpen) },
+    { label: 'Bookmarked', value: getCardDateInfo(bookCard.lastBookmarkModified) },
+    { label: 'Last update', value: getCardDateInfo(bookCard.lastBookModified) }
+  ]);
+
+  async function runMenuAction(action?: () => void | Promise<void>) {
+    await morePopover?.toggleOpen();
+    await action?.();
+  }
+</script>
+
+{#snippet cardAction(
+  icon: IconDefinition,
+  label: string,
+  ariaLabel: string,
+  action?: () => void | Promise<void>,
+  fullWidth = false
+)}
+  <button
+    type="button"
+    class={`${actionButtonClasses} ${fullWidth ? 'w-full' : ''}`}
+    aria-label={ariaLabel}
+    onclick={() => action?.()}
+  >
+    <Fa {icon} />
+    <span>{label}</span>
+  </button>
+{/snippet}
+
+{#snippet menuAction(
+  icon: IconDefinition,
+  label: string,
+  action: () => void | Promise<void>,
+  danger = false
+)}
+  <button
+    type="button"
+    class={`${menuButtonClasses} ${danger ? 'text-red-300 hover:text-red-700' : ''}`}
+    onclick={() => runMenuAction(action)}
+  >
+    <Fa {icon} />
+    <span>{label}</span>
+  </button>
+{/snippet}
+
+<div class="mt-2.5 grid grid-cols-[1fr_1fr_auto] gap-1">
+  {@render cardAction(faChartLine, 'Stats', `View statistics for ${bookCard.title}`, () =>
+    onstatistics?.({ id: bookCard.id })
+  )}
+
+  {#if bookCard.isPlaceholder}
+    {@render cardAction(faDownload, 'Download', `Download ${bookCard.title}`, () =>
+      ondownload?.({ id: bookCard.id })
+    )}
+  {:else}
+    <Popover
+      bind:this={detailsPopover}
+      placement="top"
+      fallbackPlacements={['right', 'left', 'bottom']}
+      yOffset={5}
+    >
+      {#snippet icon()}
+        {@render cardAction(
+          faCircleInfo,
+          'Details',
+          `Details for ${bookCard.title}`,
+          undefined,
+          true
+        )}
+      {/snippet}
+      {#snippet content()}
+        <div class="w-80 max-w-[calc(100vw-2rem)] p-4 font-normal">
+          <div class="wrap-break-word font-medium">{bookCard.title}</div>
+          <dl class="mt-3 grid gap-2 text-xs">
+            {#each detailRows as row (row.label)}
+              <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-4">
+                <dt class="text-gray-300">{row.label}</dt>
+                <dd class="text-right whitespace-nowrap">{row.value}</dd>
+              </div>
+            {/each}
+          </dl>
+        </div>
+      {/snippet}
+    </Popover>
+  {/if}
+
+  <Popover
+    bind:this={morePopover}
+    placement="bottom-end"
+    fallbackPlacements={['bottom', 'left', 'top-end']}
+    yOffset={5}
+  >
+    {#snippet icon()}
+      <button
+        type="button"
+        class={`${actionButtonClasses} min-w-8 px-1.5 tracking-wider`}
+        aria-label={`More actions for ${bookCard.title}`}>•••</button
+      >
+    {/snippet}
+    {#snippet content()}
+      <div class="inline-flex min-w-56 flex-col py-2">
+        <div class="max-w-72 truncate px-4 pb-2 text-xs font-medium">{bookCard.title}</div>
+        {@render menuAction(faBookOpen, 'Read book', () => onread?.({ id: bookCard.id }))}
+        {@render menuAction(faChartLine, 'View statistics', () =>
+          onstatistics?.({ id: bookCard.id })
+        )}
+        {@render menuAction(
+          faFlag,
+          bookCard.completed ? 'Mark as in progress' : 'Mark as complete',
+          () => oncomplete?.({ id: bookCard.id, completed: !bookCard.completed })
+        )}
+        {#if !bookCard.isPlaceholder}
+          {@render menuAction(faCircleInfo, 'Book details', () => detailsPopover?.toggleOpen())}
+        {/if}
+
+        {#if bookCard.isPlaceholder}
+          <hr class="mx-4 my-1 border-white/20" />
+          {@render menuAction(faDownload, 'Download to this device', () =>
+            ondownload?.({ id: bookCard.id })
+          )}
+        {/if}
+
+        <hr class="mx-4 my-1 border-white/20" />
+        {@render menuAction(faCalendarXmark, 'Delete statistics', () =>
+          ondeletestatistics?.({ id: bookCard.id })
+        )}
+        {@render menuAction(
+          faTrash,
+          'Remove from library',
+          () => onremove?.({ id: bookCard.id }),
+          true
+        )}
+      </div>
+    {/snippet}
+  </Popover>
+</div>

--- a/src/lib/components/book-card/book-card-list.svelte
+++ b/src/lib/components/book-card/book-card-list.svelte
@@ -1,135 +1,65 @@
 <script lang="ts">
-  import {
-    faCheckCircle,
-    faCircleInfo,
-    faCloudArrowDown,
-    faFolderOpen
-  } from '@fortawesome/free-solid-svg-icons';
-  import BookCard from '$lib/components/book-card/book-card.svelte';
+  import BookCardActions from '$lib/components/book-card/book-card-actions.svelte';
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
-  import Popover from '$lib/components/popover/popover.svelte';
+  import BookCard from '$lib/components/book-card/book-card.svelte';
   import { syncState } from '$lib/data/sync/sync-store.svelte';
-  import { dummyFn } from '$lib/functions/utils';
-  import Fa from 'svelte-fa';
 
   interface Props {
     bookCards?: BookCardProps[];
     currentBookId?: number | undefined;
     selectedBookIds: ReadonlySet<number>;
-    onbookClick?: (data: { id: number }) => void;
-    onremoveBookClick?: (data: { id: number }) => void;
+    selectMode?: boolean;
+    onbookClick?: (data: { id: number }) => void | Promise<void>;
+    onreadBookClick?: (data: { id: number }) => void | Promise<void>;
+    onstatisticsClick?: (data: { id: number }) => void | Promise<void>;
+    ondownloadBookClick?: (data: { id: number }) => void | Promise<void>;
+    oncompleteBookClick?: (data: { id: number; completed: boolean }) => void | Promise<void>;
+    ondeleteStatisticsClick?: (data: { id: number }) => void | Promise<void>;
+    onremoveBookClick?: (data: { id: number }) => void | Promise<void>;
   }
 
   let {
     bookCards = [],
     currentBookId,
     selectedBookIds,
+    selectMode = false,
     onbookClick,
+    onreadBookClick,
+    onstatisticsClick,
+    ondownloadBookClick,
+    oncompleteBookClick,
+    ondeleteStatisticsClick,
     onremoveBookClick
   }: Props = $props();
 
-  let placeholderIcon = $derived(
-    syncState.location?.kind === 'fs' ? faFolderOpen : faCloudArrowDown
-  );
   let placeholderTooltip = $derived(
     syncState.location?.kind === 'fs'
-      ? 'Not downloaded yet — click the book to copy it from your local sync folder'
-      : 'Not downloaded yet — click the book to fetch it from its sync location'
+      ? 'Not downloaded yet — open or download the book to copy it from your local sync folder'
+      : 'Not downloaded yet — open or download the book to fetch it from its sync location'
   );
-
-  let hoveringBookId = $state<number>();
-
-  function onBookCardClick(id: number) {
-    onbookClick?.({ id });
-  }
-
-  function getCardDateInfo(dateTime: number) {
-    return dateTime ? new Date(dateTime).toLocaleString() : 'No Data';
-  }
 </script>
 
-<div class="grid grid-cols-3 justify-between gap-5 pb-4 md:grid-cols-4 lg:grid-cols-5">
+<div class="grid grid-cols-2 gap-x-5 gap-y-9 pb-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
   {#each bookCards as bookCard (bookCard.id)}
-    <div
-      role="banner"
-      class="relative"
-      class:opacity-60={bookCard.isPlaceholder}
-      onmouseenter={() => (hoveringBookId = bookCard.id)}
-      onmouseleave={() => (hoveringBookId = undefined)}
-    >
-      <div
-        class="mdc-elevation--z1 hover:mdc-elevation--z8 mdc-elevation-transition relative overflow-hidden"
-        class:rounded-tl-xl={bookCard.id === currentBookId}
-        class:mdc-elevation--z4={selectedBookIds.has(bookCard.id) || bookCard.id === currentBookId}
-      >
-        <BookCard
-          {...bookCard}
-          tooltip={bookCard.isPlaceholder ? placeholderTooltip : undefined}
-          onclick={() => onBookCardClick(bookCard.id)}
-        />
+    <article class="relative min-w-0">
+      <BookCard
+        {...bookCard}
+        current={bookCard.id === currentBookId}
+        selected={selectedBookIds.has(bookCard.id)}
+        selectionMode={selectMode}
+        tooltip={bookCard.isPlaceholder ? placeholderTooltip : undefined}
+        onclick={() => onbookClick?.({ id: bookCard.id })}
+      />
 
-        {#if bookCard.isPlaceholder}
-          <div
-            aria-hidden="true"
-            class="pointer-events-none absolute top-2 right-2 flex size-7 items-center justify-center rounded-full bg-white/90 text-gray-700 shadow"
-          >
-            <Fa icon={placeholderIcon} />
-          </div>
-        {/if}
-
-        {#if selectedBookIds.has(bookCard.id)}
-          <div
-            tabindex="0"
-            role="button"
-            title="Book selected"
-            class="absolute inset-0 bg-gray-700/20"
-            onclick={() => onBookCardClick(bookCard.id)}
-            onkeyup={dummyFn}
-          >
-            <Fa class="absolute left-2 top-2 flex text-xl text-white" icon={faCheckCircle} />
-          </div>
-        {/if}
-      </div>
-      {#if selectedBookIds.has(bookCard.id)}
-        <div class="absolute top-10 left-2" title="Click to open details">
-          <Popover placement="right" fallbackPlacements={['bottom']} yOffset={5}>
-            {#snippet icon()}
-              <Fa
-                class="mdc-elevation--z2 hover:mdc-elevation--z8 mdc-elevation-transition left-2 top-10 rounded-full bg-blue-400 text-xl text-white"
-                icon={faCircleInfo}
-              />
-            {/snippet}
-            {#snippet content()}
-              <div class="p-4">
-                <div>Characters:</div>
-                <div class="w-40">{bookCard.characters || 'No Data'}</div>
-                <div class="mt-4">Last Read:</div>
-                <div class="w-40">{getCardDateInfo(bookCard.lastBookOpen)}</div>
-                <div class="mt-4">Bookmarked:</div>
-                <div class="w-40">{getCardDateInfo(bookCard.lastBookmarkModified)}</div>
-                <div class="mt-4">Last Update:</div>
-                <div class="w-40">{getCardDateInfo(bookCard.lastBookModified)}</div>
-              </div>
-            {/snippet}
-          </Popover>
-        </div>
-      {/if}
-      {#if bookCard.id === hoveringBookId}
-        <div
-          tabindex="0"
-          role="button"
-          class="mdc-elevation--z2 hover:mdc-elevation--z8 mdc-elevation-transition absolute -top-2 -right-2 size-6 rounded-full bg-red-400"
-          onclick={() => onremoveBookClick?.({ id: bookCard.id })}
-          onkeyup={dummyFn}
-        >
-          <svg role="img" class="w-full" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 504 504">
-            <path
-              class="fill-current text-white"
-              d="M369.6 313.1c4.7 4.7 4.7 12.3 0 17L330 369.6c-4.7 4.7-12.3 4.7-17 0L248 304l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L126.4 330c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L304 248l65.6 65.1z"
-            />
-          </svg>
-        </div>
-      {/if}
-    </div>
+      <BookCardActions
+        {bookCard}
+        onread={onreadBookClick}
+        onstatistics={onstatisticsClick}
+        ondownload={ondownloadBookClick}
+        oncomplete={oncompleteBookClick}
+        ondeletestatistics={ondeleteStatisticsClick}
+        onremove={onremoveBookClick}
+      />
+    </article>
   {/each}
 </div>

--- a/src/lib/components/book-card/book-card-props.ts
+++ b/src/lib/components/book-card/book-card-props.ts
@@ -2,6 +2,7 @@ export interface BookCardProps {
   id: number;
   imagePath: string | Blob;
   title: string;
+  author?: string;
   characters: number;
   lastBookModified: number;
   lastBookOpen: number;

--- a/src/lib/components/book-card/book-card.svelte
+++ b/src/lib/components/book-card/book-card.svelte
@@ -1,110 +1,176 @@
 <script lang="ts">
-  import type { MouseEventHandler, KeyboardEventHandler } from 'svelte/elements';
   import { faImage } from '@fortawesome/free-regular-svg-icons';
   import { onDestroy } from 'svelte';
+  import type { MouseEventHandler } from 'svelte/elements';
   import Fa from 'svelte-fa';
   import { japaneseLangIfNeeded } from '$lib/functions/japanese-language';
 
   interface Props {
     imagePath: string | Blob;
     title: string;
+    author?: string;
     progress: number;
     completed: boolean;
+    current?: boolean;
+    isPlaceholder?: boolean;
+    selected?: boolean;
+    selectionMode?: boolean;
     tooltip?: string;
-    onclick?: MouseEventHandler<HTMLDivElement>;
-    onkeyup?: KeyboardEventHandler<HTMLDivElement>;
+    onclick?: MouseEventHandler<HTMLButtonElement>;
   }
 
-  let { imagePath, title, progress, completed, tooltip, onclick, onkeyup }: Props = $props();
+  let {
+    imagePath,
+    title,
+    author,
+    progress,
+    completed,
+    current = false,
+    isPlaceholder = false,
+    selected = false,
+    selectionMode = false,
+    tooltip,
+    onclick
+  }: Props = $props();
 
-  const componentId = $props.id();
-
-  let objectUrl = '';
+  let objectURL = '';
 
   onDestroy(() => {
-    if (objectUrl) {
-      URL.revokeObjectURL(objectUrl);
+    if (objectURL) {
+      URL.revokeObjectURL(objectURL);
     }
   });
 
   function convertImagePath(value: string | Blob) {
-    if (objectUrl) {
-      URL.revokeObjectURL(objectUrl);
-      objectUrl = '';
+    if (objectURL) {
+      URL.revokeObjectURL(objectURL);
+      objectURL = '';
     }
     if (typeof value !== 'string') {
-      objectUrl = URL.createObjectURL(value);
+      objectURL = URL.createObjectURL(value);
 
-      return objectUrl;
+      return objectURL;
     }
 
     return value;
   }
 
   function mapImagePathFactory() {
-    let prevValue: string | Blob | undefined;
-    let prevResponse: string | undefined;
+    let previousValue: string | Blob | undefined;
+    let previousResponse: string | undefined;
 
     return (value: string | Blob) => {
-      if (value === prevValue) return prevResponse as string;
+      if (value === previousValue) return previousResponse as string;
 
-      prevValue = value;
-      prevResponse = convertImagePath(value);
+      previousValue = value;
+      previousResponse = convertImagePath(value);
 
-      return prevResponse;
+      return previousResponse;
     };
   }
 
   const mapImagePath = mapImagePathFactory();
 
   let imageLoading = $state(true);
-
-  let titleId = $derived(`${componentId}-title`);
-  let titleLang = $derived(japaneseLangIfNeeded(title));
-  let progressLabelId = $derived(`${componentId}-progress-label`);
+  let titleLanguage = $derived(japaneseLangIfNeeded(title));
+  let authorLanguage = $derived(author ? japaneseLangIfNeeded(author) : undefined);
   let progressPercentage = $derived(completed ? 100 : Math.round(progress * 100));
-  let progressValueClasses = $derived(
-    completed
-      ? '[&::-webkit-progress-value]:rounded-none [&::-webkit-progress-value]:from-emerald-500 [&::-webkit-progress-value]:to-emerald-600 [&::-moz-progress-bar]:rounded-none [&::-moz-progress-bar]:from-emerald-500 [&::-moz-progress-bar]:to-emerald-600'
-      : '[&::-webkit-progress-value]:rounded-r-sm [&::-webkit-progress-value]:from-blue-500 [&::-webkit-progress-value]:to-blue-700 [&::-moz-progress-bar]:rounded-r-sm [&::-moz-progress-bar]:from-blue-500 [&::-moz-progress-bar]:to-blue-700'
-  );
 </script>
 
-<div tabindex="0" role="button" class="relative aspect-2/3" title={tooltip} {onclick} {onkeyup}>
-  <div class="inline">
-    <div class="size-full text-5xl sm:text-7xl">
-      {#if imageLoading}
-        <Fa class="absolute top-1/2 left-1/2 -translate-1/2 " icon={faImage} />
-      {/if}
+<button
+  type="button"
+  class="block w-full min-w-0 rounded-sm text-left"
+  class:outline-2={selected}
+  class:outline-offset-4={selected}
+  class:outline-blue-400={selected}
+  title={tooltip}
+  aria-label={title}
+  aria-pressed={selectionMode ? selected : undefined}
+  {onclick}
+>
+  <span
+    class="mdc-elevation--z1 hover:mdc-elevation--z8 mdc-elevation-transition relative block aspect-2/3 w-full overflow-hidden text-5xl sm:text-7xl"
+    class:rounded-tl-xl={current}
+    class:mdc-elevation--z4={selected || current}
+    class:opacity-60={isPlaceholder}
+  >
+    {#if imageLoading}
+      <Fa class="absolute top-1/2 left-1/2 -translate-1/2" icon={faImage} />
+    {/if}
 
-      {#if imagePath}
-        <img
-          decoding="async"
-          loading="lazy"
-          referrerpolicy="no-referrer"
-          class="book-cover relative size-full object-cover transition delay-150 duration-700 ease-out"
-          class:blur={imageLoading}
-          src={mapImagePath(imagePath)}
-          alt=""
-          onload={() => (imageLoading = false)}
-          onerror={() => (imageLoading = false)}
-        />
-      {/if}
-    </div>
+    {#if imagePath}
+      <img
+        decoding="async"
+        loading="lazy"
+        referrerpolicy="no-referrer"
+        class="book-cover relative size-full object-cover transition delay-150 duration-700 ease-out"
+        class:blur={imageLoading}
+        src={mapImagePath(imagePath)}
+        alt=""
+        onload={() => (imageLoading = false)}
+        onerror={() => (imageLoading = false)}
+      />
+    {/if}
 
-    <div class="absolute inset-x-0 bottom-0">
-      <div
-        class="sm:h-21 h-16 bg-gray-800/80 p-0.5 px-1.5 text-justify text-sm text-white sm:p-1.5 sm:text-base"
-      >
-        <span id={titleId} class="line-clamp-3" lang={titleLang}>{title}</span>
-      </div>
-      <span id={progressLabelId} class="sr-only">Reading progress</span>
-      <progress
-        class={`block h-2.5 w-full appearance-none border-0 bg-gray-400/80 [&::-webkit-progress-bar]:bg-gray-400/80 [&::-webkit-progress-value]:bg-linear-to-b [&::-moz-progress-bar]:bg-linear-to-b ${progressValueClasses}`}
-        aria-labelledby={`${titleId} ${progressLabelId}`}
-        value={progressPercentage}
-        max="100"
-      ></progress>
-    </div>
-  </div>
-</div>
+    <progress
+      class="reading-progress"
+      class:completed
+      aria-label={`Reading progress for ${title}`}
+      value={progressPercentage}
+      max="100"
+    ></progress>
+  </span>
+
+  <span
+    class="mt-3 grid h-14.5 min-w-0 grid-cols-[minmax(0,1fr)_2rem] items-start gap-2 overflow-hidden"
+  >
+    <span class="min-w-0">
+      <span class="line-clamp-2 text-sm font-medium" lang={titleLanguage}>{title}</span>
+      <span class="mt-0.5 block truncate text-xs text-gray-500" lang={authorLanguage}>
+        {author}
+      </span>
+    </span>
+    <span
+      class="pt-0.5 text-right text-xs font-medium tabular-nums"
+      class:text-emerald-700={completed}
+      class:text-blue-700={!completed}
+    >
+      {progressPercentage}%
+    </span>
+  </span>
+</button>
+
+<style>
+  .reading-progress {
+    --progress-from: var(--color-blue-500);
+    --progress-to: var(--color-blue-700);
+
+    position: absolute;
+    inset-inline: 0;
+    bottom: 0;
+    display: block;
+    width: 100%;
+    height: 0.625rem;
+    appearance: none;
+    border: 0;
+    background: color-mix(in oklab, var(--color-gray-400) 80%, transparent);
+    pointer-events: none;
+
+    &.completed {
+      --progress-from: var(--color-emerald-500);
+      --progress-to: var(--color-emerald-600);
+    }
+
+    &::-webkit-progress-bar {
+      background: color-mix(in oklab, var(--color-gray-400) 80%, transparent);
+    }
+
+    &::-webkit-progress-value {
+      background: linear-gradient(to bottom, var(--progress-from), var(--progress-to));
+    }
+
+    &::-moz-progress-bar {
+      background: linear-gradient(to bottom, var(--progress-from), var(--progress-to));
+    }
+  }
+</style>

--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -16,8 +16,11 @@
     faArrowDownWideShort,
     faBug,
     faCalendarXmark,
+    faChartLine,
     faCircleXmark,
+    faDownload,
     faFile,
+    faFlag,
     faFolder,
     faSortDown,
     faSortUp,
@@ -29,8 +32,10 @@
 
   interface Props {
     selectMode: boolean;
+    bookCount: number;
     selectedCount: number;
-    hasBooks: boolean;
+    selectedCompletedCount: number;
+    selectedPlaceholderCount: number;
     /**
      * When non-zero, the header takes over to show a progress bar
      * and a cancel button. Imports of large libraries and bulk
@@ -42,6 +47,9 @@
     cancelTooltip: string;
     fileCountData?: Record<string, number>;
     onselectAllClick?: () => void;
+    onviewStatistics?: () => void | Promise<void>;
+    oncompletionChange?: (completed: boolean) => void | Promise<void>;
+    ondownloadClick?: () => void | Promise<void>;
     onremoveClick?: () => void;
     onbugReportClick?: () => void;
     onfilesChange?: (fileList: FileList) => void;
@@ -51,14 +59,19 @@
 
   let {
     selectMode = $bindable(),
+    bookCount,
     selectedCount,
-    hasBooks,
+    selectedCompletedCount,
+    selectedPlaceholderCount,
     replicationProgress,
     replicationToProgress,
     replicationProgressRemaining,
     cancelTooltip,
     fileCountData = $bindable(),
     onselectAllClick,
+    onviewStatistics,
+    oncompletionChange,
+    ondownloadClick,
     onremoveClick,
     onbugReportClick,
     onfilesChange,
@@ -84,6 +97,11 @@
     { property: 'progress', label: 'Progress' },
     { property: 'lastBookmarkModified', label: 'Bookmarked' }
   ];
+
+  let allBooksSelected = $derived(bookCount > 0 && selectedCount === bookCount);
+  let allSelectedBooksCompleted = $derived(
+    selectedCount > 0 && selectedCompletedCount === selectedCount
+  );
 
   function dispatchFilesChange(fileList: FileList) {
     onfilesChange?.(fileList);
@@ -129,7 +147,7 @@
           title={selectMode ? 'Disable book selection' : 'Enable book selection'}
           label="Select"
           selected={selectMode}
-          onclick={() => (selectMode = hasBooks && !selectMode)}
+          onclick={() => (selectMode = bookCount > 0 && !selectMode)}
         >
           {#snippet icon()}
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="size-3.5">
@@ -140,15 +158,8 @@
             </svg>
           {/snippet}
         </HeaderButton>
-        {#if selectMode}
-          <span
-            class="flex items-center px-2 text-xl font-medium"
-            title="{selectedCount} {selectedCount === 1 ? 'book' : 'books'} selected"
-            >{selectedCount}</span
-          >
-        {/if}
-        <div class={headerDividerClasses}></div>
         {#if !selectMode}
+          <div class={headerDividerClasses}></div>
           <HeaderButton
             faIcon={faFile}
             title="Import book files"
@@ -170,7 +181,20 @@
             onclick={() => onbugReportClick?.()}
           />
         {:else}
-          <HeaderButton title="Select all books" label="All" onclick={() => onselectAllClick?.()}>
+          <span
+            class="flex w-12 shrink-0 items-center justify-center text-xl font-medium tabular-nums"
+            title="{selectedCount} {selectedCount === 1 ? 'book' : 'books'} selected"
+            aria-live="polite"
+          >
+            {selectedCount}
+          </span>
+          <HeaderButton
+            title={allBooksSelected ? 'Clear book selection' : 'Select all books'}
+            label={allBooksSelected ? 'Clear All' : 'Select All'}
+            selected={allBooksSelected}
+            width="wide"
+            onclick={() => onselectAllClick?.()}
+          >
             {#snippet icon()}
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="size-3.5">
                 <path
@@ -181,16 +205,41 @@
             {/snippet}
           </HeaderButton>
           {#if selectedCount > 0}
+            <div class={headerDividerClasses}></div>
+            <HeaderButton
+              faIcon={faChartLine}
+              title="View statistics for selected books"
+              label="View Stats"
+              onclick={() => onviewStatistics?.()}
+            />
+            <HeaderButton
+              faIcon={faFlag}
+              title={allSelectedBooksCompleted
+                ? 'Mark selected books as in progress'
+                : 'Mark selected books as complete'}
+              label={allSelectedBooksCompleted ? 'In Progress' : 'Complete'}
+              width="wide"
+              onclick={() => oncompletionChange?.(!allSelectedBooksCompleted)}
+            />
+            {#if selectedPlaceholderCount > 0}
+              <HeaderButton
+                faIcon={faDownload}
+                title="Download selected books to this device"
+                label="Download"
+                onclick={() => ondownloadClick?.()}
+              />
+            {/if}
+            <div class={headerDividerClasses}></div>
             <HeaderButton
               faIcon={faCalendarXmark}
               title="Delete statistics for selected books"
-              label="Delete Statistics"
+              label="Delete Stats"
               onclick={() => ondeleteStatistics?.()}
             />
             <HeaderButton
               faIcon={faTrash}
-              title="Delete selected books"
-              label="Delete Book"
+              title="Remove selected books from the library"
+              label="Remove"
               onclick={() => onremoveClick?.()}
             />
           {/if}

--- a/src/lib/components/header-button.svelte
+++ b/src/lib/components/header-button.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
   import { ripple } from '$lib/components/ripple';
-  import { quintOut } from 'svelte/easing';
   import type { MouseEventHandler } from 'svelte/elements';
   import type { Snippet } from 'svelte';
-  import { scale } from 'svelte/transition';
   import Fa from 'svelte-fa';
 
   type Variant = 'action' | 'tab';
+  type Width = 'default' | 'wide';
 
   interface Props {
     faIcon?: IconDefinition;
@@ -16,6 +15,7 @@
     disabled?: boolean;
     selected?: boolean;
     variant?: Variant;
+    width?: Width;
     onclick?: MouseEventHandler<HTMLButtonElement>;
     icon?: Snippet;
   }
@@ -27,35 +27,29 @@
     disabled = false,
     selected = false,
     variant = 'action',
+    width = 'default',
     onclick,
     icon
   }: Props = $props();
 
   const iconClasses = 'flex items-center justify-center leading-none mb-0.5';
   const faIconClasses = `${iconClasses} text-sm`;
-  const inAnimationParams = {
-    delay: 150,
-    duration: 150,
-    easing: quintOut
-  };
-  const outAnimationParams = {
-    duration: 150,
-    easing: quintOut
-  };
   const variantClasses = {
     action: 'opacity-60 transition-opacity',
     tab: ''
   } satisfies Record<Variant, string>;
+  const widthClasses = {
+    default: '',
+    wide: 'w-20 shrink-0'
+  } satisfies Record<Width, string>;
 </script>
 
 <button
   use:ripple
   type="button"
-  in:scale={inAnimationParams}
-  out:scale={outAnimationParams}
   {title}
   {disabled}
-  class={`flex h-12 min-w-16 flex-col items-center justify-center px-2 text-center text-xs select-none ${variantClasses[variant]}`}
+  class={`flex h-12 min-w-16 flex-col items-center justify-center px-2 text-center text-xs select-none ${variantClasses[variant]} ${widthClasses[width]}`}
   class:opacity-100={variant === 'action' && selected}
   class:bg-gray-900={variant === 'tab' && selected}
   class:hover:bg-gray-800={variant === 'tab' && selected}

--- a/src/lib/data/database/books-db/database.service.svelte.ts
+++ b/src/lib/data/database/books-db/database.service.svelte.ts
@@ -92,6 +92,7 @@ export class DatabaseService {
     return data.map((book) => ({
       id: book.id,
       title: book.title,
+      author: book.author,
       imagePath: book.coverImage || '',
       characters: BaseStorageHandler.getBookCharacters(book.characters || 0, book.sections || []),
       lastBookModified: book.lastBookModified || 0,

--- a/src/lib/data/database/books-db/versions/v7/books-db-v7.ts
+++ b/src/lib/data/database/books-db/versions/v7/books-db-v7.ts
@@ -7,6 +7,7 @@ import type { SyncEndpointType } from '$lib/data/storage/storage-types';
 interface BooksDbV7BookData {
   id: number;
   title: string;
+  author?: string;
   language?: string;
   styleSheet: string;
   elementHtml: string;

--- a/src/lib/data/storage/handler/base-handler.ts
+++ b/src/lib/data/storage/handler/base-handler.ts
@@ -432,7 +432,7 @@ export abstract class BaseStorageHandler implements SyncEndpoint {
         | 'lastBookOpen'
         | 'lastSeenSourceInstanceId'
       >
-    > = ['title', 'styleSheet', 'elementHtml', 'htmlBackup', 'sections'];
+    > = ['title', 'author', 'styleSheet', 'elementHtml', 'htmlBackup', 'sections'];
     const staticData: Record<string, string | Section[] | undefined> = {};
     const limiter = pLimit(1);
     const cover = bookdata.coverImage;
@@ -600,6 +600,7 @@ export abstract class BaseStorageHandler implements SyncEndpoint {
                 BaseStorageHandler.getBookMetadata(filename);
 
               bookObject.title = staticData.title;
+              bookObject.author = staticData.author;
               bookObject.elementHtml = staticData.elementHtml;
               bookObject.styleSheet = staticData.styleSheet || '';
               bookObject.sections = staticData.sections || [];

--- a/src/lib/functions/file-loaders/epub/load-epub.ts
+++ b/src/lib/functions/file-loaders/epub/load-epub.ts
@@ -16,6 +16,7 @@ export default async function loadEpub(
 
   const displayData = {
     title: file.name,
+    author: '',
     language: '',
     hasThumb: true,
     styleSheet: generateEpubStyleSheet(data, contents)
@@ -32,6 +33,9 @@ export default async function loadEpub(
     const titleValues = Array.isArray(metadata['dc:title'])
       ? metadata['dc:title']
       : [metadata['dc:title']];
+    const authorValues = Array.isArray(metadata['dc:creator'])
+      ? metadata['dc:creator']
+      : [metadata['dc:creator']];
 
     for (const dcTitle of titleValues) {
       if (typeof dcTitle === 'string') {
@@ -43,13 +47,23 @@ export default async function loadEpub(
       }
     }
 
+    for (const dcCreator of authorValues) {
+      if (typeof dcCreator === 'string') {
+        displayData.author = dcCreator;
+        break;
+      } else if (dcCreator?.['#text']) {
+        displayData.author = dcCreator['#text'];
+        break;
+      }
+    }
+
     displayData.language =
-      languageValues.reduce((languages, dcLanguage) => {
+      languageValues.reduce<string[]>((languages, dcLanguage) => {
         try {
           if (typeof dcLanguage === 'string') {
             languages.push(...Intl.getCanonicalLocales(dcLanguage.trim()));
           } else if (dcLanguage && dcLanguage['#text']) {
-            languages.push(...Intl.getCanonicalLocales(dcLanguage.trim()));
+            languages.push(...Intl.getCanonicalLocales(dcLanguage['#text'].trim()));
           }
         } catch (_) {
           //no-op

--- a/src/lib/functions/file-loaders/epub/types.ts
+++ b/src/lib/functions/file-loaders/epub/types.ts
@@ -15,19 +15,18 @@ export interface EpubSpineItemRef {
   '@_idref': string;
 }
 
+type EpubMetadataValue =
+  | string
+  | {
+      '#text': string;
+    };
+
 export interface EpubContent {
   package: {
     metadata: {
-      'dc:title':
-        | string
-        | {
-            '#text': string;
-          };
-      'dc:language':
-        | string
-        | {
-            '#text': string;
-          };
+      'dc:title': EpubMetadataValue | EpubMetadataValue[];
+      'dc:creator'?: EpubMetadataValue | EpubMetadataValue[];
+      'dc:language': EpubMetadataValue | EpubMetadataValue[];
       meta?: EpubMetadataMeta | EpubMetadataMeta[];
     };
     manifest: {
@@ -42,16 +41,9 @@ export interface EpubContent {
 export interface EpubOPFContent {
   'opf:package': {
     'opf:metadata': {
-      'dc:title':
-        | string
-        | {
-            '#text': string;
-          };
-      'dc:language':
-        | string
-        | {
-            '#text': string;
-          };
+      'dc:title': EpubMetadataValue | EpubMetadataValue[];
+      'dc:creator'?: EpubMetadataValue | EpubMetadataValue[];
+      'dc:language': EpubMetadataValue | EpubMetadataValue[];
       'opf:meta'?: EpubMetadataMeta | EpubMetadataMeta[];
     };
     'opf:manifest': {

--- a/src/lib/functions/file-loaders/htmlz/load-htmlz.ts
+++ b/src/lib/functions/file-loaders/htmlz/load-htmlz.ts
@@ -17,11 +17,18 @@ export default async function loadHtmlz(
 
   const displayData = {
     title: file.name,
+    author: '',
     hasThumb: true,
     styleSheet: data['style.css']
   };
   if (metadata && metadata['dc:title']) {
     displayData.title = metadata['dc:title'];
+  }
+  const creator = metadata?.['dc:creator'];
+  if (typeof creator === 'string') {
+    displayData.author = creator;
+  } else if (typeof creator?.['#text'] === 'string') {
+    displayData.author = creator['#text'];
   }
   const blobData = reduceObjToBlobs(data);
   const coverImageFilename = getHtmlzCoverImageFilename();

--- a/src/lib/functions/statistic-util.ts
+++ b/src/lib/functions/statistic-util.ts
@@ -93,15 +93,19 @@ export function getDateString(date: Date) {
   )}-${`${date.getDate()}`.padStart(2, '0')}`;
 }
 
-export function getDateTimeString(timeInMs: number) {
+export function getDateTimeString(
+  timeInMs: number,
+  { includeSeconds = true }: { includeSeconds?: boolean } = {}
+) {
   const date = new Date(timeInMs);
-  return `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(
+  const minuteDateTime = `${getDateString(date)} ${`${date.getHours()}`.padStart(
     2,
     '0'
-  )}-${`${date.getDate()}`.padStart(2, '0')} ${`${date.getHours()}`.padStart(
-    2,
-    '0'
-  )}:${`${date.getMinutes()}`.padStart(2, '0')}:${`${date.getSeconds()}`.padStart(2, '0')}`;
+  )}:${`${date.getMinutes()}`.padStart(2, '0')}`;
+
+  return includeSeconds
+    ? `${minuteDateTime}:${`${date.getSeconds()}`.padStart(2, '0')}`
+    : minuteDateTime;
 }
 
 export function getWeekNumber(referenceDate: number, startDate: number) {

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -5,12 +5,23 @@
   import BookCardList from '$lib/components/book-card/book-card-list.svelte';
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
   import BookManagerHeader from '$lib/components/book-card/book-manager-header.svelte';
+  import {
+    defaultStatisticsView,
+    getBookStatisticsURL,
+    getStatisticsURL
+  } from '$lib/components/statistics/statistics-view';
   import { showBugReportDialog, showErrorDialog } from '$lib/components/log-report-dialog.svelte';
   import { pxScreen } from '$lib/css-classes';
   import type { BooksDbBookmarkData } from '$lib/data/database/books-db/versions/books-db';
   import { appName } from '$lib/data/env';
-  import { userDeleteBooks, userDeleteStatisticEntries, userImportBooks } from '$lib/data/library';
+  import {
+    userDeleteBooks,
+    userDeleteStatisticEntries,
+    userImportBooks,
+    userSaveBookmark
+  } from '$lib/data/library';
   import { logger } from '$lib/data/logger';
+  import { reconcileForBookOpen } from '$lib/data/sync/sync-engine';
   import { showConfirmDialog } from '$lib/components/confirm-dialog.svelte';
   import { showMessageDialog } from '$lib/components/message-dialog.svelte';
   import { SortDirection, type SortOption } from '$lib/data/sort-types';
@@ -34,7 +45,7 @@
 
   // The unified library view always reads from the local IndexedDB
   // (browser storage). Placeholder books (not-yet-downloaded cloud
-  // content) stay in the list with a cloud-icon marker and are
+  // content) stay in the list with a Download action and are
   // downloaded transparently when clicked; see onBookClick below.
   let bookCards = $derived(
     getBookCards(database.dataList, database.bookmarks, $booklistSortOptions$)
@@ -42,6 +53,11 @@
 
   let selectedBookIds: ReadonlySet<number> = $state(new Set());
   let selectMode = $state(false);
+  let selectedBookCards = $derived(bookCards.filter((book) => selectedBookIds.has(book.id)));
+  let selectedCompletedCount = $derived(selectedBookCards.filter((book) => book.completed).length);
+  let selectedPlaceholderCount = $derived(
+    selectedBookCards.filter((book) => book.isPlaceholder).length
+  );
   let abortController = $state(new AbortController());
   let signal = $derived(abortController.signal);
   let cancelTooltip = $state('');
@@ -125,28 +141,97 @@
       return;
     }
 
-    // /manage is a launcher — the reader owns downloading. For a
-    // placeholder, pre-check that the original sync source is still
-    // connected so we can surface a friendlier error than "couldn't
-    // render empty book" if not; otherwise just navigate.
+    await readBook(bookId);
+  }
+
+  async function readBook(bookId: number) {
+    if (!operationAllowed()) return;
+
+    const bookItem = bookCards.find((book) => book.id === bookId);
+    if (!bookItem || !(await placeholderActionAvailable(bookItem, 'open'))) return;
+
+    await openBook(bookId);
+  }
+
+  async function downloadBook(bookId: number) {
+    if (!operationAllowed()) return;
+
+    const bookItem = bookCards.find((book) => book.id === bookId);
+    if (!bookItem || !bookItem.isPlaceholder) return;
+
+    if (!(await placeholderActionAvailable(bookItem, 'download'))) return;
+
+    await reconcileForBookOpen({
+      id: bookItem.id,
+      title: bookItem.title,
+      imagePath: bookItem.imagePath
+    });
+    database.notifyDataListChanged();
+  }
+
+  async function placeholderActionAvailable(book: BookCardProps, action: 'open' | 'download') {
+    if (!book.isPlaceholder) return true;
+
+    const db = await database.db;
+    if ((await db.count('storageSource')) > 0) return true;
+
+    showMessageDialog({
+      title: `Can't ${action} book`,
+      message:
+        "This book's content isn't downloaded and no sync source is connected. Connect one from Settings → Sync to download."
+    });
+    return false;
+  }
+
+  function openBookStatistics(bookId: number) {
+    return goto(resolve(getBookStatisticsURL(bookId)));
+  }
+
+  function openSelectedBookStatistics() {
+    const bookIds = selectedBookCards.map((book) => book.id);
+    if (!bookIds.length) return;
+
+    return goto(resolve(getStatisticsURL(defaultStatisticsView, bookIds)));
+  }
+
+  async function setBookCompleted(bookId: number, completed: boolean) {
+    if (!operationAllowed()) return;
+
     const bookItem = bookCards.find((book) => book.id === bookId);
     if (!bookItem) return;
 
-    if (bookItem.isPlaceholder) {
-      const db = await database.db;
-      const sources = await db.getAll('storageSource');
-
-      if (sources.length === 0) {
-        showMessageDialog({
-          title: "Can't open book",
-          message:
-            "This book's content isn't downloaded and no sync source is connected. Connect one from Settings → Sync to download."
-        });
-        return;
-      }
+    try {
+      const existingBookmark = await database.getBookmark(bookId);
+      // Session and completion statistics are recorded in the reader. The library action only
+      // changes the durable completion marker while preserving the reader's current position.
+      await userSaveBookmark(
+        {
+          ...existingBookmark,
+          dataId: bookId,
+          progress: existingBookmark?.progress ?? 0,
+          completed,
+          lastBookmarkModified: Date.now()
+        },
+        { id: bookId, title: bookItem.title, imagePath: bookItem.imagePath }
+      );
+    } catch (error) {
+      showErrorDialog({
+        title: completed ? 'Error completing book' : 'Error marking book as in progress',
+        error
+      });
     }
+  }
 
-    await openBook(bookId);
+  async function setSelectedBooksCompleted(completed: boolean) {
+    for (const book of selectedBookCards) {
+      await setBookCompleted(book.id, completed);
+    }
+  }
+
+  async function downloadSelectedBooks() {
+    for (const book of selectedBookCards.filter((candidate) => candidate.isPlaceholder)) {
+      await downloadBook(book.id);
+    }
   }
 
   function operationAllowed() {
@@ -200,22 +285,45 @@
     }
   }
 
-  function onSelectAllBooks() {
+  function onToggleAllBooks() {
+    if (selectedBookIds.size === bookCards.length) {
+      selectedBookIds = new Set();
+      return;
+    }
+
     selectedBookIds = cloneMutateSet(selectedBookIds, (set) => {
       bookCards.forEach((x) => set.add(x.id));
     });
   }
 
+  function getBookTitles(bookIds: readonly number[]) {
+    const bookIdSet = new Set(bookIds);
+    return bookCards.filter((book) => bookIdSet.has(book.id)).map((book) => book.title);
+  }
+
   async function removeBooks(bookIds: number[]) {
     if (!operationAllowed()) return;
 
+    const titlesToDelete = getBookTitles(bookIds);
+
+    if (!titlesToDelete.length) return;
+
+    const confirmed = await showConfirmDialog({
+      title:
+        titlesToDelete.length === 1
+          ? 'Remove book from library?'
+          : `Remove ${titlesToDelete.length} books from library?`,
+      message: `This will remove ${
+        titlesToDelete.length === 1 ? `『${titlesToDelete[0]}』` : 'the selected books'
+      } from your library. The deletion will sync to your other devices. Depending on your settings, reading statistics may also be deleted.`,
+      confirmLabel: 'Remove',
+      danger: true
+    });
+
+    if (!confirmed) return;
+
     cancelTooltip = 'Cancels the deletion\nAlready deleted data will not be restored';
     initializeReplicationProgressData();
-
-    const titlesToDelete = bookCards.reduce((toDelete, card) => {
-      if (bookIds.includes(card.id)) toDelete.push(card.title);
-      return toDelete;
-    }, [] as string[]);
 
     try {
       await userDeleteBooks(titlesToDelete, signal, $keepLocalStatisticsOnDeletion$);
@@ -239,21 +347,23 @@
     }
   }
 
-  async function onDeleteStatistics() {
-    const titles = bookCards
-      .filter((card) => selectedBookIds.has(card.id))
-      .map((book) => book.title);
+  async function onDeleteStatistics(bookIds = Array.from(selectedBookIds)) {
+    if (!operationAllowed()) return;
+
+    const titles = getBookTitles(bookIds);
+
+    if (!titles.length) return;
 
     let confirmed = true;
 
     if ($confirmStatisticsDeletion$) {
       confirmed = await showConfirmDialog({
         title: 'Delete data',
-        message: `This will delete all statistics for the selected ${pluralize(
-          titles.length,
-          'book',
-          false
-        )} (which may include start and/or completion data). The deletion will sync to your other devices.`,
+        message: `This will delete all statistics for ${
+          titles.length === 1
+            ? `『${titles[0]}』`
+            : `the selected ${pluralize(titles.length, 'book')}`
+        } (which may include start and/or completion data). The deletion will sync to your other devices.`,
         confirmLabel: 'Delete',
         danger: true
       });
@@ -310,15 +420,20 @@
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
   <BookManagerHeader
+    bookCount={bookCards.length}
     selectedCount={selectedBookIds.size}
-    hasBooks={bookCards.length > 0}
+    {selectedCompletedCount}
+    {selectedPlaceholderCount}
     replicationProgress={replicationProgressState.progress}
     replicationToProgress={replicationProgressState.toProgress}
     replicationProgressRemaining={replicationProgressState.remaining}
     {cancelTooltip}
     bind:fileCountData
     bind:selectMode
-    onselectAllClick={onSelectAllBooks}
+    onselectAllClick={onToggleAllBooks}
+    onviewStatistics={openSelectedBookStatistics}
+    oncompletionChange={setSelectedBooksCompleted}
+    ondownloadClick={downloadSelectedBooks}
     onremoveClick={() => removeBooks(Array.from(selectedBookIds))}
     onfilesChange={onFilesChange}
     onbugReportClick={showBugReportDialog}
@@ -348,9 +463,15 @@
   {:else if bookCards.length}
     <BookCardList
       currentBookId={database.lastItemId}
+      {selectMode}
       {selectedBookIds}
       {bookCards}
       onbookClick={({ id }) => onBookClick(id)}
+      onreadBookClick={({ id }) => readBook(id)}
+      onstatisticsClick={({ id }) => openBookStatistics(id)}
+      ondownloadBookClick={({ id }) => downloadBook(id)}
+      oncompleteBookClick={({ id, completed }) => setBookCompleted(id, completed)}
+      ondeleteStatisticsClick={({ id }) => onDeleteStatistics([id])}
       onremoveBookClick={({ id }) => removeBooks([id])}
     />
   {:else}

--- a/tests/integration/fs/source-only-placeholder.spec.ts
+++ b/tests/integration/fs/source-only-placeholder.spec.ts
@@ -2,10 +2,32 @@ import { expect, test } from '../helpers/harness.ts';
 import {
   expectBookReaderText,
   expectBooksInManage,
+  fixtureTitle,
   openBookFromManage,
   VALID_BOOK
 } from '../helpers/fixtures.ts';
 import { connectFS, signOutAndWipe, syncBookFixturesToSource } from '../helpers/workflows.ts';
+
+test('download action hydrates a source-only placeholder without opening the reader', async ({
+  page
+}) => {
+  await syncBookFixturesToSource(page, [VALID_BOOK]);
+
+  await signOutAndWipe(page);
+  await connectFS(page);
+
+  await expectBooksInManage(page, { placeholders: [VALID_BOOK], downloaded: [] });
+  await page.getByRole('button', { name: 'Select' }).click();
+  await page.getByText(fixtureTitle(VALID_BOOK), { exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Download', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Select' }).click();
+  await page.getByRole('button', { name: `Download ${fixtureTitle(VALID_BOOK)}` }).click();
+
+  await expectBooksInManage(page, { placeholders: [], downloaded: [VALID_BOOK] });
+  await expect(page.getByText('テスト 太郎', { exact: true })).toBeVisible();
+  await expect(page).toHaveURL('/manage');
+});
 
 test('opening a source-only placeholder downloads the book into the reader', async ({ page }) => {
   await syncBookFixturesToSource(page, [VALID_BOOK]);

--- a/tests/integration/helpers/fixtures.ts
+++ b/tests/integration/helpers/fixtures.ts
@@ -196,7 +196,7 @@ export async function expectBooksInManage(
 
   const expectedBookCount = placeholderFixtures.size + downloadedFixtures.size;
 
-  await expect(page.locator('[role="banner"]')).toHaveCount(expectedBookCount, {
+  await expect(page.locator('article')).toHaveCount(expectedBookCount, {
     timeout: SYNC_ASSERTION_TIMEOUT
   });
   await Promise.all([
@@ -296,7 +296,11 @@ export async function deleteBookFromManage(page: Page, fixture: LibraryBookFixtu
 
   await page.getByRole('button', { name: 'Select' }).click();
   await bookTitle.click();
-  await page.getByRole('button', { name: 'Delete Book' }).click();
+  await page.getByRole('button', { name: 'Remove', exact: true }).click();
+  const dialog = page.locator('dialog[open]').filter({
+    has: page.getByRole('heading', { name: 'Remove book from library?' })
+  });
+  await dialog.getByRole('button', { name: 'Remove', exact: true }).click();
 
   await expect(bookTitle).toHaveCount(0);
 }
@@ -423,7 +427,7 @@ export async function expectImportFailedForFixture(page: Page, fixture: InvalidI
 }
 
 export function bookCard(page: Page, fixture: LibraryBookFixture) {
-  return page.locator('[role="banner"]').filter({
+  return page.locator('article').filter({
     has: page.getByText(fixtureTitle(fixture), { exact: true })
   });
 }

--- a/tests/integration/manage/book-author.spec.ts
+++ b/tests/integration/manage/book-author.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { fixtureTitle, importBookFixtures, VALID_BOOK } from '../helpers/fixtures.ts';
+
+test('import preserves EPUB creator metadata on the book record', async ({ page }) => {
+  await importBookFixtures(page, [VALID_BOOK]);
+
+  const author = await page.evaluate(async (title) => {
+    const databaseRequest = indexedDB.open('books');
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      databaseRequest.addEventListener('success', () => resolve(databaseRequest.result));
+      databaseRequest.addEventListener('error', () => reject(databaseRequest.error));
+    });
+    const transaction = database.transaction('data', 'readonly');
+    const bookRequest = transaction.objectStore('data').index('title').get(title);
+    const book = await new Promise<{ author?: string } | undefined>((resolve, reject) => {
+      bookRequest.addEventListener('success', () => resolve(bookRequest.result));
+      bookRequest.addEventListener('error', () => reject(bookRequest.error));
+    });
+    database.close();
+    return book?.author;
+  }, fixtureTitle(VALID_BOOK));
+
+  expect(author).toBe('テスト 太郎');
+});

--- a/tests/integration/manage/book-list.spec.ts
+++ b/tests/integration/manage/book-list.spec.ts
@@ -7,6 +7,7 @@ import {
   importBookFixtures,
   LONG_BOOK,
   PLAIN_TEXT_BOOK,
+  VALID_BOOK,
   type LibraryBookFixture
 } from '../helpers/fixtures.ts';
 import { navigateToManage } from '../helpers/navigation.ts';
@@ -28,6 +29,143 @@ test('manager derives card progress and sort order from library state', async ({
   await expectBookOrder(page, [PLAIN_TEXT_BOOK, LONG_BOOK, COVER_REFRESH_BOOK]);
 });
 
+test('manager exposes per-book actions without entering selection mode', async ({ page }) => {
+  await importBookFixtures(page, [VALID_BOOK]);
+  await navigateToManage(page);
+
+  const card = page.locator('article').filter({ hasText: fixtureTitle(VALID_BOOK) });
+  await expect(card.getByText('テスト 太郎', { exact: true })).toBeVisible();
+  await expect(
+    card.getByRole('button', { name: `View statistics for ${fixtureTitle(VALID_BOOK)}` })
+  ).toBeVisible();
+  await expect(
+    card.getByRole('button', { name: `Details for ${fixtureTitle(VALID_BOOK)}` })
+  ).toBeVisible();
+
+  await card.getByRole('button', { name: `More actions for ${fixtureTitle(VALID_BOOK)}` }).click();
+  await expect(page.getByRole('button', { name: 'Read book' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'View statistics', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Book details' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Export book backup' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Delete statistics' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Remove from library' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Book details' }).click();
+  await expect(page.getByText('Last update', { exact: true })).toBeVisible();
+  await expect(
+    page.getByText('Last update', { exact: true }).locator('..').locator('dd')
+  ).toHaveText(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+  await expect(page.getByRole('button', { name: 'Back to book actions' })).toHaveCount(0);
+  await card.getByRole('button', { name: `Details for ${fixtureTitle(VALID_BOOK)}` }).click();
+
+  await card.getByRole('button', { name: `More actions for ${fixtureTitle(VALID_BOOK)}` }).click();
+  await page.getByRole('button', { name: 'Mark as complete' }).click();
+  await expect(card.getByRole('progressbar', { name: /Reading progress/ })).toHaveAttribute(
+    'value',
+    '100'
+  );
+  await expect(card.getByText('100%', { exact: true })).toBeVisible();
+
+  await card
+    .getByRole('button', { name: `View statistics for ${fixtureTitle(VALID_BOOK)}` })
+    .click();
+  await page.waitForURL((url) => url.pathname === '/statistics' && url.searchParams.has('b'));
+});
+
+test('manager confirms before removing a book from the library', async ({ page }) => {
+  await importBookFixtures(page, [VALID_BOOK]);
+  await navigateToManage(page);
+
+  const title = fixtureTitle(VALID_BOOK);
+  const card = page.locator('article').filter({ hasText: title });
+
+  await card.getByRole('button', { name: `More actions for ${title}` }).click();
+  await page.getByRole('button', { name: 'Remove from library' }).click();
+
+  const dialog = page.locator('dialog[open]').filter({
+    has: page.getByRole('heading', { name: 'Remove book from library?' })
+  });
+  await expect(dialog).toContainText(`『${title}』`);
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(card).toBeVisible();
+
+  await card.getByRole('button', { name: `More actions for ${title}` }).click();
+  await page.getByRole('button', { name: 'Remove from library' }).click();
+  await dialog.getByRole('button', { name: 'Remove', exact: true }).click();
+  await expect(card).toHaveCount(0);
+});
+
+test('selection mode exposes the applicable per-book actions in bulk', async ({ page }) => {
+  await importBookFixtures(page, [VALID_BOOK]);
+  await navigateToManage(page);
+
+  const title = fixtureTitle(VALID_BOOK);
+  const card = page.locator('article').filter({ hasText: title });
+  await page.getByRole('button', { name: 'Select' }).click();
+  const selectedCount = page.getByTitle(/books? selected/);
+  await expect(selectedCount).toHaveText('0');
+  const emptySelectionWidth = await selectedCount.evaluate(
+    (element) => element.getBoundingClientRect().width
+  );
+  const selectAllWidth = await page
+    .getByRole('button', { name: 'Select All' })
+    .evaluate((button) => button.getBoundingClientRect().width);
+  await page.getByRole('button', { name: 'Select All' }).click();
+  await expect(selectedCount).toHaveText('1');
+  const populatedSelectionWidth = await selectedCount.evaluate(
+    (element) => element.getBoundingClientRect().width
+  );
+  expect(populatedSelectionWidth).toBe(emptySelectionWidth);
+  const clearAllWidth = await page
+    .getByRole('button', { name: 'Clear All' })
+    .evaluate((button) => button.getBoundingClientRect().width);
+  expect(clearAllWidth).toBe(selectAllWidth);
+  await page.getByRole('button', { name: 'Clear All' }).click();
+  await expect(selectedCount).toHaveText('0');
+  await expect(page.getByRole('button', { name: 'Select All' })).toBeVisible();
+  await card.getByText(title, { exact: true }).click();
+
+  await expect(card.getByRole('button', { name: title, exact: true })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+  await expect(card.getByRole('button', { name: `View statistics for ${title}` })).toBeVisible();
+  await expect(card.getByRole('button', { name: `Details for ${title}` })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'View Stats', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Complete', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Delete Stats', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Remove', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Read book' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Book details' })).toHaveCount(0);
+
+  const completeWidth = await page
+    .getByRole('button', { name: 'Complete', exact: true })
+    .evaluate((button) => button.getBoundingClientRect().width);
+  await page.getByRole('button', { name: 'Complete', exact: true }).click();
+  await expect(card.getByRole('progressbar', { name: /Reading progress/ })).toHaveAttribute(
+    'value',
+    '100'
+  );
+
+  const inProgressWidth = await page
+    .getByRole('button', { name: 'In Progress', exact: true })
+    .evaluate((button) => button.getBoundingClientRect().width);
+  expect(inProgressWidth).toBe(completeWidth);
+  await page.getByRole('button', { name: 'In Progress', exact: true }).click();
+  await expect(card.getByRole('progressbar', { name: /Reading progress/ })).toHaveAttribute(
+    'value',
+    '0'
+  );
+
+  await page.getByRole('button', { name: 'Delete Stats', exact: true }).click();
+  const dialog = page.locator('dialog[open]').filter({
+    has: page.getByRole('heading', { name: 'Delete data' })
+  });
+  await expect(dialog).toContainText(`『${title}』`);
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+});
+
 async function selectSort(page: Page, label: string, direction: 'ascending' | 'descending') {
   await page.getByRole('button', { name: /Sort/ }).click();
   await page
@@ -38,7 +176,7 @@ async function selectSort(page: Page, label: string, direction: 'ascending' | 'd
 }
 
 async function expectBookOrder(page: Page, fixtures: LibraryBookFixture[]) {
-  const cards = page.locator('[role="banner"]');
+  const cards = page.locator('article');
   await expect(cards).toHaveCount(fixtures.length);
 
   for (const [index, fixture] of fixtures.entries()) {


### PR DESCRIPTION
Redesigns `/manage` as a quieter, progress-focused shelf. Each book now uses one cover-and-metadata target with an attached progress bar, author when available, stable percentage label, and a selection outline that does not shift the grid.

Adds discoverable per-book actions for reading, statistics, details, local downloads, completion state, statistics deletion, and library removal. The overflow menu carries the full action inventory, destructive actions are separated and confirmed, and book-backup export is removed from the library so that workflow stays in sync settings.

Selection mode now mirrors the applicable per-book operations in the existing toolbar. Fixed-width toggles and uniform header-button mounting prevent the previous staggered transitions and label-driven layout shifts.

Imported EPUB and HTMLZ creator metadata was previously discarded. New imports now parse and persist it, include it in synced and backup book data, and expose it on library cards. Existing library rows remain blank until their original source is re-imported because the old stored form does not retain source metadata. Details use a fixed-width popover with ISO-style timestamps, and source-only books can be downloaded without opening the reader.

Integration coverage exercises direct actions, bulk actions, destructive confirmations, author persistence, stable toolbar widths, and placeholder downloads. The complete 110-test Playwright suite, repository checks, and production build pass.
