### PR TITLE
fix: respect PORT for development server

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,5 +1,6 @@
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
+import process from 'node:process';
 import generateIcons from './scripts/generate-icons.mjs';
 
 /** @returns {import('vite').Plugin} */
@@ -13,6 +14,12 @@ function iconsPlugin() {
 /** @type {import('vite').UserConfig} */
 const config = {
   plugins: [iconsPlugin(), tailwindcss(), sveltekit()],
+  server: process.env.PORT
+    ? {
+        port: Number(process.env.PORT),
+        strictPort: true
+      }
+    : undefined,
   ssr: {
     // https://github.com/FortAwesome/Font-Awesome/issues/18677
     noExternal: ['@fortawesome/*', '@popperjs/*']


### PR DESCRIPTION
Configure Vite to use the externally supplied `PORT` and fail rather than silently choosing a different port.