### PR TITLE
Make route navigation use native links

### DIFF
--- a/src/lib/components/book-card/book-card-actions.svelte
+++ b/src/lib/components/book-card/book-card-actions.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
+  import type { ResolvedPathname } from '$app/types';
   import {
     faBookOpen,
     faCalendarXmark,
@@ -10,29 +12,21 @@
   } from '@fortawesome/free-solid-svg-icons';
   import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
+  import { getBookStatisticsURL } from '$lib/components/statistics/statistics-view';
   import Popover from '$lib/components/popover/popover.svelte';
+  import { getBookURL } from '$lib/functions/book-url';
   import { getDateTimeString } from '$lib/functions/statistic-util';
   import Fa from 'svelte-fa';
 
   interface Props {
     bookCard: BookCardProps;
-    onread?: (data: { title: string }) => void | Promise<void>;
-    onstatistics?: (data: { title: string }) => void | Promise<void>;
     ondownload?: (data: { title: string }) => void | Promise<void>;
     oncomplete?: (data: { title: string; completed: boolean }) => void | Promise<void>;
     ondeletestatistics?: (data: { title: string }) => void | Promise<void>;
     onremove?: (data: { title: string }) => void | Promise<void>;
   }
 
-  let {
-    bookCard,
-    onread,
-    onstatistics,
-    ondownload,
-    oncomplete,
-    ondeletestatistics,
-    onremove
-  }: Props = $props();
+  let { bookCard, ondownload, oncomplete, ondeletestatistics, onremove }: Props = $props();
 
   let detailsPopover = $state<Popover>();
   let morePopover = $state<Popover>();
@@ -66,45 +60,76 @@
   icon: IconDefinition,
   label: string,
   ariaLabel: string,
-  action?: () => void | Promise<void>,
+  action: { href: ResolvedPathname } | { href?: never; onClick?: () => void | Promise<void> },
   fullWidth = false
 )}
-  <button
-    type="button"
-    class={`${actionButtonClasses} ${fullWidth ? 'w-full' : ''}`}
-    aria-label={ariaLabel}
-    onclick={() => action?.()}
-  >
-    <Fa {icon} />
-    <span>{label}</span>
-  </button>
+  {#if action.href !== undefined}
+    <!-- Destinations are resolved by the caller before reaching this snippet. -->
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+    <a
+      class={`${actionButtonClasses} ${fullWidth ? 'w-full' : ''}`}
+      aria-label={ariaLabel}
+      href={action.href}
+    >
+      <Fa {icon} />
+      <span>{label}</span>
+    </a>
+  {:else}
+    <button
+      type="button"
+      class={`${actionButtonClasses} ${fullWidth ? 'w-full' : ''}`}
+      aria-label={ariaLabel}
+      onclick={() => action.onClick?.()}
+    >
+      <Fa {icon} />
+      <span>{label}</span>
+    </button>
+  {/if}
 {/snippet}
 
 {#snippet menuAction(
   icon: IconDefinition,
   label: string,
-  action: () => void | Promise<void>,
+  action: { href: ResolvedPathname } | { href?: never; onClick: () => void | Promise<void> },
   danger = false
 )}
-  <button
-    type="button"
-    class={`${menuButtonClasses} ${danger ? 'text-red-300 hover:text-red-700' : ''}`}
-    onclick={() => runMenuAction(action)}
-  >
-    <Fa {icon} />
-    <span>{label}</span>
-  </button>
+  {#if action.href !== undefined}
+    <!-- Close the popover on activation like the button items; on a plain click the ensuing
+      navigation unmounts it anyway, but a modified click stays on this page. -->
+    <!-- Destinations are resolved by the caller before reaching this snippet. -->
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+    <a
+      class={`${menuButtonClasses} ${danger ? 'text-red-300 hover:text-red-700' : ''}`}
+      href={action.href}
+      onclick={() => morePopover?.toggleOpen()}
+      onauxclick={(event) => {
+        if (event.button === 1) morePopover?.toggleOpen();
+      }}
+    >
+      <Fa {icon} />
+      <span>{label}</span>
+    </a>
+  {:else}
+    <button
+      type="button"
+      class={`${menuButtonClasses} ${danger ? 'text-red-300 hover:text-red-700' : ''}`}
+      onclick={() => runMenuAction(action.onClick)}
+    >
+      <Fa {icon} />
+      <span>{label}</span>
+    </button>
+  {/if}
 {/snippet}
 
 <div class="mt-2.5 grid grid-cols-[1fr_1fr_auto] gap-1">
-  {@render cardAction(faChartLine, 'Stats', `View statistics for ${bookCard.title}`, () =>
-    onstatistics?.({ title: bookCard.title })
-  )}
+  {@render cardAction(faChartLine, 'Stats', `View statistics for ${bookCard.title}`, {
+    href: resolve(getBookStatisticsURL(bookCard.title))
+  })}
 
   {#if bookCard.isPlaceholder}
-    {@render cardAction(faDownload, 'Download', `Download ${bookCard.title}`, () =>
-      ondownload?.({ title: bookCard.title })
-    )}
+    {@render cardAction(faDownload, 'Download', `Download ${bookCard.title}`, {
+      onClick: () => ondownload?.({ title: bookCard.title })
+    })}
   {:else}
     <Popover
       bind:this={detailsPopover}
@@ -113,13 +138,7 @@
       yOffset={5}
     >
       {#snippet icon()}
-        {@render cardAction(
-          faCircleInfo,
-          'Details',
-          `Details for ${bookCard.title}`,
-          undefined,
-          true
-        )}
+        {@render cardAction(faCircleInfo, 'Details', `Details for ${bookCard.title}`, {}, true)}
       {/snippet}
       {#snippet content()}
         <div class="w-80 max-w-[calc(100vw-2rem)] p-4 font-normal">
@@ -153,34 +172,38 @@
     {#snippet content()}
       <div class="inline-flex min-w-56 flex-col py-2">
         <div class="max-w-72 truncate px-4 pb-2 text-xs font-medium">{bookCard.title}</div>
-        {@render menuAction(faBookOpen, 'Read book', () => onread?.({ title: bookCard.title }))}
-        {@render menuAction(faChartLine, 'View statistics', () =>
-          onstatistics?.({ title: bookCard.title })
-        )}
+        {@render menuAction(faBookOpen, 'Read book', { href: resolve(getBookURL(bookCard.title)) })}
+        {@render menuAction(faChartLine, 'View statistics', {
+          href: resolve(getBookStatisticsURL(bookCard.title))
+        })}
         {@render menuAction(
           faFlag,
           bookCard.completed ? 'Mark as in progress' : 'Mark as complete',
-          () => oncomplete?.({ title: bookCard.title, completed: !bookCard.completed })
+          {
+            onClick: () => oncomplete?.({ title: bookCard.title, completed: !bookCard.completed })
+          }
         )}
         {#if !bookCard.isPlaceholder}
-          {@render menuAction(faCircleInfo, 'Book details', () => detailsPopover?.toggleOpen())}
+          {@render menuAction(faCircleInfo, 'Book details', {
+            onClick: () => detailsPopover?.toggleOpen()
+          })}
         {/if}
 
         {#if bookCard.isPlaceholder}
           <hr class="mx-4 my-1 border-white/20" />
-          {@render menuAction(faDownload, 'Download to this device', () =>
-            ondownload?.({ title: bookCard.title })
-          )}
+          {@render menuAction(faDownload, 'Download to this device', {
+            onClick: () => ondownload?.({ title: bookCard.title })
+          })}
         {/if}
 
         <hr class="mx-4 my-1 border-white/20" />
-        {@render menuAction(faCalendarXmark, 'Delete statistics', () =>
-          ondeletestatistics?.({ title: bookCard.title })
-        )}
+        {@render menuAction(faCalendarXmark, 'Delete statistics', {
+          onClick: () => ondeletestatistics?.({ title: bookCard.title })
+        })}
         {@render menuAction(
           faTrash,
           'Remove from library',
-          () => onremove?.({ title: bookCard.title }),
+          { onClick: () => onremove?.({ title: bookCard.title }) },
           true
         )}
       </div>

--- a/src/lib/components/book-card/book-card-list.svelte
+++ b/src/lib/components/book-card/book-card-list.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import BookCardActions from '$lib/components/book-card/book-card-actions.svelte';
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
   import BookCard from '$lib/components/book-card/book-card.svelte';
   import { syncState } from '$lib/data/sync/sync-store.svelte';
+  import { getBookURL } from '$lib/functions/book-url';
 
   interface Props {
     bookCards?: BookCardProps[];
     currentBookTitle?: string | undefined;
     selectedBookTitles: ReadonlySet<string>;
     selectMode?: boolean;
-    onbookClick?: (data: { title: string }) => void | Promise<void>;
-    onreadBookClick?: (data: { title: string }) => void | Promise<void>;
-    onstatisticsClick?: (data: { title: string }) => void | Promise<void>;
+    onbookSelect?: (data: { title: string }) => void;
     ondownloadBookClick?: (data: { title: string }) => void | Promise<void>;
     oncompleteBookClick?: (data: { title: string; completed: boolean }) => void | Promise<void>;
     ondeleteStatisticsClick?: (data: { title: string }) => void | Promise<void>;
@@ -23,9 +23,7 @@
     currentBookTitle,
     selectedBookTitles,
     selectMode = false,
-    onbookClick,
-    onreadBookClick,
-    onstatisticsClick,
+    onbookSelect,
     ondownloadBookClick,
     oncompleteBookClick,
     ondeleteStatisticsClick,
@@ -37,24 +35,45 @@
       ? 'Not downloaded yet — open or download the book to copy it from your local sync folder'
       : 'Not downloaded yet — open or download the book to fetch it from its sync location'
   );
+
+  const hitTargetClasses = 'absolute inset-0 z-1 rounded-sm';
 </script>
 
 <div class="grid grid-cols-2 gap-x-5 gap-y-9 pb-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
   {#each bookCards as bookCard (bookCard.title)}
+    {@const isSelected = selectMode && selectedBookTitles.has(bookCard.title)}
     <article class="relative min-w-0">
-      <BookCard
-        {...bookCard}
-        current={bookCard.title === currentBookTitle}
-        selected={selectedBookTitles.has(bookCard.title)}
-        selectionMode={selectMode}
-        tooltip={bookCard.isPlaceholder ? placeholderTooltip : undefined}
-        onclick={() => onbookClick?.({ title: bookCard.title })}
-      />
+      <div class="group relative min-w-0 rounded-sm">
+        <BookCard
+          {...bookCard}
+          current={bookCard.title === currentBookTitle}
+          selected={isSelected}
+        />
+
+        {#if selectMode}
+          <button
+            type="button"
+            class={hitTargetClasses}
+            class:outline-2={isSelected}
+            class:outline-offset-4={isSelected}
+            class:outline-blue-400={isSelected}
+            title={bookCard.isPlaceholder ? placeholderTooltip : undefined}
+            aria-label={bookCard.title}
+            aria-pressed={isSelected}
+            onclick={() => onbookSelect?.({ title: bookCard.title })}
+          ></button>
+        {:else}
+          <a
+            class={hitTargetClasses}
+            title={bookCard.isPlaceholder ? placeholderTooltip : undefined}
+            aria-label={bookCard.title}
+            href={resolve(getBookURL(bookCard.title))}
+          ></a>
+        {/if}
+      </div>
 
       <BookCardActions
         {bookCard}
-        onread={onreadBookClick}
-        onstatistics={onstatisticsClick}
         ondownload={ondownloadBookClick}
         oncomplete={oncompleteBookClick}
         ondeletestatistics={ondeleteStatisticsClick}

--- a/src/lib/components/book-card/book-card.svelte
+++ b/src/lib/components/book-card/book-card.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { faImage } from '@fortawesome/free-regular-svg-icons';
   import { onDestroy } from 'svelte';
-  import type { MouseEventHandler } from 'svelte/elements';
   import Fa from 'svelte-fa';
   import { japaneseLangIfNeeded } from '$lib/functions/japanese-language';
 
@@ -14,9 +13,6 @@
     current?: boolean;
     isPlaceholder?: boolean;
     selected?: boolean;
-    selectionMode?: boolean;
-    tooltip?: string;
-    onclick?: MouseEventHandler<HTMLButtonElement>;
   }
 
   let {
@@ -27,10 +23,7 @@
     completed,
     current = false,
     isPlaceholder = false,
-    selected = false,
-    selectionMode = false,
-    tooltip,
-    onclick
+    selected = false
   }: Props = $props();
 
   let objectURL = '';
@@ -77,68 +70,56 @@
   let progressPercentage = $derived(completed ? 100 : Math.round(progress * 100));
 </script>
 
-<button
-  type="button"
-  class="block w-full min-w-0 rounded-sm text-left"
-  class:outline-2={selected}
-  class:outline-offset-4={selected}
-  class:outline-blue-400={selected}
-  title={tooltip}
-  aria-label={title}
-  aria-pressed={selectionMode ? selected : undefined}
-  {onclick}
+<span
+  class="mdc-elevation--z1 hover:mdc-elevation--z8 group-hover:mdc-elevation--z8 mdc-elevation-transition relative block aspect-2/3 w-full overflow-hidden text-5xl sm:text-7xl"
+  class:rounded-tl-xl={current}
+  class:mdc-elevation--z4={selected || current}
+  class:opacity-60={isPlaceholder}
 >
-  <span
-    class="mdc-elevation--z1 hover:mdc-elevation--z8 mdc-elevation-transition relative block aspect-2/3 w-full overflow-hidden text-5xl sm:text-7xl"
-    class:rounded-tl-xl={current}
-    class:mdc-elevation--z4={selected || current}
-    class:opacity-60={isPlaceholder}
-  >
-    {#if imageLoading}
-      <Fa class="absolute top-1/2 left-1/2 -translate-1/2" icon={faImage} />
-    {/if}
+  {#if imageLoading}
+    <Fa class="absolute top-1/2 left-1/2 -translate-1/2" icon={faImage} />
+  {/if}
 
-    {#if imagePath}
-      <img
-        decoding="async"
-        loading="lazy"
-        referrerpolicy="no-referrer"
-        class="book-cover relative size-full object-cover transition delay-150 duration-700 ease-out"
-        class:blur={imageLoading}
-        src={mapImagePath(imagePath)}
-        alt=""
-        onload={() => (imageLoading = false)}
-        onerror={() => (imageLoading = false)}
-      />
-    {/if}
+  {#if imagePath}
+    <img
+      decoding="async"
+      loading="lazy"
+      referrerpolicy="no-referrer"
+      class="book-cover relative size-full object-cover transition delay-150 duration-700 ease-out"
+      class:blur={imageLoading}
+      src={mapImagePath(imagePath)}
+      alt=""
+      onload={() => (imageLoading = false)}
+      onerror={() => (imageLoading = false)}
+    />
+  {/if}
 
-    <progress
-      class="reading-progress"
-      class:completed
-      aria-label={`Reading progress for ${title}`}
-      value={progressPercentage}
-      max="100"
-    ></progress>
-  </span>
+  <progress
+    class="reading-progress"
+    class:completed
+    aria-label={`Reading progress for ${title}`}
+    value={progressPercentage}
+    max="100"
+  ></progress>
+</span>
 
-  <span
-    class="mt-3 grid h-14.5 min-w-0 grid-cols-[minmax(0,1fr)_2rem] items-start gap-2 overflow-hidden"
-  >
-    <span class="min-w-0">
-      <span class="line-clamp-2 text-sm font-medium" lang={titleLanguage}>{title}</span>
-      <span class="mt-0.5 block truncate text-xs text-gray-500" lang={authorLanguage}>
-        {author}
-      </span>
-    </span>
-    <span
-      class="pt-0.5 text-right text-xs font-medium tabular-nums"
-      class:text-emerald-700={completed}
-      class:text-blue-700={!completed}
-    >
-      {progressPercentage}%
+<span
+  class="mt-3 grid h-14.5 min-w-0 grid-cols-[minmax(0,1fr)_2rem] items-start gap-2 overflow-hidden"
+>
+  <span class="min-w-0">
+    <span class="line-clamp-2 text-sm font-medium" lang={titleLanguage}>{title}</span>
+    <span class="mt-0.5 block truncate text-xs text-gray-500" lang={authorLanguage}>
+      {author}
     </span>
   </span>
-</button>
+  <span
+    class="pt-0.5 text-right text-xs font-medium tabular-nums"
+    class:text-emerald-700={completed}
+    class:text-blue-700={!completed}
+  >
+    {progressPercentage}%
+  </span>
+</span>
 
 <style>
   .reading-progress {

--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { browser } from '$app/environment';
+  import type { ResolvedPathname } from '$app/types';
   import HeaderButton from '$lib/components/header-button.svelte';
   import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
@@ -45,8 +46,8 @@
     replicationProgressRemaining: string;
     cancelTooltip: string;
     fileCountData?: Record<string, number>;
+    statisticsHref?: ResolvedPathname;
     onselectAllClick?: () => void;
-    onviewStatistics?: () => void | Promise<void>;
     oncompletionChange?: (completed: boolean) => void | Promise<void>;
     ondownloadClick?: () => void | Promise<void>;
     onremoveClick?: () => void;
@@ -67,8 +68,8 @@
     replicationProgressRemaining,
     cancelTooltip,
     fileCountData = $bindable(),
+    statisticsHref,
     onselectAllClick,
-    onviewStatistics,
     oncompletionChange,
     ondownloadClick,
     onremoveClick,
@@ -205,12 +206,14 @@
           </HeaderButton>
           {#if selectedCount > 0}
             <div class={headerDividerClasses}></div>
-            <HeaderButton
-              faIcon={faChartLine}
-              title="View statistics for selected books"
-              label="View Stats"
-              onclick={() => onviewStatistics?.()}
-            />
+            {#if statisticsHref}
+              <HeaderButton
+                faIcon={faChartLine}
+                title="View statistics for selected books"
+                label="View Stats"
+                href={statisticsHref}
+              />
+            {/if}
             <HeaderButton
               faIcon={faFlag}
               title={allSelectedBooksCompleted

--- a/src/lib/components/book-reader/book-reader-header.svelte
+++ b/src/lib/components/book-reader/book-reader-header.svelte
@@ -20,6 +20,7 @@
   import { ViewMode } from '$lib/data/view-mode';
 
   interface Props {
+    currentBookTitle?: string;
     hasChapterData: boolean;
     hasText: boolean;
     autoScrollMultiplier: number;
@@ -38,13 +39,11 @@
     onshowCustomReadingPoint?: () => void;
     onsetCustomReadingPoint?: () => void;
     onresetCustomReadingPoint?: () => void;
-    onstatisticsClick?: () => void;
     onreaderImageGalleryClick?: () => void;
-    onsettingsClick?: () => void;
-    onbookManagerClick?: () => void;
   }
 
   let {
+    currentBookTitle,
     hasChapterData,
     hasText,
     autoScrollMultiplier,
@@ -63,10 +62,7 @@
     onshowCustomReadingPoint,
     onsetCustomReadingPoint,
     onresetCustomReadingPoint,
-    onstatisticsClick,
-    onreaderImageGalleryClick,
-    onsettingsClick,
-    onbookManagerClick
+    onreaderImageGalleryClick
   }: Props = $props();
 
   let customReadingPointMenuItems = $derived([
@@ -148,13 +144,6 @@
       />
       <div class={headerDividerClasses}></div>
     {/if}
-    <HeaderNavTabs
-      disableNavigation
-      onnavigate={(routeId) => {
-        if (routeId === '/statistics') onstatisticsClick?.();
-        else if (routeId === '/settings') onsettingsClick?.();
-        else if (routeId === '/manage') onbookManagerClick?.();
-      }}
-    />
+    <HeaderNavTabs {currentBookTitle} />
   </div>
 </div>

--- a/src/lib/components/bottom-left-cluster.svelte
+++ b/src/lib/components/bottom-left-cluster.svelte
@@ -2,9 +2,9 @@
   // Bottom-left controls cluster — always shows the sync status pill;
   // in reader mode, stacks a play/pause and a stats-menu button above
   // it. The sync pill stays anchored in the lower-left corner across every route so users always know where to find it.
-  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
+  import type { Snippet } from 'svelte';
   import Fa from 'svelte-fa';
   import {
     faArrowsRotate,
@@ -112,10 +112,20 @@
     isReaderRoute && $statisticsEnabled$ && trackerStatus.available
   );
 
-  async function onSyncClick() {
-    if (!syncClickable) return;
+  function isPlainPrimaryClick(event: MouseEvent) {
+    return (
+      event.button === 0 && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey
+    );
+  }
+
+  async function onSyncClick(event: MouseEvent) {
     const location = syncState.location;
-    if (syncState.health.status === 'reauth-required' && location?.kind === 'cloud') {
+    if (
+      isPlainPrimaryClick(event) &&
+      syncState.health.status === 'reauth-required' &&
+      location?.kind === 'cloud'
+    ) {
+      event.preventDefault();
       reconnecting = true;
       try {
         await connectCloud(location.provider, {
@@ -127,13 +137,7 @@
       } finally {
         reconnecting = false;
       }
-      return;
     }
-    await goto(
-      indicator.kind === 'off'
-        ? resolve('/settings/sync#sync-direction')
-        : resolve('/settings/sync')
-    );
   }
 
   // The hit target size comes from the shared sync-indicator CSS variables.
@@ -142,17 +146,7 @@
     'sync-indicator-size flex items-center justify-center rounded-full text-base transition-colors hover:bg-black/5 sm:text-lg';
 </script>
 
-{#snippet clusterButton(
-  label: string,
-  icon: IconDefinition,
-  opts: {
-    onClick: () => void;
-    clickable?: boolean;
-    colorClass?: string;
-    spin?: boolean;
-  }
-)}
-  {@const clickable = opts.clickable ?? true}
+{#snippet clusterPopover(label: string, control: Snippet)}
   <Popover
     eventType="pointer"
     placement="right"
@@ -161,37 +155,55 @@
     contentStyles="padding: 0.4rem 0.6rem; font-size: 0.75rem; font-weight: 500;"
   >
     {#snippet content()}{label}{/snippet}
-    <button
-      type="button"
-      aria-label={label}
-      class="{buttonClass} {opts.colorClass ?? ''}"
-      class:cursor-pointer={clickable}
-      class:cursor-default={!clickable}
-      onclick={opts.onClick}
-      tabindex={clickable ? 0 : -1}
-    >
-      <Fa {icon} class={opts.spin ? 'animate-spin' : ''} />
-    </button>
+    {@render control()}
   </Popover>
 {/snippet}
 
+{#snippet actionButton(label: string, icon: IconDefinition, onClick: (event: MouseEvent) => void)}
+  {#snippet control()}
+    <button
+      type="button"
+      aria-label={label}
+      class="{buttonClass} cursor-pointer text-gray-600"
+      onclick={onClick}
+    >
+      <Fa {icon} />
+    </button>
+  {/snippet}
+  {@render clusterPopover(label, control)}
+{/snippet}
+
+{#snippet syncControl()}
+  {#if syncClickable}
+    <a
+      aria-label={syncLabel}
+      class="{buttonClass} {wrapperVariantClasses[indicator.kind]} cursor-pointer"
+      href={resolve(indicator.kind === 'off' ? '/settings/sync#sync-direction' : '/settings/sync')}
+      onclick={onSyncClick}
+    >
+      <Fa icon={icons[indicator.kind]} />
+    </a>
+  {:else}
+    <button
+      type="button"
+      aria-label={syncLabel}
+      class="{buttonClass} {wrapperVariantClasses[indicator.kind]} cursor-default"
+      tabindex={-1}
+    >
+      <Fa icon={icons[indicator.kind]} class={indicator.kind === 'syncing' ? 'animate-spin' : ''} />
+    </button>
+  {/if}
+{/snippet}
+
 <div class="sync-indicator-inset writing-horizontal-tb fixed z-40 flex flex-col-reverse gap-2">
-  {@render clusterButton(syncLabel, icons[indicator.kind], {
-    onClick: onSyncClick,
-    clickable: syncClickable,
-    colorClass: wrapperVariantClasses[indicator.kind],
-    spin: indicator.kind === 'syncing'
-  })}
+  {@render clusterPopover(syncLabel, syncControl)}
 
   {#if showTrackerButtons}
-    {@render clusterButton(
+    {@render actionButton(
       trackerStatus.paused ? 'Resume reading tracker' : 'Pause reading tracker',
       trackerStatus.paused ? faPlay : faPause,
-      { onClick: toggleTrackerPauseByUser, colorClass: 'text-gray-600' }
+      toggleTrackerPauseByUser
     )}
-    {@render clusterButton('Open reading statistics', faChartBar, {
-      onClick: openTrackerMenu,
-      colorClass: 'text-gray-600'
-    })}
+    {@render actionButton('Open reading statistics', faChartBar, openTrackerMenu)}
   {/if}
 </div>

--- a/src/lib/components/header-button.svelte
+++ b/src/lib/components/header-button.svelte
@@ -1,24 +1,28 @@
 <script lang="ts">
+  import type { ResolvedPathname } from '$app/types';
   import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
   import { ripple } from '$lib/components/ripple';
-  import type { MouseEventHandler } from 'svelte/elements';
   import type { Snippet } from 'svelte';
   import Fa from 'svelte-fa';
 
   type Variant = 'action' | 'tab';
   type Width = 'default' | 'wide';
 
-  interface Props {
+  interface CommonProps {
     faIcon?: IconDefinition;
     label?: string;
     title?: string;
-    disabled?: boolean;
     selected?: boolean;
     variant?: Variant;
     width?: Width;
-    onclick?: MouseEventHandler<HTMLButtonElement>;
     icon?: Snippet;
   }
+
+  type Props = CommonProps &
+    (
+      | { href: ResolvedPathname; disabled?: never; onclick?: never }
+      | { href?: undefined; disabled?: boolean; onclick?: (event: MouseEvent) => void }
+    );
 
   let {
     faIcon,
@@ -28,6 +32,7 @@
     selected = false,
     variant = 'action',
     width = 'default',
+    href,
     onclick,
     icon
   }: Props = $props();
@@ -42,23 +47,24 @@
     default: '',
     wide: 'w-20 shrink-0'
   } satisfies Record<Width, string>;
+
+  let classes = $derived(
+    [
+      'flex h-12 min-w-16 flex-col items-center justify-center px-2 text-center text-xs select-none',
+      variantClasses[variant],
+      widthClasses[width],
+      variant === 'action' && selected ? 'opacity-100' : '',
+      variant === 'tab' && selected ? 'bg-gray-900 hover:bg-gray-800' : '',
+      variant === 'tab' && !selected ? 'hover:bg-gray-900' : '',
+      variant === 'action' && !disabled ? 'hover:opacity-100' : '',
+      disabled ? 'cursor-not-allowed opacity-30' : ''
+    ]
+      .filter(Boolean)
+      .join(' ')
+  );
 </script>
 
-<button
-  use:ripple
-  type="button"
-  {title}
-  {disabled}
-  class={`flex h-12 min-w-16 flex-col items-center justify-center px-2 text-center text-xs select-none ${variantClasses[variant]} ${widthClasses[width]}`}
-  class:opacity-100={variant === 'action' && selected}
-  class:bg-gray-900={variant === 'tab' && selected}
-  class:hover:bg-gray-800={variant === 'tab' && selected}
-  class:hover:bg-gray-900={variant === 'tab' && !selected}
-  class:hover:opacity-100={variant === 'action' && !disabled}
-  class:cursor-not-allowed={disabled}
-  class:opacity-30={disabled}
-  {onclick}
->
+{#snippet content()}
   {#if icon}
     <span class={iconClasses}>
       {@render icon()}
@@ -70,4 +76,16 @@
   {#if label}
     <span>{label}</span>
   {/if}
-</button>
+{/snippet}
+
+{#if href !== undefined}
+  <!-- Internal destinations are resolved by the caller before reaching this renderer. -->
+  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+  <a use:ripple {href} {title} class={classes} aria-current={selected ? 'page' : undefined}>
+    {@render content()}
+  </a>
+{:else}
+  <button use:ripple type="button" {title} {disabled} class={classes} {onclick}>
+    {@render content()}
+  </button>
+{/if}

--- a/src/lib/components/header-nav-tabs.svelte
+++ b/src/lib/components/header-nav-tabs.svelte
@@ -1,23 +1,21 @@
 <script lang="ts">
   import type { RouteId } from '$app/types';
-  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { faBookOpen, faChartLine, faCog, faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
   import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
   import HeaderButton from '$lib/components/header-button.svelte';
+  import { getBookStatisticsURL } from '$lib/components/statistics/statistics-view';
   import { database } from '$lib/data/store';
+  import { getBookURL } from '$lib/functions/book-url';
 
   type HeaderRouteId = Extract<RouteId, '/b' | '/statistics' | '/settings' | '/manage'>;
-  type HeaderRouteWithQuery = HeaderRouteId | `${HeaderRouteId}?${string}`;
-  type QueryString = `?${string}` | '';
 
   interface Props {
-    disableNavigation?: boolean;
-    onnavigate?: (routeId: HeaderRouteId) => void;
+    currentBookTitle?: string;
   }
 
-  let { disableNavigation = false, onnavigate }: Props = $props();
+  let { currentBookTitle }: Props = $props();
 
   const tabs = [
     { routeId: '/statistics', label: 'Statistics', icon: faChartLine },
@@ -29,16 +27,12 @@
     return page.route.id === routeId || page.route.id?.startsWith(`${routeId}/`);
   }
 
-  function handleClick(routeId: HeaderRouteId, query: QueryString = '') {
-    onnavigate?.(routeId);
-
-    if (!disableNavigation) {
-      goto(resolve(getRouteWithQuery(routeId, query)));
+  function getTabHref(routeId: HeaderRouteId) {
+    if (routeId === '/statistics' && page.route.id === '/b' && currentBookTitle) {
+      return getBookStatisticsURL(currentBookTitle);
     }
-  }
 
-  function getRouteWithQuery(routeId: HeaderRouteId, query: QueryString): HeaderRouteWithQuery {
-    return query ? `${routeId}${query}` : routeId;
+    return routeId;
   }
 </script>
 
@@ -48,7 +42,7 @@
     label="Book"
     selected={page.route.id === '/b'}
     variant="tab"
-    onclick={() => handleClick('/b', `?${new URLSearchParams({ t: database.lastItemTitle! })}`)}
+    href={resolve(getBookURL(database.lastItemTitle))}
   />
 {/if}
 {#each tabs as tab (tab.routeId)}
@@ -57,6 +51,6 @@
     label={tab.label}
     selected={isSelectedRoute(tab.routeId)}
     variant="tab"
-    onclick={() => handleClick(tab.routeId)}
+    href={resolve(getTabHref(tab.routeId))}
   />
 {/each}

--- a/src/lib/components/ripple.ts
+++ b/src/lib/components/ripple.ts
@@ -57,9 +57,18 @@ function setOverlayVisible(overlay: HTMLElement, visible: boolean) {
   overlay.style.opacity = visible ? (overlay.dataset.rippleOpacity ?? '0') : '0';
 }
 
+function addPaintContainment(contain: string) {
+  if (contain === 'strict' || contain === 'content' || contain.split(' ').includes('paint')) {
+    return contain;
+  }
+
+  return contain === 'none' ? 'paint' : `${contain} paint`;
+}
+
 export function ripple(node: HTMLElement) {
-  const hadRelativeClass = node.classList.contains('relative');
-  const hadOverflowHiddenClass = node.classList.contains('overflow-hidden');
+  const originalContain = node.style.getPropertyValue('contain');
+  const originalContainPriority = node.style.getPropertyPriority('contain');
+  const computedContain = getComputedStyle(node).contain;
   const surface = createSurface();
   const holdOverlay = createOverlay(0.25);
   const focusOverlay = createOverlay(0.1);
@@ -67,7 +76,7 @@ export function ripple(node: HTMLElement) {
   let hold = false;
   let focus = false;
 
-  node.classList.add('relative', 'overflow-hidden');
+  node.style.setProperty('contain', addPaintContainment(computedContain), originalContainPriority);
   surface.append(holdOverlay, focusOverlay);
   node.append(surface);
 
@@ -172,14 +181,7 @@ export function ripple(node: HTMLElement) {
       node.removeEventListener('touchcancel', handleTouchEnd);
 
       surface.remove();
-
-      if (!hadRelativeClass) {
-        node.classList.remove('relative');
-      }
-
-      if (!hadOverflowHiddenClass) {
-        node.classList.remove('overflow-hidden');
-      }
+      node.style.setProperty('contain', originalContain, originalContainPriority);
     }
   };
 }

--- a/src/lib/components/settings/settings-header.svelte
+++ b/src/lib/components/settings/settings-header.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import type { RouteId } from '$app/types';
   import { faBookOpenReader, faClock, faCloudArrowUp } from '@fortawesome/free-solid-svg-icons';
   import HeaderButton from '$lib/components/header-button.svelte';
@@ -8,7 +9,6 @@
 
   interface Props {
     activeRouteId?: RouteId | null;
-    onselect?: (href: SettingsRoute) => void;
   }
 
   interface SettingItem {
@@ -17,7 +17,7 @@
     icon: typeof faBookOpenReader;
   }
 
-  let { activeRouteId, onselect }: Props = $props();
+  let { activeRouteId }: Props = $props();
 
   const settingItems: SettingItem[] = [
     {
@@ -40,14 +40,14 @@
 
 <div class={baseHeaderClasses}>
   <div class="flex h-full justify-between">
-    <div class="flex">
+    <div class="flex" data-sveltekit-keepfocus data-sveltekit-noscroll>
       {#each settingItems as settingItem (settingItem.label)}
         <HeaderButton
           faIcon={settingItem.icon}
           label={settingItem.label}
           selected={activeRouteId === settingItem.href}
           variant="tab"
-          onclick={() => onselect?.(settingItem.href)}
+          href={resolve(settingItem.href)}
         />
       {/each}
     </div>

--- a/src/lib/components/statistics/statistics-header.svelte
+++ b/src/lib/components/statistics/statistics-header.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { ResolvedPathname } from '$app/types';
   import {
     faCalendarDays,
     faCopy,
@@ -22,7 +23,8 @@
     oncopydata: (dataKey: keyof BookStatistic) => void;
     onopenfilter: () => void;
     onopensettings: () => void;
-    onselecttab: (view: StatisticsView) => void;
+    summaryHref: ResolvedPathname;
+    heatmapHref: ResolvedPathname;
   }
 
   let {
@@ -31,7 +33,8 @@
     oncopydata,
     onopenfilter,
     onopensettings,
-    onselecttab
+    summaryHref,
+    heatmapHref
   }: Props = $props();
 
   const copyStatisticsDataItems: StatisticsDataSource[] = [
@@ -46,14 +49,14 @@
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
   <div class={baseHeaderClasses}>
     <div class="flex h-full justify-between">
-      <div class="flex">
+      <div class="flex" data-sveltekit-keepfocus data-sveltekit-noscroll>
         <HeaderButton
           faIcon={faCalendarDays}
           label="Summary"
           selected={summarySelected}
           variant="tab"
           title={summarySelected ? undefined : 'Switch to Summary tab'}
-          onclick={() => onselecttab('summary')}
+          href={summaryHref}
         />
         <HeaderButton
           faIcon={faMap}
@@ -61,7 +64,7 @@
           selected={heatmapSelected}
           variant="tab"
           title={heatmapSelected ? undefined : 'Switch to Heatmap tab'}
-          onclick={() => onselecttab('heatmap')}
+          href={heatmapHref}
         />
         <div class={headerDividerClasses}></div>
         <HeaderButton

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { page } from '$app/state';
-  import { goto } from '$app/navigation';
+  import { beforeNavigate, goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import type { RouteId } from '$app/types';
+  import type { BeforeNavigate } from '@sveltejs/kit';
   import { faSpinner } from '@fortawesome/free-solid-svg-icons';
   import { BookReaderController } from '$lib/components/book-reader/book-reader-controller.svelte';
   import BookReader from '$lib/components/book-reader/book-reader.svelte';
@@ -77,7 +77,6 @@
   import { showNumberDialog } from '$lib/components/number-dialog.svelte';
   import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
   import SidebarOverlay from '$lib/components/sidebar-overlay.svelte';
-  import { getBookStatisticsURL } from '$lib/components/statistics/statistics-view';
   import {
     type BooksDbBookData,
     type BooksDbBookmarkData,
@@ -127,8 +126,6 @@
     getReferencePoints,
     pulseElement
   } from '$lib/functions/range-util';
-
-  type ReaderExitRoute = Extract<RouteId, '/manage' | '/settings' | '/statistics'>;
 
   const READER_STATISTICS_SYNC_THROTTLE_MS = 60_000;
   const trackerMenuFitsBesideReader = new MediaQuery('min-width: 900px');
@@ -180,6 +177,51 @@
   let hasLegacyBookId = $derived(browser && page.url.searchParams.has('id'));
   let rawBookData = $state<BooksDbBookData>();
   let bookData = $state<LoadedBookData>();
+  // Async exit work cancels the first navigation and stores its target here so only the exact
+  // replay may bypass the guard. Consumed by every navigation (and expired on a timer when a
+  // popstate replay never fires) so a stale value can't exempt a later, unrelated exit.
+  let allowedNavigationURL: string | undefined;
+
+  beforeNavigate((navigation) => {
+    const destination = navigation.to;
+    const pendingExitHref = allowedNavigationURL;
+    allowedNavigationURL = undefined;
+
+    if (navigation.willUnload || !destination) {
+      return;
+    }
+
+    if (destination.route.id === '/b' && destination.url.searchParams.get('t') === bookTitle) {
+      // The reader header's own Book tab links to the current URL; suppress that no-op
+      // navigation so SvelteKit doesn't scroll a continuous-mode reader back to the top.
+      if (navigation.type === 'link' && navigation.from?.url.href === destination.url.href) {
+        navigation.cancel();
+      }
+      return;
+    }
+
+    if (!rawBookData) {
+      // Nothing to save while the book is still loading, but the user leaving for the library
+      // or home must still clear the last-item record — the home route otherwise redirects
+      // straight back into the abandoned book. Internal `goto` bounces (e.g. a failed load
+      // returning to the manager) keep the record so the previous book stays reachable.
+      if (
+        navigation.type !== 'goto' &&
+        (destination.route.id === '/' || destination.route.id === '/manage')
+      ) {
+        void database.deleteLastItem();
+      }
+      return;
+    }
+
+    if (pendingExitHref === destination.url.href) {
+      return;
+    }
+
+    navigation.cancel();
+    void leaveReader(navigation);
+  });
+
   $effect(() => {
     if (!browser) return;
 
@@ -236,7 +278,7 @@
     bookmarkData = Promise.resolve(undefined);
 
     try {
-      loadedBook = await loadReaderBookData(title);
+      loadedBook = await loadReaderBookData(title, signal);
       if (signal.aborted) return;
 
       rawBookData = loadedBook;
@@ -263,7 +305,7 @@
     }
   }
 
-  async function loadReaderBookData(title: string) {
+  async function loadReaderBookData(title: string, signal: AbortSignal) {
     let book: BooksDbBookData | undefined;
     logger.debug(`reader/rawBookData: start title=${JSON.stringify(title)}`);
 
@@ -276,6 +318,18 @@
 
     if (!book) {
       return book;
+    }
+
+    if (!book.elementHtml) {
+      // A placeholder can only hydrate when a sync source is connected; bail before recording
+      // the book as opened so a failed open leaves no trace in the library or sync data.
+      const db = await database.db;
+      if ((await db.count('storageSource')) === 0) {
+        throw new Error(
+          "This book's content hasn't been downloaded yet. " +
+            'Connect its sync location in Settings → Sync, then try again.'
+        );
+      }
     }
 
     const currentContext = {
@@ -318,6 +372,14 @@
         scheduleReplication(StorageDataType.STATISTICS);
       }
     }
+
+    if (signal.aborted) {
+      return book;
+    }
+
+    // Only a fully loaded book becomes the last-opened book. Checking immediately before the
+    // write also prevents an older, slower load from replacing a newer route's last-item record.
+    await database.putLastItem(book.title);
 
     return book;
   }
@@ -889,8 +951,9 @@
     readerController.goToChapter(nextChapter.reference);
   }
 
-  async function leaveReader(routeId: ReaderExitRoute, deleteLastItem = true) {
-    if (!beginReaderAction()) {
+  async function leaveReader(navigation: BeforeNavigate) {
+    const destination = navigation.to;
+    if (!destination || !beginReaderAction()) {
       return;
     }
 
@@ -916,7 +979,8 @@
           await tick();
         }
 
-        if (deleteLastItem) {
+        // The home route otherwise redirects straight back to the last-opened book.
+        if (destination.route.id === '/' || destination.route.id === '/manage') {
           await database.deleteLastItem();
         }
 
@@ -933,10 +997,20 @@
         showErrorDialog({ title: 'Error saving reader state', error });
       }
 
-      if (routeId === mergeEntries.STATISTICS.routeId && bookTitle) {
-        await goto(resolve(getBookStatisticsURL(bookTitle)));
+      allowedNavigationURL = destination.url.href;
+      if (navigation.type === 'popstate') {
+        history.go(navigation.delta);
+        // If the target entry vanished (extra Back/Forward presses while the confirm dialog was
+        // up), the replay never fires; expire the bypass so a later exit still saves state.
+        setTimeout(() => {
+          if (allowedNavigationURL === destination.url.href) {
+            allowedNavigationURL = undefined;
+          }
+        }, 1000);
       } else {
-        await goto(resolve(routeId));
+        // `destination.url` is the already-resolved target supplied by SvelteKit.
+        // eslint-disable-next-line svelte/no-navigation-without-resolve
+        await goto(destination.url);
       }
     } finally {
       endReaderAction();
@@ -1218,6 +1292,7 @@
   use:clickOutside={() => (showHeader = false)}
 >
   <BookReaderHeader
+    currentBookTitle={rawBookData?.title}
     hasChapterData={bookTOCState.hasChapters}
     hasText={!!bookCharCount}
     hasCustomReadingPoint={!!(
@@ -1269,13 +1344,10 @@
       showHeader = false;
       scrollToBookmark();
     }}
-    onstatisticsClick={() => leaveReader(mergeEntries.STATISTICS.routeId, false)}
     onreaderImageGalleryClick={() => {
       showHeader = false;
       showReaderImageGallery = true;
     }}
-    onsettingsClick={() => leaveReader(mergeEntries.SETTINGS.routeId, false)}
-    onbookManagerClick={() => leaveReader(mergeEntries.MANAGE.routeId)}
   />
 </div>
 

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { faUpload } from '@fortawesome/free-solid-svg-icons';
   import BookCardList from '$lib/components/book-card/book-card-list.svelte';
@@ -7,7 +6,6 @@
   import BookManagerHeader from '$lib/components/book-card/book-manager-header.svelte';
   import {
     defaultStatisticsView,
-    getBookStatisticsURL,
     getStatisticsURL
   } from '$lib/components/statistics/statistics-view';
   import { showBugReportDialog, showErrorDialog } from '$lib/components/log-report-dialog.svelte';
@@ -31,7 +29,6 @@
     database,
     keepLocalReadingDataOnDeletion$
   } from '$lib/data/store';
-  import { getBookURL } from '$lib/functions/book-url';
   import { cloneMutateSet } from '$lib/functions/clone-mutate-set';
   import { getDropEventFiles } from '$lib/functions/file-dom/get-drop-event-files';
   import { inputFile } from '$lib/functions/file-dom/input-file';
@@ -47,7 +44,7 @@
   // The unified library view always reads from the local IndexedDB
   // (browser storage). Placeholder books (not-yet-downloaded cloud
   // content) stay in the list with a Download action and are
-  // downloaded transparently when clicked; see onBookClick below.
+  // downloaded transparently when opened in the reader.
   let bookCards = $derived(
     getBookCards(database.dataList, database.bookmarks, $booklistSortOptions$)
   );
@@ -59,6 +56,12 @@
   let selectedPlaceholderCount = $derived(
     selectedBookCards.filter((book) => book.isPlaceholder).length
   );
+  let selectedStatisticsHref = $derived.by(() => {
+    const bookTitles = selectedBookCards.map((book) => book.title);
+    return bookTitles.length
+      ? resolve(getStatisticsURL(defaultStatisticsView, bookTitles))
+      : undefined;
+  });
   let abortController = $state(new AbortController());
   let signal = $derived(abortController.signal);
   let cancelTooltip = $state('');
@@ -126,32 +129,14 @@
     return sortDiff;
   }
 
-  async function onBookClick(title: string) {
-    if (!operationAllowed()) {
-      return;
-    }
-
-    if (selectMode) {
-      selectedBookTitles = cloneMutateSet(selectedBookTitles, (set) => {
-        if (set.has(title)) {
-          set.delete(title);
-          return;
-        }
-        set.add(title);
-      });
-      return;
-    }
-
-    await readBook(title);
-  }
-
-  async function readBook(title: string) {
-    if (!operationAllowed()) return;
-
-    const bookItem = bookCards.find((book) => book.title === title);
-    if (!bookItem || !(await placeholderActionAvailable(bookItem, 'open'))) return;
-
-    await openBook(title);
+  function selectBook(title: string) {
+    selectedBookTitles = cloneMutateSet(selectedBookTitles, (set) => {
+      if (set.has(title)) {
+        set.delete(title);
+        return;
+      }
+      set.add(title);
+    });
   }
 
   async function downloadBook(title: string) {
@@ -160,7 +145,7 @@
     const bookItem = bookCards.find((book) => book.title === title);
     if (!bookItem || !bookItem.isPlaceholder) return;
 
-    if (!(await placeholderActionAvailable(bookItem, 'download'))) return;
+    if (!(await placeholderDownloadAvailable())) return;
 
     await reconcileForBookOpen({
       title: bookItem.title,
@@ -169,29 +154,16 @@
     void database.notifyDataListChanged();
   }
 
-  async function placeholderActionAvailable(book: BookCardProps, action: 'open' | 'download') {
-    if (!book.isPlaceholder) return true;
-
+  async function placeholderDownloadAvailable() {
     const db = await database.db;
     if ((await db.count('storageSource')) > 0) return true;
 
     showMessageDialog({
-      title: `Can't ${action} book`,
+      title: "Can't download book",
       message:
         "This book's content isn't downloaded and no sync source is connected. Connect one from Settings → Sync to download."
     });
     return false;
-  }
-
-  function openBookStatistics(title: string) {
-    return goto(resolve(getBookStatisticsURL(title)));
-  }
-
-  function openSelectedBookStatistics() {
-    const bookTitles = selectedBookCards.map((book) => book.title);
-    if (!bookTitles.length) return;
-
-    return goto(resolve(getStatisticsURL(defaultStatisticsView, bookTitles)));
   }
 
   async function setBookCompleted(title: string, completed: boolean) {
@@ -247,15 +219,6 @@
   function resetProgress() {
     replicationProgressState.reset();
     cancelTooltip = '';
-  }
-
-  async function openBook(title: string) {
-    if (!title) {
-      return;
-    }
-
-    await database.putLastItem(title);
-    await goto(resolve(getBookURL(title)));
   }
 
   async function onFilesChange(fileList: FileList | File[]) {
@@ -425,8 +388,8 @@
     {cancelTooltip}
     bind:fileCountData
     bind:selectMode
+    statisticsHref={selectedStatisticsHref}
     onselectAllClick={onToggleAllBooks}
-    onviewStatistics={openSelectedBookStatistics}
     oncompletionChange={setSelectedBooksCompleted}
     ondownloadClick={downloadSelectedBooks}
     onremoveClick={() => removeBooks(Array.from(selectedBookTitles))}
@@ -442,6 +405,9 @@
   />
 </div>
 
+<!-- The drag handlers live outside the inert subtree: while replication runs, drag events fall
+  through inert content to this wrapper, which must still cancel them or the browser would
+  navigate to the dropped file. -->
 <div
   role="application"
   class="{pxScreen} h-full pt-16"
@@ -453,47 +419,47 @@
     getDropEventFiles(ev).then(onFilesChange);
   }}
 >
-  {#if database.listLoading}
-    Loading...
-  {:else if bookCards.length}
-    <BookCardList
-      currentBookTitle={database.lastItemTitle}
-      {selectMode}
-      {selectedBookTitles}
-      {bookCards}
-      onbookClick={({ title }) => onBookClick(title)}
-      onreadBookClick={({ title }) => readBook(title)}
-      onstatisticsClick={({ title }) => openBookStatistics(title)}
-      ondownloadBookClick={({ title }) => downloadBook(title)}
-      oncompleteBookClick={({ title, completed }) => setBookCompleted(title, completed)}
-      ondeleteStatisticsClick={({ title }) => onDeleteStatistics([title])}
-      onremoveBookClick={({ title }) => removeBooks([title])}
-    />
-  {:else}
-    <div class="flex h-full flex-col items-center gap-6 pt-8 text-center">
-      <h1 class="text-2xl font-bold">{appName}</h1>
-      <p class="max-w-3xl px-8 text-gray-500">
-        An online ebook reader for Japanese language learners. Read EPUB and TXT files in your
-        browser with support for dictionary extensions like Yomitan.
-      </p>
-      <label
-        class="mt-8 flex cursor-pointer flex-col items-center gap-4 text-gray-400/40 transition-colors hover:text-gray-400/60"
-      >
-        <div class="flex w-32 justify-center">
-          <Fa icon={faUpload} style="width: 100%; height: auto" />
+  <div class="h-full" inert={!!replicationProgressState.toProgress}>
+    {#if database.listLoading}
+      Loading...
+    {:else if bookCards.length}
+      <BookCardList
+        currentBookTitle={database.lastItemTitle}
+        {selectMode}
+        {selectedBookTitles}
+        {bookCards}
+        onbookSelect={({ title }) => selectBook(title)}
+        ondownloadBookClick={({ title }) => downloadBook(title)}
+        oncompleteBookClick={({ title, completed }) => setBookCompleted(title, completed)}
+        ondeleteStatisticsClick={({ title }) => onDeleteStatistics([title])}
+        onremoveBookClick={({ title }) => removeBooks([title])}
+      />
+    {:else}
+      <div class="flex h-full flex-col items-center gap-6 pt-8 text-center">
+        <h1 class="text-2xl font-bold">{appName}</h1>
+        <p class="max-w-3xl px-8 text-gray-500">
+          An online ebook reader for Japanese language learners. Read EPUB and TXT files in your
+          browser with support for dictionary extensions like Yomitan.
+        </p>
+        <label
+          class="mt-8 flex cursor-pointer flex-col items-center gap-4 text-gray-400/40 transition-colors hover:text-gray-400/60"
+        >
+          <div class="flex w-32 justify-center">
+            <Fa icon={faUpload} style="width: 100%; height: auto" />
+          </div>
+          <span class="text-sm text-gray-500">Drop files here or click to upload</span>
+          <input
+            type="file"
+            accept="application/epub+zip,.epub,.htmlz,plain/text,.txt"
+            multiple
+            hidden
+            use:inputFile={onFilesChange}
+          />
+        </label>
+        <div class="mt-auto pb-4 text-xs text-gray-400">
+          <a href={resolve('/privacy')} class="underline">Privacy Policy</a>
         </div>
-        <span class="text-sm text-gray-500">Drop files here or click to upload</span>
-        <input
-          type="file"
-          accept="application/epub+zip,.epub,.htmlz,plain/text,.txt"
-          multiple
-          hidden
-          use:inputFile={onFilesChange}
-        />
-      </label>
-      <div class="mt-auto pb-4 text-xs text-gray-400">
-        <a href={resolve('/privacy')} class="underline">Privacy Policy</a>
       </div>
-    </div>
-  {/if}
+    {/if}
+  </div>
 </div>

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
   import type { RouteId } from '$app/types';
-  import { goto } from '$app/navigation';
-  import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import type { Snippet } from 'svelte';
   import SettingsHeader from '$lib/components/settings/settings-header.svelte';
-  import type { SettingsRoute } from '$lib/components/settings/settings-route';
   import { pxScreen } from '$lib/css-classes';
 
   interface Props {
@@ -15,18 +12,10 @@
   let { children }: Props = $props();
 
   let activeRouteId = $derived(page.route.id as RouteId | null);
-
-  function navigateToSettingsSection(href: SettingsRoute) {
-    if (href === page.route.id) {
-      return;
-    }
-
-    goto(resolve(href), { keepFocus: true, noScroll: true });
-  }
 </script>
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
-  <SettingsHeader {activeRouteId} onselect={navigateToSettingsSection} />
+  <SettingsHeader {activeRouteId} />
 </div>
 
 <div class="{pxScreen} h-full pt-16">

--- a/src/routes/statistics/+page.svelte
+++ b/src/routes/statistics/+page.svelte
@@ -94,11 +94,7 @@
     controller.applyBookFilterTitles(requestedStatisticsBookTitles);
   });
 
-  function navigateToStatisticsTab(view: StatisticsView) {
-    if (view === activeView && requestedStatisticsView === view) {
-      return;
-    }
-
+  function getStatisticsTabHref(view: StatisticsView) {
     // Prefer the controller's live filter state, but when it reports "no
     // filter" — every title selected, e.g. because a URL prefilter happens to
     // cover every book with statistics — keep the URL's explicit titles.
@@ -106,12 +102,11 @@
     // whenever the controller has nothing narrower to say.
     const { bookTitles } = controller.getBookFilterURLState();
 
-    $lastStatisticsView$ = view;
-    goto(resolve(getStatisticsURL(view, bookTitles ?? requestedStatisticsBookTitles)), {
-      keepFocus: true,
-      noScroll: true
-    });
+    return resolve(getStatisticsURL(view, bookTitles ?? requestedStatisticsBookTitles));
   }
+
+  let summaryHref = $derived(getStatisticsTabHref('summary'));
+  let heatmapHref = $derived(getStatisticsTabHref('heatmap'));
 
   function handleTitleFilterToggle(title: string, isSelected: boolean) {
     controller.setTitleFilterSelection(title, isSelected);
@@ -142,7 +137,8 @@
   oncopydata={(dataKey) => controller.copyStatisticsData(dataKey)}
   onopenfilter={() => (controller.titleFilterIsOpen = true)}
   onopensettings={() => (controller.showStatisticsSettings = true)}
-  onselecttab={navigateToStatisticsTab}
+  {summaryHref}
+  {heatmapHref}
 />
 
 <div class="{pxScreen} flex min-h-full flex-col pt-16">

--- a/tests/integration/fs/source-only-placeholder.spec.ts
+++ b/tests/integration/fs/source-only-placeholder.spec.ts
@@ -18,7 +18,7 @@ test('download action hydrates a source-only placeholder without opening the rea
 
   await expectBooksInManage(page, { placeholders: [VALID_BOOK], downloaded: [] });
   await page.getByRole('button', { name: 'Select' }).click();
-  await page.getByText(fixtureTitle(VALID_BOOK), { exact: true }).click();
+  await page.getByRole('button', { name: fixtureTitle(VALID_BOOK), exact: true }).click();
   await expect(page.getByRole('button', { name: 'Download', exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0);
   await page.getByRole('button', { name: 'Select' }).click();

--- a/tests/integration/fs/source-placeholder-varied-and-corrupt.spec.ts
+++ b/tests/integration/fs/source-placeholder-varied-and-corrupt.spec.ts
@@ -58,4 +58,5 @@ test('fresh-device placeholders preserve varied UI-created progress and surface 
   await expect(dialog).not.toContainText('Connect its sync location');
   await expect(dialog.getByRole('link', { name: 'Open Issue Tracker' })).toBeVisible();
   await expect(dialog.getByRole('link', { name: 'Download Logs' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Book', exact: true })).toHaveCount(0);
 });

--- a/tests/integration/fs/sync-direction-off-delete-local-only.spec.ts
+++ b/tests/integration/fs/sync-direction-off-delete-local-only.spec.ts
@@ -13,7 +13,7 @@ test('deleting a book with sync "Off" leaves the source copy intact', async ({ p
   await setSyncDirection(page, 'Off');
   await clearRemoveEntryLog(page);
   await deleteBookFromManage(page, VALID_BOOK);
-  await expect(page.getByRole('button', { name: 'Sync is off' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Sync is off' })).toBeVisible();
 
   await expectSourceBookRemoveNotLogged(page, VALID_BOOK);
   await expectBooksInSyncRoot(page, [VALID_BOOK]);

--- a/tests/integration/fs/sync-direction-off-indicator.spec.ts
+++ b/tests/integration/fs/sync-direction-off-indicator.spec.ts
@@ -9,7 +9,7 @@ test('sync indicator shows a neutral off state and links to sync direction setti
   await setSyncDirection(page, 'Off');
 
   await navigateToManage(page);
-  await page.getByRole('button', { name: 'Sync is off' }).click();
+  await page.getByRole('link', { name: 'Sync is off' }).click();
 
   await expect(page).toHaveURL('/settings/sync#sync-direction');
   const syncDirection = page.getByRole('group', { name: 'Sync direction' });
@@ -21,7 +21,7 @@ test('sync indicator reacts to browser online state', async ({ context, page }) 
   await connectFS(page);
   await navigateToManage(page);
 
-  await expect(page.getByRole('button', { name: /^(Up to date|Synced)/ })).toBeVisible();
+  await expect(page.getByRole('link', { name: /^(Up to date|Synced)/ })).toBeVisible();
 
   await context.setOffline(true);
   await expect(
@@ -29,5 +29,5 @@ test('sync indicator reacts to browser online state', async ({ context, page }) 
   ).toBeVisible();
 
   await context.setOffline(false);
-  await expect(page.getByRole('button', { name: /^(Up to date|Synced)/ })).toBeVisible();
+  await expect(page.getByRole('link', { name: /^(Up to date|Synced)/ })).toBeVisible();
 });

--- a/tests/integration/helpers/fixtures.ts
+++ b/tests/integration/helpers/fixtures.ts
@@ -291,11 +291,12 @@ export async function expectBookReaderText(page: Page, fixture: LibraryBookFixtu
 
 export async function deleteBookFromManage(page: Page, fixture: LibraryBookFixture) {
   await navigateToManage(page);
-  const bookTitle = page.getByText(fixtureTitle(fixture), { exact: true });
+  const title = fixtureTitle(fixture);
+  const bookTitle = page.getByText(title, { exact: true });
   await expect(bookTitle).toBeVisible();
 
   await page.getByRole('button', { name: 'Select' }).click();
-  await bookTitle.click();
+  await bookCard(page, fixture).getByRole('button', { name: title, exact: true }).click();
   await page.getByRole('button', { name: 'Remove', exact: true }).click();
   const dialog = page.locator('dialog[open]').filter({
     has: page.getByRole('heading', { name: 'Remove book from library?' })

--- a/tests/integration/helpers/navigation.ts
+++ b/tests/integration/helpers/navigation.ts
@@ -59,7 +59,7 @@ export async function navigateToStatisticsSummary(page: Page, options?: Navigati
     }
 
     if (currentStatisticsView(page) !== 'summary') {
-      await page.getByRole('button', { name: 'Summary', exact: true }).click();
+      await page.getByRole('link', { name: 'Summary', exact: true }).click();
     }
   }
   await expectPath(page, '/statistics');
@@ -84,7 +84,7 @@ async function navigateToSettingsSection(
       );
     }
 
-    await page.getByRole('button', { name: tabName, exact: true }).first().click();
+    await page.getByRole('link', { name: tabName, exact: true }).first().click();
   }
   await expectPath(page, path);
 }
@@ -103,7 +103,7 @@ async function navigateWithGlobalTab(
   if (readerMounted) {
     await navigateFromReader(page, tabName, options);
   } else {
-    await page.getByRole('button', { name: tabName, exact: true }).last().click();
+    await page.getByRole('link', { name: tabName, exact: true }).last().click();
   }
   await expect
     .poll(async () => isExpectedPath(currentPath(page)) && !(await readerIsMounted(page)), {
@@ -121,7 +121,7 @@ async function navigateFromReader(
   if ((await header.getAttribute('inert')) !== null) {
     header = await showReaderHeader(page);
   }
-  await header.getByRole('button', { name: tabName, exact: true }).click();
+  await header.getByRole('link', { name: tabName, exact: true }).click();
   await assertExpectedReaderExitDialog(page, readerExitDialog);
 }
 

--- a/tests/integration/helpers/workflows.ts
+++ b/tests/integration/helpers/workflows.ts
@@ -17,6 +17,7 @@ interface ReaderSettings {
   autoBookmarkTime?: string;
   autoPositionOnResize?: string;
   blurImage?: string;
+  closeConfirmation?: string;
   customReadingPoint?: string;
   fontSize?: string;
   fontVPAL?: string;
@@ -163,6 +164,9 @@ export async function useReaderSettings(page: Page, settings: ReaderSettings) {
   }
   if (settings.autoPositionOnResize) {
     await selectReaderSetting(page, /^Auto position on resize$/i, settings.autoPositionOnResize);
+  }
+  if (settings.closeConfirmation) {
+    await selectReaderSetting(page, /^Close Confirmation$/i, settings.closeConfirmation);
   }
   if (settings.customReadingPoint) {
     await selectReaderSetting(page, /^Custom Reading Point$/i, settings.customReadingPoint);
@@ -358,7 +362,7 @@ export async function importBackup(
  * account; it does not prove ambient pushes, boot reconcile, or force re-sync work has finished.
  */
 export async function waitForSyncIdle(page: Page) {
-  await expect(page.getByRole('button', { name: /^(Synced|Up to date)/ })).toBeVisible({
+  await expect(page.getByRole('link', { name: /^(Synced|Up to date)/ })).toBeVisible({
     timeout: SYNC_ASSERTION_TIMEOUT
   });
 }
@@ -368,7 +372,7 @@ export async function waitForSyncIdle(page: Page) {
  * source operation, not merely an idle "Up to date" state with sync disabled or disconnected.
  */
 export async function waitForSuccessfulSync(page: Page) {
-  await expect(page.getByRole('button', { name: /^Synced/ })).toBeVisible({
+  await expect(page.getByRole('link', { name: /^Synced/ })).toBeVisible({
     timeout: SYNC_ASSERTION_TIMEOUT
   });
 }

--- a/tests/integration/manage/book-list.spec.ts
+++ b/tests/integration/manage/book-list.spec.ts
@@ -36,15 +36,15 @@ test('manager exposes per-book actions without entering selection mode', async (
   const card = page.locator('article').filter({ hasText: fixtureTitle(VALID_BOOK) });
   await expect(card.getByText('テスト 太郎', { exact: true })).toBeVisible();
   await expect(
-    card.getByRole('button', { name: `View statistics for ${fixtureTitle(VALID_BOOK)}` })
+    card.getByRole('link', { name: `View statistics for ${fixtureTitle(VALID_BOOK)}` })
   ).toBeVisible();
   await expect(
     card.getByRole('button', { name: `Details for ${fixtureTitle(VALID_BOOK)}` })
   ).toBeVisible();
 
   await card.getByRole('button', { name: `More actions for ${fixtureTitle(VALID_BOOK)}` }).click();
-  await expect(page.getByRole('button', { name: 'Read book' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'View statistics', exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Read book' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'View statistics', exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Book details' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Export book backup' })).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Delete statistics' })).toBeVisible();
@@ -66,9 +66,7 @@ test('manager exposes per-book actions without entering selection mode', async (
   );
   await expect(card.getByText('100%', { exact: true })).toBeVisible();
 
-  await card
-    .getByRole('button', { name: `View statistics for ${fixtureTitle(VALID_BOOK)}` })
-    .click();
+  await card.getByRole('link', { name: `View statistics for ${fixtureTitle(VALID_BOOK)}` }).click();
   await page.waitForURL((url) => url.pathname === '/statistics' && url.searchParams.has('t'));
 });
 
@@ -93,6 +91,25 @@ test('manager confirms before removing a book from the library', async ({ page }
   await page.getByRole('button', { name: 'Remove from library' }).click();
   await dialog.getByRole('button', { name: 'Remove', exact: true }).click();
   await expect(card).toHaveCount(0);
+});
+
+test('selection mode keeps book cards mounted', async ({ page }) => {
+  await importBookFixtures(page, [VALID_BOOK]);
+  await navigateToManage(page);
+
+  const title = fixtureTitle(VALID_BOOK);
+  const card = page.locator('article').filter({ hasText: title });
+  const presentation = card.getByRole('progressbar', { name: /Reading progress/ }).locator('..');
+  await expect(presentation).toBeVisible();
+  await presentation.evaluate((element) => (element.dataset.mountMarker = 'original'));
+
+  await page.getByRole('button', { name: 'Select', exact: true }).click();
+  await expect(card.getByRole('button', { name: title, exact: true })).toBeVisible();
+  await expect(presentation).toHaveAttribute('data-mount-marker', 'original');
+
+  await page.getByRole('button', { name: 'Select', exact: true }).click();
+  await expect(card.getByRole('link', { name: title, exact: true })).toBeVisible();
+  await expect(presentation).toHaveAttribute('data-mount-marker', 'original');
 });
 
 test('selection mode exposes the applicable per-book actions in bulk', async ({ page }) => {
@@ -123,20 +140,20 @@ test('selection mode exposes the applicable per-book actions in bulk', async ({ 
   await page.getByRole('button', { name: 'Clear All' }).click();
   await expect(selectedCount).toHaveText('0');
   await expect(page.getByRole('button', { name: 'Select All' })).toBeVisible();
-  await card.getByText(title, { exact: true }).click();
+  await card.getByRole('button', { name: title, exact: true }).click();
 
   await expect(card.getByRole('button', { name: title, exact: true })).toHaveAttribute(
     'aria-pressed',
     'true'
   );
-  await expect(card.getByRole('button', { name: `View statistics for ${title}` })).toBeVisible();
+  await expect(card.getByRole('link', { name: `View statistics for ${title}` })).toBeVisible();
   await expect(card.getByRole('button', { name: `Details for ${title}` })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'View Stats', exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'View Stats', exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Complete', exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Delete Stats', exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Remove', exact: true })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Read book' })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: 'Read book' })).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Book details' })).toHaveCount(0);
 
   const completeWidth = await page

--- a/tests/integration/navigation.spec.ts
+++ b/tests/integration/navigation.spec.ts
@@ -1,11 +1,15 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from './helpers/harness.ts';
 import {
   expectBookReaderText,
   fixtureTitle,
   importBookFixtures,
+  LONG_BOOK,
   openBookFromManage,
   PLAIN_TEXT_BOOK
 } from './helpers/fixtures.ts';
+import { showReaderHeader } from './helpers/reader.ts';
+import { useReaderSettings } from './helpers/workflows.ts';
 
 test('home route opens the manager when there is no last-opened book', async ({ page }) => {
   await page.goto('/');
@@ -25,7 +29,177 @@ test('home route and Book tab open the last-opened book', async ({ page }) => {
   await expectBookReaderText(page, PLAIN_TEXT_BOOK);
 
   await page.goto('/settings/reader');
-  await page.getByRole('button', { name: 'Book', exact: true }).click();
+  await page.getByRole('link', { name: 'Book', exact: true }).click();
   await expect(page).toHaveURL(bookURL);
   await expectBookReaderText(page, PLAIN_TEXT_BOOK);
 });
+
+test('route-changing controls expose their destinations as links', async ({ page }) => {
+  const title = fixtureTitle(PLAIN_TEXT_BOOK);
+  const bookURL = `/b?${new URLSearchParams({ t: title })}`;
+  const statisticsURL = `/statistics?${new URLSearchParams({ t: title })}`;
+
+  await importBookFixtures(page, [PLAIN_TEXT_BOOK]);
+
+  await expect(page.getByRole('link', { name: 'Statistics', exact: true })).toHaveAttribute(
+    'href',
+    '/statistics'
+  );
+  await expect(page.getByRole('link', { name: 'Settings', exact: true })).toHaveAttribute(
+    'href',
+    '/settings'
+  );
+  await expect(page.getByRole('link', { name: 'Manager', exact: true })).toHaveAttribute(
+    'href',
+    '/manage'
+  );
+
+  const book = page.getByRole('link', { name: title, exact: true });
+  await expect(book).toHaveAttribute('href', bookURL);
+  await expect(
+    page.getByRole('link', {
+      name: `View statistics for ${title}`
+    })
+  ).toHaveAttribute('href', statisticsURL);
+
+  await openBookFromManage(page, PLAIN_TEXT_BOOK);
+  await expectBookReaderText(page, PLAIN_TEXT_BOOK);
+  await showReaderHeader(page);
+  await expect(page.getByRole('link', { name: 'Statistics', exact: true })).toHaveAttribute(
+    'href',
+    statisticsURL
+  );
+
+  await page.goto('/settings/reader');
+  await expect(page.getByRole('link', { name: 'Reader', exact: true })).toHaveAttribute(
+    'href',
+    '/settings/reader'
+  );
+  await expect(page.getByRole('link', { name: 'Sync', exact: true })).toHaveAttribute(
+    'href',
+    '/settings/sync'
+  );
+  await expect(page.getByRole('link', { name: 'Statistics', exact: true }).first()).toHaveAttribute(
+    'href',
+    '/settings/statistics'
+  );
+
+  await page.goto('/statistics?view=summary');
+  await expect(page.getByRole('link', { name: 'Summary', exact: true })).toHaveAttribute(
+    'href',
+    '/statistics?view=summary'
+  );
+  await expect(page.getByRole('link', { name: 'Heatmap', exact: true })).toHaveAttribute(
+    'href',
+    '/statistics?view=heatmap'
+  );
+});
+
+test('header link ripple stays contained after its selected state changes', async ({ page }) => {
+  await page.goto('/statistics?view=heatmap');
+
+  const summary = page.getByRole('link', { name: 'Summary', exact: true });
+  await summary.click();
+  await expect(page).toHaveURL('/statistics?view=summary');
+
+  const rippleSurface = summary.locator(':scope > span[aria-hidden="true"]');
+  await expect(rippleSurface).toHaveCount(1);
+  expect(await rippleSurface.boundingBox()).toEqual(await summary.boundingBox());
+});
+
+test('modified book navigation records the book opened in the new tab', async ({ page }) => {
+  const bookURL = `/b?${new URLSearchParams({ t: fixtureTitle(PLAIN_TEXT_BOOK) })}`;
+
+  await importBookFixtures(page, [PLAIN_TEXT_BOOK]);
+
+  const bookLink = page.getByRole('link', {
+    name: fixtureTitle(PLAIN_TEXT_BOOK),
+    exact: true
+  });
+  const readerPagePromise = page.context().waitForEvent('page');
+  await bookLink.click({ modifiers: ['Control'] });
+  const readerPage = await readerPagePromise;
+
+  try {
+    await expect(readerPage).toHaveURL(bookURL);
+    await expectBookReaderText(readerPage, PLAIN_TEXT_BOOK);
+  } finally {
+    await readerPage.close();
+  }
+
+  await page.goto('/');
+  await expect(page).toHaveURL(bookURL);
+  await expectBookReaderText(page, PLAIN_TEXT_BOOK);
+});
+
+test('modified reader navigation opens a new tab without leaving the reader', async ({ page }) => {
+  const bookURL = `/b?${new URLSearchParams({ t: fixtureTitle(PLAIN_TEXT_BOOK) })}`;
+
+  await importBookFixtures(page, [PLAIN_TEXT_BOOK]);
+  await openBookFromManage(page, PLAIN_TEXT_BOOK);
+  await expectBookReaderText(page, PLAIN_TEXT_BOOK);
+
+  const header = await showReaderHeader(page);
+  const managerLink = header.getByRole('link', { name: 'Manager', exact: true });
+  const managerPagePromise = page.context().waitForEvent('page');
+  await managerLink.click({ modifiers: ['Control'] });
+  const managerPage = await managerPagePromise;
+
+  try {
+    await expect(managerPage).toHaveURL('/manage');
+    await expect(page).toHaveURL(bookURL);
+    await expectBookReaderText(page, PLAIN_TEXT_BOOK);
+  } finally {
+    await managerPage.close();
+  }
+});
+
+test('browser Back honors a canceled reader exit', async ({ page }) => {
+  const { bookURL } = await prepareReaderWithUnsavedProgress(page);
+  await page.evaluate(() => history.back());
+  const dialog = readerExitDialog(page);
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(page).toHaveURL(bookURL);
+});
+
+test('browser Back saves reader state and preserves Forward history', async ({ page }) => {
+  const { bookURL, progressAfterMove } = await prepareReaderWithUnsavedProgress(page);
+  await page.evaluate(() => history.back());
+  const dialog = readerExitDialog(page);
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'Continue' }).click();
+  await expect(page).toHaveURL('/manage');
+
+  await page.goForward();
+  await expect(page).toHaveURL(bookURL);
+  await expectBookReaderText(page, LONG_BOOK);
+  await expect(page.locator('#miwake-page-footer span').nth(1)).toHaveText(progressAfterMove);
+});
+
+async function prepareReaderWithUnsavedProgress(page: Page) {
+  const bookURL = `/b?${new URLSearchParams({ t: fixtureTitle(LONG_BOOK) })}`;
+
+  await useReaderSettings(page, {
+    autoBookmark: 'Off',
+    closeConfirmation: 'On',
+    viewMode: 'Paginated',
+    writingMode: 'Horizontal'
+  });
+  await importBookFixtures(page, [LONG_BOOK]);
+  await openBookFromManage(page, LONG_BOOK);
+  await expectBookReaderText(page, LONG_BOOK);
+
+  const progress = page.locator('#miwake-page-footer span').nth(1);
+  const initialProgress = await progress.innerText();
+  await page.keyboard.press('d');
+  await expect.poll(() => progress.innerText()).not.toBe(initialProgress);
+
+  return { bookURL, progressAfterMove: await progress.innerText() };
+}
+
+function readerExitDialog(page: Page) {
+  return page.locator('dialog[open]').filter({
+    has: page.getByRole('heading', { name: 'Confirm exit' })
+  });
+}

--- a/tests/integration/reader/document-styles.spec.ts
+++ b/tests/integration/reader/document-styles.spec.ts
@@ -36,7 +36,7 @@ test('reader applies document styles while mounted and cleans them up on exit', 
   });
 
   const header = await showReaderHeader(page);
-  await header.getByRole('button', { name: 'Manager', exact: true }).click();
+  await header.getByRole('link', { name: 'Manager', exact: true }).click();
 
   await expectDocumentReaderStyles(page, { backgroundColor: '', writingMode: '' });
 });

--- a/tests/integration/statistics/heatmap-layout.spec.ts
+++ b/tests/integration/statistics/heatmap-layout.spec.ts
@@ -12,7 +12,7 @@ test('statistics heatmap expands day cells to fill desktop width', async ({ page
   await recordStatisticForBook(page, VALID_BOOK, LATER_STAT_DATE);
 
   await navigateToStatisticsSummary(page);
-  await page.getByRole('button', { name: 'Heatmap', exact: true }).click();
+  await page.getByRole('link', { name: 'Heatmap', exact: true }).click();
 
   const heatmap = page.getByRole('grid', { name: 'Reading Data for 2026' });
   const dayCell = heatmap.getByRole('cell', { name: new RegExp(`^${LATER_STAT_DATE},`) });

--- a/tests/integration/statistics/reader-filter-navigation.spec.ts
+++ b/tests/integration/statistics/reader-filter-navigation.spec.ts
@@ -32,21 +32,27 @@ test('reader statistics navigation preserves the active tab and filters to the c
   await recordStatisticForBook(page, VALID_BOOK, LATER_STAT_DATE);
 
   await navigateToStatisticsSummary(page);
-  await page.getByRole('button', { name: 'Heatmap', exact: true }).click();
+  await page.getByRole('link', { name: 'Heatmap', exact: true }).click();
   await expectStatisticsView(page, 'heatmap');
 
   await openBookFromManage(page, PLAIN_TEXT_BOOK);
   const header = await showReaderHeader(page);
-  await header.getByRole('button', { name: 'Statistics', exact: true }).click();
+  const statisticsLink = header.getByRole('link', { name: 'Statistics', exact: true });
+  const bookTitle = fixtureTitle(PLAIN_TEXT_BOOK);
+  await expect(statisticsLink).toHaveAttribute(
+    'href',
+    `/statistics?${new URLSearchParams({ t: bookTitle })}`
+  );
+  await statisticsLink.click();
   await expect(page).toHaveURL(/\/statistics/);
   await expectStatisticsView(page, 'heatmap');
   await expect
     .poll(() => new URL(page.url()).searchParams.get('t'), {
       timeout: SYNC_ASSERTION_TIMEOUT
     })
-    .toBe(fixtureTitle(PLAIN_TEXT_BOOK));
+    .toBe(bookTitle);
 
-  await page.getByRole('button', { name: 'Summary', exact: true }).click();
+  await page.getByRole('link', { name: 'Summary', exact: true }).click();
   await expectStatisticsView(page, 'summary');
 
   await expectSummaryBookVisible(page, PLAIN_TEXT_BOOK);

--- a/tests/integration/statistics/tab-switch-preserves-filter.spec.ts
+++ b/tests/integration/statistics/tab-switch-preserves-filter.spec.ts
@@ -21,7 +21,7 @@ test('switching tabs keeps the title filter when it covers every book', async ({
   const title = fixtureTitle(LONG_BOOK);
   await page.goto(`/statistics?${new URLSearchParams({ view: 'heatmap', t: title })}`);
 
-  await page.getByRole('button', { name: 'Summary', exact: true }).click();
+  await page.getByRole('link', { name: 'Summary', exact: true }).click();
 
   await expect(page).toHaveURL(`/statistics?${new URLSearchParams({ view: 'summary', t: title })}`);
 });


### PR DESCRIPTION
Routes now expose native link behavior—including modified clicks and destination previews—while reader exits, card selection, sync controls, and ripples preserve their existing interactions.
