### PR TITLE
refactor: remove BookCardProps from storage handlers

### DIFF
--- a/src/lib/data/storage/handler/api-handler.ts
+++ b/src/lib/data/storage/handler/api-handler.ts
@@ -114,7 +114,7 @@ export abstract class ApiStorageHandler extends BaseStorageHandler {
     if (clearAll) {
       this.rootId = '';
       this.titleToId.clear();
-      this.titleToBookCard.clear();
+      this.syncTitles.clear();
       this.dataListFetched = false;
     }
   }
@@ -136,7 +136,7 @@ export abstract class ApiStorageHandler extends BaseStorageHandler {
       }
       this.titleToFiles.delete(title);
       this.titleToId.delete(title);
-      this.titleToBookCard.delete(title);
+      this.syncTitles.delete(title);
       database.notifyDataListChanged();
     });
   }
@@ -540,7 +540,7 @@ export class ScopedApiHandler
       title: this.title
     });
 
-    this.handler.addBookCard(this.title, { characters, lastBookModified, lastBookOpen });
+    this.handler.addSyncTitle(this.title, { characters, lastBookModified, lastBookOpen });
 
     return 0;
   }
@@ -561,7 +561,7 @@ export class ScopedApiHandler
       title: this.title
     });
 
-    this.handler.addBookCard(this.title, { lastBookmarkModified, progress, completed });
+    this.handler.addSyncTitle(this.title, { lastBookmarkModified, progress, completed });
   }
 
   async saveStatistics(statistics: BooksDbStatistic[], lastStatisticModified: number) {
@@ -600,7 +600,7 @@ export class ScopedApiHandler
       title: this.title
     });
 
-    this.handler.addBookCard(this.title, {});
+    this.handler.addSyncTitle(this.title, {});
   }
 
   async saveCover(data: Blob | undefined) {
@@ -625,8 +625,8 @@ export class ScopedApiHandler
       });
     }
 
-    if (this.handler.titleToBookCard.has(this.title)) {
-      this.handler.addBookCard(this.title, { imagePath: data });
+    if (this.handler.syncTitles.has(this.title)) {
+      this.handler.addSyncTitle(this.title, { coverImage: data });
     }
   }
 

--- a/src/lib/data/storage/handler/base-handler.ts
+++ b/src/lib/data/storage/handler/base-handler.ts
@@ -1,4 +1,3 @@
-import type { BookCardProps } from '$lib/components/book-card/book-card-props';
 import type {
   BooksDbBookData,
   BooksDbBookmarkData,
@@ -128,7 +127,7 @@ export abstract class BaseStorageHandler implements SyncEndpoint {
   rootFileListFetched = false;
 
   /** @internal Used by `BaseScopedHandler` subclasses; not for outside callers. */
-  titleToBookCard = new Map<string, BookCardProps>();
+  syncTitles = new Map<string, SyncTitle>();
 
   /** @internal Used by `BaseScopedHandler` subclasses; not for outside callers. */
   rootFiles = new Map<string, ExternalFile>();
@@ -153,23 +152,22 @@ export abstract class BaseStorageHandler implements SyncEndpoint {
   }
 
   /** @internal Used by `BaseScopedHandler` subclasses. */
-  addBookCard(title: string, dataToAdd: Record<string, any>) {
-    const bookCard: BookCardProps = {
-      ...(this.titleToBookCard.get(title) || {
+  addSyncTitle(title: string, dataToAdd: Partial<SyncTitle>) {
+    const syncTitle: SyncTitle = {
+      ...(this.syncTitles.get(title) || {
         title,
-        imagePath: '',
+        coverImage: '',
         characters: 0,
         lastBookModified: 0,
         lastBookOpen: 0,
         progress: 0,
         completed: false,
-        lastBookmarkModified: 0,
-        isPlaceholder: false
+        lastBookmarkModified: 0
       }),
       ...dataToAdd
     };
 
-    this.titleToBookCard.set(title, bookCard);
+    this.syncTitles.set(title, syncTitle);
   }
 
   /**

--- a/src/lib/data/storage/handler/filesystem-handler.ts
+++ b/src/lib/data/storage/handler/filesystem-handler.ts
@@ -10,10 +10,9 @@ import { mergeStatistics, updateStatisticToStore } from '$lib/functions/statisti
 
 import { BaseScopedHandler, BaseStorageHandler } from '$lib/data/storage/handler/base-handler';
 import type { ScopedBookOperations, ScopedSettings } from '$lib/data/storage/handler/handler-roles';
-import type { BookCardProps } from '$lib/components/book-card/book-card-props';
 import { isRemoteContext } from '$lib/data/storage/storage-source-types';
 import { NeedsPermissionGrantError } from '$lib/data/storage/errors';
-import { SyncEndpointType } from '$lib/data/storage/storage-types';
+import { SyncEndpointType, type SyncTitle } from '$lib/data/storage/storage-types';
 import { showConfirmDialog } from '$lib/components/confirm-dialog.svelte';
 import pLimit from 'p-limit';
 import type { ReplicationContext } from '$lib/functions/replication/replication-progress.svelte';
@@ -48,16 +47,7 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
       this.dataListFetched = true;
     }
 
-    return [...this.titleToBookCard.values()].map((card) => ({
-      title: card.title,
-      characters: card.characters,
-      lastBookModified: card.lastBookModified,
-      lastBookOpen: card.lastBookOpen,
-      coverImage: card.imagePath || undefined,
-      progress: card.progress,
-      lastBookmarkModified: card.lastBookmarkModified,
-      completed: card.completed
-    }));
+    return [...this.syncTitles.values()];
   }
 
   authenticate(): Promise<void> {
@@ -77,7 +67,7 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
     if (clearAll) {
       this.rootDirectory = undefined;
       this.titleToDirectory.clear();
-      this.titleToBookCard.clear();
+      this.syncTitles.clear();
       this.dataListFetched = false;
     }
   }
@@ -98,7 +88,7 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
       });
       this.titleToDirectory.delete(title);
       this.titleToFiles.delete(title);
-      this.titleToBookCard.delete(title);
+      this.syncTitles.delete(title);
     });
   }
 
@@ -272,16 +262,15 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
               return;
             }
 
-            const bookCard: BookCardProps = {
+            const syncTitle: SyncTitle = {
               title: BaseStorageHandler.desanitizeFilename(directory.name),
-              imagePath: '',
+              coverImage: '',
               characters: 0,
               lastBookModified: 0,
               lastBookOpen: 0,
               progress: 0,
               completed: false,
-              lastBookmarkModified: 0,
-              isPlaceholder: false
+              lastBookmarkModified: 0
             };
             const fileLimiter = pLimit(1);
             const fileTasks: Promise<void>[] = [];
@@ -293,17 +282,17 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
                     if (file.name.startsWith('bookdata_')) {
                       const metadata = BaseStorageHandler.getBookMetadata(file.name);
 
-                      bookCard.characters = metadata.characters;
-                      bookCard.lastBookModified = metadata.lastBookModified;
-                      bookCard.lastBookOpen = metadata.lastBookOpen;
+                      syncTitle.characters = metadata.characters;
+                      syncTitle.lastBookModified = metadata.lastBookModified;
+                      syncTitle.lastBookOpen = metadata.lastBookOpen;
                     } else if (file.name.startsWith('progress_')) {
                       const metadata = BaseStorageHandler.getProgressMetadata(file.name);
 
-                      bookCard.lastBookmarkModified = metadata.lastBookmarkModified;
-                      bookCard.progress = metadata.progress;
-                      bookCard.completed = metadata.completed;
+                      syncTitle.lastBookmarkModified = metadata.lastBookmarkModified;
+                      syncTitle.progress = metadata.progress;
+                      syncTitle.completed = metadata.completed;
                     } else if (file.name.startsWith('cover_')) {
-                      bookCard.imagePath = await file.getFile();
+                      syncTitle.coverImage = await file.getFile();
                     }
                   } catch (error) {
                     fileLimiter.clearQueue();
@@ -315,9 +304,9 @@ export class FilesystemStorageHandler extends BaseStorageHandler {
 
             await Promise.all(fileTasks);
 
-            this.titleToDirectory.set(bookCard.title, directory);
-            this.titleToFiles.set(bookCard.title, files);
-            this.titleToBookCard.set(bookCard.title, bookCard);
+            this.titleToDirectory.set(syncTitle.title, directory);
+            this.titleToFiles.set(syncTitle.title, files);
+            this.syncTitles.set(syncTitle.title, syncTitle);
           } catch (error) {
             listLimiter.clearQueue();
             throw error;
@@ -583,7 +572,7 @@ class ScopedFilesystemHandler
 
     await this.writeFile(rootDirectory, filename, bookData, files, file, 0.4);
 
-    this.handler.addBookCard(this.title, { characters, lastBookModified, lastBookOpen });
+    this.handler.addSyncTitle(this.title, { characters, lastBookModified, lastBookOpen });
 
     return 0;
   }
@@ -596,7 +585,7 @@ class ScopedFilesystemHandler
 
     await this.writeFile(rootDirectory, filename, JSON.stringify(data), files, file, 0.6);
 
-    this.handler.addBookCard(this.title, { lastBookmarkModified, progress, completed });
+    this.handler.addSyncTitle(this.title, { lastBookmarkModified, progress, completed });
   }
 
   async saveStatistics(statistics: BooksDbStatistic[], lastStatisticModified: number) {
@@ -637,7 +626,7 @@ class ScopedFilesystemHandler
       0.6
     );
 
-    this.handler.addBookCard(this.title, {});
+    this.handler.addSyncTitle(this.title, {});
   }
 
   async saveCover(data: Blob | undefined) {
@@ -654,8 +643,8 @@ class ScopedFilesystemHandler
       await this.writeFile(rootDirectory, filename, data, files, undefined, 0.6);
     }
 
-    if (this.handler.titleToBookCard.has(this.title)) {
-      this.handler.addBookCard(this.title, { imagePath: data });
+    if (this.handler.syncTitles.has(this.title)) {
+      this.handler.addSyncTitle(this.title, { coverImage: data });
     }
   }
 

--- a/src/lib/data/storage/handler/gdrive-handler.ts
+++ b/src/lib/data/storage/handler/gdrive-handler.ts
@@ -1,8 +1,7 @@
-import type { BookCardProps } from '$lib/components/book-card/book-card-props';
 import { gDriveRefreshEndpoint } from '$lib/data/env';
 import { ApiStorageHandler, type UploadOptions } from '$lib/data/storage/handler/api-handler';
 import { BaseStorageHandler, type ExternalFile } from '$lib/data/storage/handler/base-handler';
-import { SyncEndpointType } from '$lib/data/storage/storage-types';
+import { SyncEndpointType, type SyncTitle } from '$lib/data/storage/storage-types';
 import pLimit from 'p-limit';
 
 interface GDriveFile extends ExternalFile {
@@ -84,16 +83,7 @@ export class GDriveStorageHandler extends ApiStorageHandler {
       }
     }
 
-    return [...this.titleToBookCard.values()].map((card) => ({
-      title: card.title,
-      characters: card.characters,
-      lastBookModified: card.lastBookModified,
-      lastBookOpen: card.lastBookOpen,
-      coverImage: card.imagePath || undefined,
-      progress: card.progress,
-      lastBookmarkModified: card.lastBookmarkModified,
-      completed: card.completed
-    }));
+    return [...this.syncTitles.values()];
   }
 
   async ensureTitle(name = BaseStorageHandler.rootName, parent = 'root', readOnly = false) {
@@ -336,16 +326,15 @@ export class GDriveStorageHandler extends ApiStorageHandler {
         return;
       }
 
-      const bookCard: BookCardProps = {
+      const syncTitle: SyncTitle = {
         title,
-        imagePath: '',
+        coverImage: '',
         characters: 0,
         lastBookModified: 0,
         lastBookOpen: 0,
         progress: 0,
         completed: false,
-        lastBookmarkModified: 0,
-        isPlaceholder: false
+        lastBookmarkModified: 0
       };
 
       for (let index2 = 0, { length: length2 } = files; index2 < length2; index2 += 1) {
@@ -356,23 +345,23 @@ export class GDriveStorageHandler extends ApiStorageHandler {
             file.name
           );
 
-          bookCard.characters = characters;
-          bookCard.lastBookModified = lastBookModified;
-          bookCard.lastBookOpen = lastBookOpen;
+          syncTitle.characters = characters;
+          syncTitle.lastBookModified = lastBookModified;
+          syncTitle.lastBookOpen = lastBookOpen;
         } else if (file.name.startsWith('progress_')) {
           const { progress, lastBookmarkModified, completed } =
             BaseStorageHandler.getProgressMetadata(file.name);
 
-          bookCard.progress = progress;
-          bookCard.lastBookmarkModified = lastBookmarkModified;
-          bookCard.completed = completed;
+          syncTitle.progress = progress;
+          syncTitle.lastBookmarkModified = lastBookmarkModified;
+          syncTitle.completed = completed;
         } else if (file.name.startsWith('cover_') && file.thumbnailLink) {
-          bookCard.imagePath = file.thumbnailLink.replace(/=s\d+$/, '=s720');
+          syncTitle.coverImage = file.thumbnailLink.replace(/=s\d+$/, '=s720');
         }
       }
 
       this.titleToFiles.set(title, files);
-      this.titleToBookCard.set(title, bookCard);
+      this.syncTitles.set(title, syncTitle);
     }
   }
 }

--- a/src/lib/data/storage/handler/onedrive-handler.ts
+++ b/src/lib/data/storage/handler/onedrive-handler.ts
@@ -1,8 +1,7 @@
-import type { BookCardProps } from '$lib/components/book-card/book-card-props';
 import { oneDriveTokenEndpoint } from '$lib/data/env';
 import { ApiStorageHandler, type UploadOptions } from '$lib/data/storage/handler/api-handler';
 import { BaseStorageHandler, type ExternalFile } from '$lib/data/storage/handler/base-handler';
-import { SyncEndpointType } from '$lib/data/storage/storage-types';
+import { SyncEndpointType, type SyncTitle } from '$lib/data/storage/storage-types';
 import pLimit from 'p-limit';
 
 interface OneDriveFile extends ExternalFile {
@@ -158,16 +157,7 @@ export class OneDriveStorageHandler extends ApiStorageHandler {
       }
     }
 
-    return [...this.titleToBookCard.values()].map((card) => ({
-      title: card.title,
-      characters: card.characters,
-      lastBookModified: card.lastBookModified,
-      lastBookOpen: card.lastBookOpen,
-      coverImage: card.imagePath || undefined,
-      progress: card.progress,
-      lastBookmarkModified: card.lastBookmarkModified,
-      completed: card.completed
-    }));
+    return [...this.syncTitles.values()];
   }
 
   async ensureTitle(name = BaseStorageHandler.rootName, _parent = 'root', readOnly = false) {
@@ -446,16 +436,15 @@ export class OneDriveStorageHandler extends ApiStorageHandler {
       return;
     }
 
-    const bookCard: BookCardProps = {
+    const syncTitle: SyncTitle = {
       title,
-      imagePath: '',
+      coverImage: '',
       characters: 0,
       lastBookModified: 0,
       lastBookOpen: 0,
       progress: 0,
       completed: false,
-      lastBookmarkModified: 0,
-      isPlaceholder: false
+      lastBookmarkModified: 0
     };
 
     for (let index = 0, { length } = files; index < length; index += 1) {
@@ -466,23 +455,23 @@ export class OneDriveStorageHandler extends ApiStorageHandler {
           file.name
         );
 
-        bookCard.characters = characters;
-        bookCard.lastBookModified = lastBookModified;
-        bookCard.lastBookOpen = lastBookOpen;
+        syncTitle.characters = characters;
+        syncTitle.lastBookModified = lastBookModified;
+        syncTitle.lastBookOpen = lastBookOpen;
       } else if (file.name.startsWith('progress_')) {
         const { progress, lastBookmarkModified, completed } =
           BaseStorageHandler.getProgressMetadata(file.name);
 
-        bookCard.progress = progress;
-        bookCard.lastBookmarkModified = lastBookmarkModified;
-        bookCard.completed = completed;
+        syncTitle.progress = progress;
+        syncTitle.lastBookmarkModified = lastBookmarkModified;
+        syncTitle.completed = completed;
       } else if (file.name.startsWith('cover_') && file.thumbnails?.[0].large?.url) {
-        bookCard.imagePath = file.thumbnails?.[0].large?.url;
+        syncTitle.coverImage = file.thumbnails?.[0].large?.url;
       }
     }
 
     this.titleToFiles.set(title, files);
-    this.titleToBookCard.set(title, bookCard);
+    this.syncTitles.set(title, syncTitle);
   }
 
   private async rename(

--- a/src/lib/data/storage/storage-types.ts
+++ b/src/lib/data/storage/storage-types.ts
@@ -12,24 +12,27 @@ export enum SyncEndpointType {
 }
 
 /**
- * Lean shape returned by a sync endpoint's listSyncTitles(): just
- * enough to seed placeholder rows on the local side. Distinct from
- * BookCardProps (which the unified library view uses) — the source's
- * job is "tell me which titles you hold," not "render a card."
+ * Lean shape a sync endpoint caches per remote book and returns from
+ * listSyncTitles(): just enough to seed placeholder rows on the local
+ * side. Distinct from BookCardProps (which the unified library view
+ * uses) — the source's job is "tell me which titles you hold," not
+ * "render a card." Handlers fill every field, using zero values for
+ * whatever the source doesn't provide.
  */
 export interface SyncTitle {
   title: string;
-  characters?: number;
-  lastBookModified?: number;
-  lastBookOpen?: number;
+  characters: number;
+  lastBookModified: number;
+  lastBookOpen: number;
   /**
    * Cover image to surface in /manage's library view before the book
-   * itself is downloaded. Cloud handlers populate this with their
-   * thumbnail URL (refreshed on every boot reconcile, so staleness
-   * doesn't outlast a session); FS handlers populate it with a Blob
-   * read from the cover_ file in the book's directory.
+   * itself is downloaded, or '' when the source has none. Cloud
+   * handlers populate this with their thumbnail URL (refreshed on
+   * every boot reconcile, so staleness doesn't outlast a session); FS
+   * handlers populate it with a Blob read from the cover_ file in the
+   * book's directory.
    */
-  coverImage?: string | Blob;
+  coverImage: string | Blob;
   /**
    * Reading progress fields parsed from the source's progress_*
    * filename, so /manage can show real values on placeholder rows
@@ -37,9 +40,9 @@ export interface SyncTitle {
    * scroll / char-count details still come down via the per-book
    * pull on open.
    */
-  progress?: number;
-  lastBookmarkModified?: number;
-  completed?: boolean;
+  progress: number;
+  lastBookmarkModified: number;
+  completed: boolean;
 }
 
 export enum StorageDataType {


### PR DESCRIPTION
Storage handlers now cache the lean `SyncTitle` shape directly instead of presentational `BookCardProps` rows, deleting the triplicated re-projection in the `listSyncTitles()` implementations. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)