### PR TITLE
feat: simplify book titles for display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,8 @@
         "tslib": "^2.8.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.1",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2046,10 +2047,28 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2889,6 +2908,119 @@
         "valibot": "^1.4.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.26",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
@@ -3009,6 +3141,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -3049,6 +3191,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3264,6 +3416,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -3496,6 +3655,13 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.47.0",
@@ -3909,6 +4075,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3925,6 +4101,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fake-indexeddb": {
       "version": "6.2.5",
@@ -5301,6 +5487,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5886,6 +6079,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5963,6 +6163,20 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -6260,6 +6474,13 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -6285,6 +6506,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -6742,6 +6973,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6756,6 +7077,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "check:types": "svelte-check --tsconfig ./tsconfig.json",
     "lint": "eslint --fix .",
     "format": "prettier --write .",
-    "test": "playwright test",
+    "test": "npm run test:unit && npm run test:integration",
+    "test:unit": "vitest run tests/unit",
+    "test:integration": "playwright test",
     "generate-fixtures": "node scripts/generate-test-fixtures.mjs"
   },
   "devDependencies": {
@@ -54,7 +56,8 @@
     "tslib": "^2.8.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",

--- a/scripts/generate-test-fixtures.mjs
+++ b/scripts/generate-test-fixtures.mjs
@@ -158,6 +158,17 @@ await writeOut(
 );
 
 await writeOut(
+  'edition-title-book.epub',
+  await buildEPUB({
+    title: '52ヘルツのクジラたち【特典付き】 (中公文庫)',
+    author: '町田そのこ',
+    identifier: 'urn:uuid:00000000-0000-4000-8000-000000000006',
+    language: 'ja',
+    chapters: [{ title: '第一章', body: 'この本は書名表示のテスト用です。' }]
+  })
+);
+
+await writeOut(
   'plain-text-book.txt',
   enc.encode(`This plain text fixture gives the library another real imported book.
 

--- a/src/lib/components/backup/backup-selection-tree.svelte
+++ b/src/lib/components/backup/backup-selection-tree.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { displayTitle } from '$lib/functions/book-title';
   import { japaneseLangIfNeeded } from '$lib/functions/japanese-language';
   import type { BackupBook, BackupCatalog, BackupSelection } from './backup-types';
 
@@ -203,7 +204,8 @@
           {@const selected = isBookSelected(book)}
           {@const entry = selection.perBook.get(book.title)}
           {@const disabled = disabledItems.books?.has(book.title) ?? false}
-          {@const bookTitleLang = japaneseLangIfNeeded(book.title)}
+          {@const bookTitle = displayTitle(book.title)}
+          {@const bookTitleLang = japaneseLangIfNeeded(bookTitle)}
           <li class="py-2">
             <label class="flex items-center gap-3">
               <input
@@ -218,8 +220,8 @@
               <span
                 class="flex-1 truncate text-sm"
                 class:text-gray-400={disabled}
-                title={book.title}
-                lang={bookTitleLang}>{book.title}</span
+                title={bookTitle}
+                lang={bookTitleLang}>{bookTitle}</span
               >
             </label>
             {#if selected && (book.hasBookmark || book.hasStatistics)}

--- a/src/lib/components/book-card/book-card-actions.svelte
+++ b/src/lib/components/book-card/book-card-actions.svelte
@@ -14,6 +14,7 @@
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
   import { getBookStatisticsURL } from '$lib/components/statistics/statistics-view';
   import Popover from '$lib/components/popover/popover.svelte';
+  import { displayTitle } from '$lib/functions/book-title';
   import { getBookURL } from '$lib/functions/book-url';
   import { getDateTimeString } from '$lib/functions/statistic-util';
   import Fa from 'svelte-fa';
@@ -27,6 +28,8 @@
   }
 
   let { bookCard, ondownload, oncomplete, ondeletestatistics, onremove }: Props = $props();
+
+  let title = $derived(displayTitle(bookCard.title));
 
   let detailsPopover = $state<Popover>();
   let morePopover = $state<Popover>();
@@ -122,12 +125,12 @@
 {/snippet}
 
 <div class="mt-2.5 grid grid-cols-[1fr_1fr_auto] gap-1">
-  {@render cardAction(faChartLine, 'Stats', `View statistics for ${bookCard.title}`, {
+  {@render cardAction(faChartLine, 'Stats', `View statistics for ${title}`, {
     href: resolve(getBookStatisticsURL(bookCard.title))
   })}
 
   {#if bookCard.isPlaceholder}
-    {@render cardAction(faDownload, 'Download', `Download ${bookCard.title}`, {
+    {@render cardAction(faDownload, 'Download', `Download ${title}`, {
       onClick: () => ondownload?.({ title: bookCard.title })
     })}
   {:else}
@@ -138,11 +141,11 @@
       yOffset={5}
     >
       {#snippet icon()}
-        {@render cardAction(faCircleInfo, 'Details', `Details for ${bookCard.title}`, {}, true)}
+        {@render cardAction(faCircleInfo, 'Details', `Details for ${title}`, {}, true)}
       {/snippet}
       {#snippet content()}
         <div class="w-80 max-w-[calc(100vw-2rem)] p-4 font-normal">
-          <div class="wrap-break-word font-medium">{bookCard.title}</div>
+          <div class="wrap-break-word font-medium">{title}</div>
           <dl class="mt-3 grid gap-2 text-xs">
             {#each detailRows as row (row.label)}
               <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-4">
@@ -166,12 +169,12 @@
       <button
         type="button"
         class={`${actionButtonClasses} min-w-8 px-1.5 tracking-wider`}
-        aria-label={`More actions for ${bookCard.title}`}>•••</button
+        aria-label={`More actions for ${title}`}>•••</button
       >
     {/snippet}
     {#snippet content()}
       <div class="inline-flex min-w-56 flex-col py-2">
-        <div class="max-w-72 truncate px-4 pb-2 text-xs font-medium">{bookCard.title}</div>
+        <div class="max-w-72 truncate px-4 pb-2 text-xs font-medium">{title}</div>
         {@render menuAction(faBookOpen, 'Read book', { href: resolve(getBookURL(bookCard.title)) })}
         {@render menuAction(faChartLine, 'View statistics', {
           href: resolve(getBookStatisticsURL(bookCard.title))

--- a/src/lib/components/book-card/book-card-list.svelte
+++ b/src/lib/components/book-card/book-card-list.svelte
@@ -4,6 +4,7 @@
   import type { BookCardProps } from '$lib/components/book-card/book-card-props';
   import BookCard from '$lib/components/book-card/book-card.svelte';
   import { syncState } from '$lib/data/sync/sync-store.svelte';
+  import { displayTitle } from '$lib/functions/book-title';
   import { getBookURL } from '$lib/functions/book-url';
 
   interface Props {
@@ -42,6 +43,7 @@
 <div class="grid grid-cols-2 gap-x-5 gap-y-9 pb-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
   {#each bookCards as bookCard (bookCard.title)}
     {@const isSelected = selectMode && selectedBookTitles.has(bookCard.title)}
+    {@const displayedTitle = displayTitle(bookCard.title)}
     <article class="relative min-w-0">
       <div class="group relative min-w-0 rounded-sm">
         <BookCard
@@ -58,7 +60,7 @@
             class:outline-offset-4={isSelected}
             class:outline-blue-400={isSelected}
             title={bookCard.isPlaceholder ? placeholderTooltip : undefined}
-            aria-label={bookCard.title}
+            aria-label={displayedTitle}
             aria-pressed={isSelected}
             onclick={() => onbookSelect?.({ title: bookCard.title })}
           ></button>
@@ -66,7 +68,7 @@
           <a
             class={hitTargetClasses}
             title={bookCard.isPlaceholder ? placeholderTooltip : undefined}
-            aria-label={bookCard.title}
+            aria-label={displayedTitle}
             href={resolve(getBookURL(bookCard.title))}
           ></a>
         {/if}

--- a/src/lib/components/book-card/book-card.svelte
+++ b/src/lib/components/book-card/book-card.svelte
@@ -2,6 +2,7 @@
   import { faImage } from '@fortawesome/free-regular-svg-icons';
   import { onDestroy } from 'svelte';
   import Fa from 'svelte-fa';
+  import { displayTitle } from '$lib/functions/book-title';
   import { japaneseLangIfNeeded } from '$lib/functions/japanese-language';
 
   interface Props {
@@ -65,7 +66,8 @@
   const mapImagePath = mapImagePathFactory();
 
   let imageLoading = $state(true);
-  let titleLanguage = $derived(japaneseLangIfNeeded(title));
+  let displayedTitle = $derived(displayTitle(title));
+  let titleLanguage = $derived(japaneseLangIfNeeded(displayedTitle));
   let authorLanguage = $derived(author ? japaneseLangIfNeeded(author) : undefined);
   let progressPercentage = $derived(completed ? 100 : Math.round(progress * 100));
 </script>
@@ -97,7 +99,7 @@
   <progress
     class="reading-progress"
     class:completed
-    aria-label={`Reading progress for ${title}`}
+    aria-label={`Reading progress for ${displayedTitle}`}
     value={progressPercentage}
     max="100"
   ></progress>
@@ -107,7 +109,7 @@
   class="mt-3 grid h-14.5 min-w-0 grid-cols-[minmax(0,1fr)_2rem] items-start gap-2 overflow-hidden"
 >
   <span class="min-w-0">
-    <span class="line-clamp-2 text-sm font-medium" lang={titleLanguage}>{title}</span>
+    <span class="line-clamp-2 text-sm font-medium" lang={titleLanguage}>{displayedTitle}</span>
     <span class="mt-0.5 block truncate text-xs text-gray-500" lang={authorLanguage}>
       {author}
     </span>

--- a/src/lib/components/statistics/statistics-controller.svelte.ts
+++ b/src/lib/components/statistics/statistics-controller.svelte.ts
@@ -18,6 +18,7 @@ import type {
 } from '$lib/data/database/books-db/versions/books-db';
 import { showConfirmDialog } from '$lib/components/confirm-dialog.svelte';
 import { showErrorDialog } from '$lib/components/log-report-dialog.svelte';
+import { displayTitle } from '$lib/functions/book-title';
 import { logger } from '$lib/data/logger';
 import { getDateRangeLabel } from '$lib/data/reading-goal';
 import { appShortcuts } from '$lib/data/app-shortcuts.svelte';
@@ -232,7 +233,7 @@ export class StatisticsController {
           : getNumberFromObject(statistic, dataKeyToCopy);
 
       if (loggedValue) {
-        dataLines.push(`.log ${logKey} ${loggedValue} ${statistic.title}`);
+        dataLines.push(`.log ${logKey} ${loggedValue} ${displayTitle(statistic.title)}`);
       }
     }
 
@@ -515,7 +516,9 @@ export class StatisticsController {
           titleLabel
         )}, which may include start and/or completion data.\n\nDeletion syncs to connected sources when upward sync is enabled.\n\n${escapeHTML(
           titleLabel
-        )}:\n${[...titlesToDelete].map(formatJapaneseHTML).join('\n\n')}`,
+        )}:\n${[...titlesToDelete]
+          .map((title) => formatJapaneseHTML(displayTitle(title)))
+          .join('\n\n')}`,
         confirmLabel: 'Delete',
         danger: true
       });
@@ -627,7 +630,7 @@ export class StatisticsController {
 
     const confirmed = await showConfirmDialog({
       title: 'Update data',
-      messageHTML: `This will update the data for ${formatJapaneseHTML(title)} on ${escapeHTML(
+      messageHTML: `This will update the data for ${formatJapaneseHTML(displayTitle(title))} on ${escapeHTML(
         dateKey
       )}.\n\nTime: ${secondsToMinutes(statistic.readingTime)} min => ${secondsToMinutes(
         newReadingTime

--- a/src/lib/components/statistics/statistics-summary/statistics-summary.svelte
+++ b/src/lib/components/statistics/statistics-summary/statistics-summary.svelte
@@ -24,6 +24,7 @@
     titleDataSources
   } from '$lib/components/statistics/statistics-types';
   import { SortDirection } from '$lib/data/sort-types';
+  import { compareBookTitles, displayTitle } from '$lib/functions/book-title';
   import { japaneseLangIfNeeded } from '$lib/functions/japanese-language';
   import {
     lastBlurredTrackerItems$,
@@ -199,7 +200,7 @@
 
     if ($lastStatisticsSummarySortDirection$ === SortDirection.ASC) {
       if (isTitleSort) {
-        sortDiff = row1.title.localeCompare(row2.title, 'ja-JP', { numeric: true });
+        sortDiff = compareBookTitles(row1.title, row2.title);
       } else if (isDateKeySort) {
         if (row1Prop === row2Prop) {
           sortDiff = 0;
@@ -210,7 +211,7 @@
         sortDiff = +row1Prop - +row2Prop;
       }
     } else if (isTitleSort) {
-      sortDiff = row2.title.localeCompare(row1.title, 'ja-JP', { numeric: true });
+      sortDiff = compareBookTitles(row2.title, row1.title);
     } else if (isDateKeySort) {
       if (row1Prop === row2Prop) {
         sortDiff = 0;
@@ -222,7 +223,7 @@
     }
 
     if (!sortDiff) {
-      sortDiff = row1.title.localeCompare(row2.title, 'ja-JP', { numeric: true });
+      sortDiff = compareBookTitles(row1.title, row2.title);
     }
 
     return sortDiff;
@@ -325,7 +326,8 @@
       {#each sortedData as currentStatisticsSummaryRow (currentStatisticsSummaryRow.id)}
         {@const currentRowInEdit = rowInEdit && rowInEdit.id === currentStatisticsSummaryRow.id}
         {@const otherRowInEdit = rowInEdit && !currentRowInEdit}
-        {@const titleLang = japaneseLangIfNeeded(currentStatisticsSummaryRow.title)}
+        {@const title = displayTitle(currentStatisticsSummaryRow.title)}
+        {@const titleLang = japaneseLangIfNeeded(title)}
         <div class="col-span-2 md:col-span-1">
           <button
             class="hover:text-red-500"
@@ -370,13 +372,8 @@
         <div class="whitespace-nowrap" class:hidden={isTitleAggregation}>
           {currentStatisticsSummaryRow.dateKey}
         </div>
-        <div
-          class="line-clamp-2"
-          class:hidden={isDateAggregation}
-          title={currentStatisticsSummaryRow.title}
-          lang={titleLang}
-        >
-          {currentStatisticsSummaryRow.title}
+        <div class="line-clamp-2" class:hidden={isDateAggregation} {title} lang={titleLang}>
+          {title}
         </div>
         {#if currentRowInEdit}
           <input

--- a/src/lib/components/statistics/statistics-title-filter.svelte
+++ b/src/lib/components/statistics/statistics-title-filter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ToggleSwitch from '$lib/components/toggle-switch.svelte';
+  import { displayTitle } from '$lib/functions/book-title';
   import { japaneseLangIfNeeded } from '$lib/functions/japanese-language';
 
   interface Props {
@@ -24,7 +25,7 @@
   let visibleTitles = $derived(
     [...statisticsTitleFilters.keys()].filter(
       (title) =>
-        (!titleFilter || title.includes(titleFilter)) &&
+        (!titleFilter || displayTitle(title).includes(titleFilter)) &&
         (!filterDateRangeOnly || titlesInStatisticsDateRange.has(title))
     )
   );
@@ -77,7 +78,8 @@
         </thead>
         <tbody>
           {#each visibleTitles as title (title)}
-            {@const titleLang = japaneseLangIfNeeded(title)}
+            {@const displayedTitle = displayTitle(title)}
+            {@const titleLang = japaneseLangIfNeeded(displayedTitle)}
             <tr>
               <td class="py-2 pr-4">
                 <input
@@ -93,7 +95,7 @@
                 class:opacity-50={!titlesInStatisticsDateRange.has(title)}
                 lang={titleLang}
               >
-                {title}
+                {displayedTitle}
               </td>
             </tr>
           {/each}

--- a/src/lib/data/book-title-settings.ts
+++ b/src/lib/data/book-title-settings.ts
@@ -1,0 +1,3 @@
+import { booleanLocalStorageStore } from '$lib/data/internal/persistent-local-storage-store';
+
+export const simplifyBookTitles$ = booleanLocalStorageStore('simplifyBookTitles', true);

--- a/src/lib/data/store.ts
+++ b/src/lib/data/store.ts
@@ -84,6 +84,7 @@ export const enableReaderWakeLock$ = booleanLocalStorageStore('enableReaderWakeL
 export const verticalMode$ = derived(writingMode$, (writingMode) => writingMode === 'vertical-rl');
 export const showCharacterCounter$ = booleanLocalStorageStore('showCharacterCounter', true);
 export const showPercentage$ = booleanLocalStorageStore('showPercentage', true);
+export { simplifyBookTitles$ } from '$lib/data/book-title-settings';
 export const showFooterChapterCharacterCounter$ = booleanLocalStorageStore(
   'showFooterChapterCharacterCounter',
   false

--- a/src/lib/data/sync/backup-service.ts
+++ b/src/lib/data/sync/backup-service.ts
@@ -7,6 +7,7 @@ import type {
 import { resolve } from '$app/paths';
 import { BlobReader, ZipReader } from '@zip.js/zip.js';
 import { database, lastReadingGoalsModified$ } from '$lib/data/store';
+import { compareBookTitles } from '$lib/functions/book-title';
 import { localStoragePreferences } from '$lib/data/internal/persistent-local-storage-store';
 import { BackupStorageHandler } from '$lib/data/storage/handler/backup-handler';
 import { BaseStorageHandler } from '$lib/data/storage/handler/base-handler';
@@ -58,7 +59,7 @@ export async function buildCurrentCatalog(): Promise<BackupCatalog> {
       hasBookmark: bookmarkTitles.has(b.title),
       hasStatistics: statTitles.has(b.title)
     }))
-    .sort((a, b) => a.title.localeCompare(b.title));
+    .sort((a, b) => compareBookTitles(a.title, b.title));
 
   return {
     hasAppSettings: localStorage.length > 0,
@@ -193,7 +194,7 @@ export async function parseBackupZIP(file: File): Promise<BackupCatalog> {
     return {
       hasAppSettings,
       hasReadingGoals,
-      books: [...books.values()].sort((a, b) => a.title.localeCompare(b.title))
+      books: [...books.values()].sort((a, b) => compareBookTitles(a.title, b.title))
     };
   } finally {
     await reader.close();

--- a/src/lib/functions/book-title.ts
+++ b/src/lib/functions/book-title.ts
@@ -1,0 +1,55 @@
+import { fromStore } from 'svelte/store';
+import { simplifyBookTitles$ } from '$lib/data/book-title-settings';
+
+const editionMarkerPattern =
+  /(?:文庫|新書|単行本|コミックス?)(?:[\p{Script=Katakana}ーA-ZＡ-Ｚ0-9０-９]*)$|MFC$|版$/iu;
+const parentheticalSuffixPattern = /\s*(?:\(([^()]*)\)|（([^（）]*)）)$/u;
+const bundledContentSuffixPattern = /\s*【[^【】]*付き】$/u;
+
+function simplifyBookTitle(title: string) {
+  let simplifiedTitle = title.trimEnd();
+
+  while (simplifiedTitle) {
+    const withoutBundledContent = simplifiedTitle.replace(bundledContentSuffixPattern, '');
+    if (withoutBundledContent !== simplifiedTitle) {
+      simplifiedTitle = withoutBundledContent.trimEnd();
+      continue;
+    }
+
+    const parentheticalSuffix = simplifiedTitle.match(parentheticalSuffixPattern);
+    const parentheticalContent = parentheticalSuffix?.[1] ?? parentheticalSuffix?.[2];
+    if (
+      !parentheticalSuffix ||
+      !parentheticalContent ||
+      !editionMarkerPattern.test(parentheticalContent)
+    ) {
+      break;
+    }
+
+    simplifiedTitle = simplifiedTitle.slice(0, parentheticalSuffix.index).trimEnd();
+  }
+
+  return simplifiedTitle || title;
+}
+
+const simplifyTitles = fromStore(simplifyBookTitles$);
+
+/**
+ * The title to render for a stored book title, honoring the
+ * simplify-titles setting. Reactive when read in a reactive context;
+ * stored titles (database keys, URLs, sync data) are never changed.
+ */
+export function displayTitle(title: string) {
+  return simplifyTitles.current ? simplifyBookTitle(title) : title;
+}
+
+/**
+ * Order stored book titles by their displayed form, falling back to
+ * the stored form so books whose display titles collide sort stably.
+ */
+export function compareBookTitles(first: string, second: string) {
+  return (
+    displayTitle(first).localeCompare(displayTitle(second), 'ja-JP', { numeric: true }) ||
+    first.localeCompare(second, 'ja-JP', { numeric: true })
+  );
+}

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -102,6 +102,7 @@
   import loadBookData, {
     type LoadedBookData
   } from '$lib/functions/book-data-loader/load-book-data';
+  import { displayTitle } from '$lib/functions/book-title';
   import { formatPageTitle } from '$lib/functions/format-page-title';
   import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
   import type { ReplicationContext } from '$lib/functions/replication/replication-progress.svelte';
@@ -1269,7 +1270,7 @@
 </script>
 
 <svelte:head>
-  <title>{formatPageTitle(rawBookData?.title ?? '')}</title>
+  <title>{formatPageTitle(rawBookData ? displayTitle(rawBookData.title) : '')}</title>
 </svelte:head>
 
 <button

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -23,6 +23,7 @@
   import { showConfirmDialog } from '$lib/components/confirm-dialog.svelte';
   import { showMessageDialog } from '$lib/components/message-dialog.svelte';
   import { SortDirection, type SortOption } from '$lib/data/sort-types';
+  import { compareBookTitles, displayTitle } from '$lib/functions/book-title';
   import {
     booklistSortOptions$,
     confirmStatisticsDeletion$,
@@ -114,16 +115,16 @@
 
     if (sortProp.direction === SortDirection.ASC) {
       sortDiff = isTitleSort
-        ? card1.title.localeCompare(card2.title, 'ja-JP', { numeric: true })
+        ? compareBookTitles(card1.title, card2.title)
         : +card1Prop - +card2Prop;
     } else {
       sortDiff = isTitleSort
-        ? card2.title.localeCompare(card1.title, 'ja-JP', { numeric: true })
+        ? compareBookTitles(card2.title, card1.title)
         : +card2Prop - +card1Prop;
     }
 
     if (!sortDiff) {
-      sortDiff = card1.title.localeCompare(card2.title, 'ja-JP', { numeric: true });
+      sortDiff = compareBookTitles(card1.title, card2.title);
     }
 
     return sortDiff;
@@ -270,7 +271,9 @@
           ? 'Remove book from library?'
           : `Remove ${titlesToDelete.length} books from library?`,
       message: `This will remove ${
-        titlesToDelete.length === 1 ? `『${titlesToDelete[0]}』` : 'the selected books'
+        titlesToDelete.length === 1
+          ? `『${displayTitle(titlesToDelete[0])}』`
+          : 'the selected books'
       } from your library. The deletion will sync to your other devices. Depending on your settings, reading statistics may also be deleted.`,
       confirmLabel: 'Remove',
       danger: true
@@ -319,7 +322,7 @@
         title: 'Delete data',
         message: `This will delete all statistics for ${
           titles.length === 1
-            ? `『${titles[0]}』`
+            ? `『${displayTitle(titles[0])}』`
             : `the selected ${pluralize(titles.length, 'book')}`
         } (which may include start and/or completion data). The deletion will sync to your other devices.`,
         confirmLabel: 'Delete',

--- a/src/routes/settings/reader/+page.svelte
+++ b/src/routes/settings/reader/+page.svelte
@@ -45,6 +45,7 @@
     prioritizeReaderStyles$,
     secondDimensionMaxValue$,
     selectionToBookmarkEnabled$,
+    simplifyBookTitles$,
     showCharacterCounter$,
     showFooterChapterCharacterCounter$,
     showFooterChapterPercentage$,
@@ -124,6 +125,11 @@
     { id: BlurMode.AFTER_TOC, text: 'After ToC' }
   ];
 
+  const optionsForBookTitleDisplay: ToggleOption<boolean>[] = [
+    { id: true, text: 'Simplified' },
+    { id: false, text: 'Full' }
+  ];
+
   $effect(() => {
     if ($textMarginMode$ === 'auto') {
       $textMarginValue$ = 0;
@@ -196,6 +202,15 @@
       <ButtonToggleGroup options={optionsForViewMode} bind:selectedOptionId={$viewMode$} />
     </SettingsItemGroup>
   </div>
+  <SettingsItemGroup
+    title="Book Title Display"
+    tooltip="Hide recognized edition, imprint, and bundled-content suffixes throughout the app. Stored titles are unchanged."
+  >
+    <ButtonToggleGroup
+      options={optionsForBookTitleDisplay}
+      bind:selectedOptionId={$simplifyBookTitles$}
+    />
+  </SettingsItemGroup>
   <FontPicker group="serif" bind:selectedFont={$fontFamilyGroupOne$} />
   <FontPicker group="sans-serif" bind:selectedFont={$fontFamilyGroupTwo$} />
   <SettingsItemGroup title="Font size">

--- a/tests/integration/helpers/fixtures.ts
+++ b/tests/integration/helpers/fixtures.ts
@@ -15,6 +15,7 @@ const NOT_A_ZIP_BOOK = 'not-a-zip-book';
 const NOT_AN_EPUB_BOOK = 'not-an-epub-book';
 
 export const COVER_REFRESH_BOOK = 'cover-refresh-book';
+export const EDITION_TITLE_BOOK = 'edition-title-book';
 export const LONG_BOOK = 'long-book';
 export const LONG_BOOK_CHAPTER_CHARACTERS = 7519;
 export const MEDIA_SIZING_BOOK = 'media-sizing-book';
@@ -25,6 +26,7 @@ export const INVALID_IMPORT_BOOKS = [NOT_A_ZIP_BOOK, NOT_AN_EPUB_BOOK] as const;
 
 export type LibraryBookFixture =
   | typeof COVER_REFRESH_BOOK
+  | typeof EDITION_TITLE_BOOK
   | typeof VALID_BOOK
   | typeof LONG_BOOK
   | typeof MEDIA_SIZING_BOOK
@@ -39,6 +41,7 @@ interface BaseBookFixtureMetadata {
 
 interface LibraryBookFixtureMetadata extends BaseBookFixtureMetadata {
   title: string;
+  displayTitle?: string;
   readerText: string;
   partwayBookmark?: PartwayBookmarkMetadata;
 }
@@ -77,6 +80,15 @@ const fixtureMetadata = new Map<BookFixture, BookFixtureMetadata>([
       title: 'Cover refresh book',
       path: resolve(fixtureRoot, 'cover-refresh-book.epub'),
       readerText: 'This book has a deterministic cover image.'
+    }
+  ],
+  [
+    EDITION_TITLE_BOOK,
+    {
+      title: '52ヘルツのクジラたち【特典付き】 (中公文庫)',
+      displayTitle: '52ヘルツのクジラたち',
+      path: resolve(fixtureRoot, 'edition-title-book.epub'),
+      readerText: 'この本は書名表示のテスト用です。'
     }
   ],
   [
@@ -149,6 +161,11 @@ export function fixtureDescription(fixture: BookFixture) {
     : metadata.title;
 }
 
+export function fixtureDisplayTitle(fixture: LibraryBookFixture) {
+  const metadata = getFixtureMetadata(fixture);
+  return metadata.displayTitle ?? metadata.title;
+}
+
 export async function startImportBookFixtures(page: Page, fixtures: readonly BookFixture[]) {
   await navigateToManage(page);
   const importButton = page.getByRole('button', { name: 'Import Files' });
@@ -161,7 +178,7 @@ export async function importBookFixtures(page: Page, fixtures: readonly BookFixt
   await startImportBookFixtures(page, fixtures);
   await Promise.all(
     libraryBookFixtures(fixtures).map((fixture) =>
-      expect(page.getByText(fixtureTitle(fixture), { exact: true })).toBeVisible({
+      expect(page.getByText(fixtureDisplayTitle(fixture), { exact: true })).toBeVisible({
         timeout: SYNC_ASSERTION_TIMEOUT
       })
     )
@@ -250,7 +267,9 @@ export async function expectStatisticsInSummary(
       await expect(page.getByText(dateKey, { exact: true })).toBeVisible({
         timeout: SYNC_ASSERTION_TIMEOUT
       });
-      await expect(page.getByText(fixtureTitle(fixture), { exact: true }).first()).toBeVisible({
+      await expect(
+        page.getByText(fixtureDisplayTitle(fixture), { exact: true }).first()
+      ).toBeVisible({
         timeout: SYNC_ASSERTION_TIMEOUT
       });
     }),
@@ -291,7 +310,7 @@ export async function expectBookReaderText(page: Page, fixture: LibraryBookFixtu
 
 export async function deleteBookFromManage(page: Page, fixture: LibraryBookFixture) {
   await navigateToManage(page);
-  const title = fixtureTitle(fixture);
+  const title = fixtureDisplayTitle(fixture);
   const bookTitle = page.getByText(title, { exact: true });
   await expect(bookTitle).toBeVisible();
 
@@ -429,7 +448,7 @@ export async function expectImportFailedForFixture(page: Page, fixture: InvalidI
 
 export function bookCard(page: Page, fixture: LibraryBookFixture) {
   return page.locator('article').filter({
-    has: page.getByText(fixtureTitle(fixture), { exact: true })
+    has: page.getByText(fixtureDisplayTitle(fixture), { exact: true })
   });
 }
 
@@ -530,6 +549,7 @@ function libraryBookFixtures(fixtures: readonly BookFixture[]) {
   return fixtures.filter(
     (fixture): fixture is LibraryBookFixture =>
       fixture === COVER_REFRESH_BOOK ||
+      fixture === EDITION_TITLE_BOOK ||
       fixture === VALID_BOOK ||
       fixture === LONG_BOOK ||
       fixture === SPOILER_IMAGE_GALLERY_BOOK ||

--- a/tests/integration/manage/book-list.spec.ts
+++ b/tests/integration/manage/book-list.spec.ts
@@ -3,6 +3,7 @@ import {
   bookmarkFixturePartway,
   COVER_REFRESH_BOOK,
   expectBookPartwayProgress,
+  fixtureDisplayTitle,
   fixtureTitle,
   importBookFixtures,
   LONG_BOOK,
@@ -197,6 +198,6 @@ async function expectBookOrder(page: Page, fixtures: LibraryBookFixture[]) {
   await expect(cards).toHaveCount(fixtures.length);
 
   for (const [index, fixture] of fixtures.entries()) {
-    await expect(cards.nth(index)).toContainText(fixtureTitle(fixture));
+    await expect(cards.nth(index)).toContainText(fixtureDisplayTitle(fixture));
   }
 }

--- a/tests/integration/manage/book-title-format.spec.ts
+++ b/tests/integration/manage/book-title-format.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+import {
+  EDITION_TITLE_BOOK,
+  fixtureDisplayTitle,
+  fixtureTitle,
+  importBookFixtures,
+  openBookFromManage,
+  recordStatisticForBook,
+  startImportBookFixtures
+} from '../helpers/fixtures.ts';
+import {
+  navigateToManage,
+  navigateToSettingsReader,
+  navigateToSettingsSync,
+  navigateToStatisticsSummary
+} from '../helpers/navigation.ts';
+import { enableStatistics } from '../helpers/workflows.ts';
+import { openStatisticsFilter } from '../statistics/helpers.ts';
+
+test('uses simplified titles by default without changing book URLs', async ({ page }) => {
+  const fullTitle = fixtureTitle(EDITION_TITLE_BOOK);
+  const simplifiedTitle = fixtureDisplayTitle(EDITION_TITLE_BOOK);
+
+  await startImportBookFixtures(page, [EDITION_TITLE_BOOK]);
+  await expect(page.getByText(simplifiedTitle, { exact: true })).toBeVisible();
+  await expect(page.getByText(fullTitle, { exact: true })).toHaveCount(0);
+
+  await openBookFromManage(page, EDITION_TITLE_BOOK);
+  await expect(page).toHaveTitle(`${simplifiedTitle} | Miwake Reader`);
+  expect(new URL(page.url()).searchParams.get('t')).toBe(fullTitle);
+
+  await navigateToSettingsReader(page);
+  await page.getByRole('button', { name: 'Full', exact: true }).click();
+  await navigateToManage(page);
+
+  await expect(page.getByText(fullTitle, { exact: true })).toBeVisible();
+  await expect(page.getByText(simplifiedTitle, { exact: true })).toHaveCount(0);
+});
+
+test('uses simplified titles in statistics and backup selection', async ({ page }) => {
+  const fullTitle = fixtureTitle(EDITION_TITLE_BOOK);
+  const simplifiedTitle = fixtureDisplayTitle(EDITION_TITLE_BOOK);
+  const statisticDate = '2026-08-08';
+
+  await page.clock.install({ time: new Date(`${statisticDate}T12:00:00Z`) });
+  await enableStatistics(page);
+  await importBookFixtures(page, [EDITION_TITLE_BOOK]);
+  await recordStatisticForBook(page, EDITION_TITLE_BOOK, statisticDate);
+
+  await navigateToStatisticsSummary(page);
+  await expect(page.getByTitle(simplifiedTitle).filter({ visible: true })).toBeVisible();
+  await expect(page.getByText(fullTitle, { exact: true })).toHaveCount(0);
+
+  const filter = await openStatisticsFilter(page);
+  await expect(filter.getByText(simplifiedTitle, { exact: true })).toBeVisible();
+  await expect(filter.getByText(fullTitle, { exact: true })).toHaveCount(0);
+  await filter.getByTitle('Close book filter').click();
+
+  await navigateToSettingsSync(page);
+  await page.getByRole('button', { name: 'Export' }).click();
+  const dialog = page.locator('dialog[open]').filter({
+    has: page.getByRole('heading', { name: 'Export backup' })
+  });
+  await expect(dialog.getByText(simplifiedTitle, { exact: true })).toBeVisible();
+  await expect(dialog.getByText(fullTitle, { exact: true })).toHaveCount(0);
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+});

--- a/tests/integration/statistics/helpers.ts
+++ b/tests/integration/statistics/helpers.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect, SYNC_ASSERTION_TIMEOUT } from '../helpers/harness.ts';
-import { fixtureTitle, type LibraryBookFixture } from '../helpers/fixtures.ts';
+import { fixtureDisplayTitle, type LibraryBookFixture } from '../helpers/fixtures.ts';
 
 export const EARLIER_STAT_DATE = '2026-04-10';
 export const LATER_STAT_DATE = '2026-05-10';
@@ -21,7 +21,7 @@ export async function setStatisticsFilterBook(
 ) {
   await filter
     .locator('tr')
-    .filter({ hasText: fixtureTitle(fixture) })
+    .filter({ hasText: fixtureDisplayTitle(fixture) })
     .getByRole('checkbox')
     .setChecked(checked);
 }
@@ -43,11 +43,15 @@ export async function expectStatisticsView(page: Page, view: 'summary' | 'heatma
 }
 
 export async function expectSummaryBookVisible(page: Page, fixture: LibraryBookFixture) {
-  await expect(page.getByTitle(fixtureTitle(fixture)).filter({ visible: true })).toBeVisible({
-    timeout: SYNC_ASSERTION_TIMEOUT
-  });
+  await expect(page.getByTitle(fixtureDisplayTitle(fixture)).filter({ visible: true })).toBeVisible(
+    {
+      timeout: SYNC_ASSERTION_TIMEOUT
+    }
+  );
 }
 
 export async function expectSummaryBookHidden(page: Page, fixture: LibraryBookFixture) {
-  await expect(page.getByTitle(fixtureTitle(fixture)).filter({ visible: true })).toHaveCount(0);
+  await expect(page.getByTitle(fixtureDisplayTitle(fixture)).filter({ visible: true })).toHaveCount(
+    0
+  );
 }

--- a/tests/unit/book-title.spec.ts
+++ b/tests/unit/book-title.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { compareBookTitles, displayTitle } from '../../src/lib/functions/book-title.ts';
+import { simplifyBookTitles$ } from '../../src/lib/data/book-title-settings.ts';
+
+afterEach(() => {
+  simplifyBookTitles$.set(true);
+});
+
+describe('displayTitle', () => {
+  const simplifiedTitles = [
+    ['コンビニ人間 (文春文庫)', 'コンビニ人間'],
+    ['わたし、定時で帰ります。（新潮文庫）', 'わたし、定時で帰ります。'],
+    [
+      'ソードアート・オンライン2 アインクラッド (電撃文庫)',
+      'ソードアート・オンライン2 アインクラッド'
+    ],
+    ['52ヘルツのクジラたち【特典付き】 (中公文庫)', '52ヘルツのクジラたち'],
+    ['作品名【電子限定イラスト付き】', '作品名'],
+    ['作品名（完全版）（文春文庫）', '作品名'],
+    ['作品名 (MF文庫J)', '作品名'],
+    ['作品名（中公新書ラクレ）', '作品名'],
+    ['山田くんとLv999の恋をする（１） (MFC)', '山田くんとLv999の恋をする（１）']
+  ] as const;
+
+  for (const [title, expectedTitle] of simplifiedTitles) {
+    it(`simplifies ${title}`, () => {
+      expect(displayTitle(title)).toBe(expectedTitle);
+    });
+  }
+
+  const unchangedTitles = [
+    '世界から猫が消えたなら',
+    '山田くんとLv999の恋をする（１）',
+    '山田くんとLv999の恋をする（第1巻）',
+    'ノルウェイの森（上）',
+    '【推しの子】',
+    '文庫という名前の本（仮）',
+    '出版をめぐる物語（文庫について）'
+  ];
+
+  for (const title of unchangedTitles) {
+    it(`preserves ${title}`, () => {
+      expect(displayTitle(title)).toBe(title);
+    });
+  }
+
+  it('does not simplify a title to an empty string', () => {
+    expect(displayTitle('（文庫版）')).toBe('（文庫版）');
+  });
+
+  it('returns the stored title when the setting is off', () => {
+    simplifyBookTitles$.set(false);
+
+    expect(displayTitle('コンビニ人間 (文春文庫)')).toBe('コンビニ人間 (文春文庫)');
+  });
+});
+
+describe('compareBookTitles', () => {
+  it('breaks display-title ties using the stored title', () => {
+    expect(compareBookTitles('コンビニ人間', 'コンビニ人間 (文春文庫)')).toBeLessThan(0);
+    expect(compareBookTitles('コンビニ人間 (文春文庫)', 'コンビニ人間')).toBeGreaterThan(0);
+    expect(compareBookTitles('コンビニ人間 (文春文庫)', 'コンビニ人間 (文春文庫)')).toBe(0);
+  });
+
+  it('compares numbered volumes numerically', () => {
+    expect(compareBookTitles('作品名 2巻 (文春文庫)', '作品名 10巻 (文春文庫)')).toBeLessThan(0);
+  });
+});


### PR DESCRIPTION
Displayed book titles now drop recognized edition, imprint, and bundled-content suffixes (e.g. ` (文春文庫)`, `【特典付き】`), controlled by a new "Book Title Display" setting that defaults to simplified. Display sites call `displayTitle()` and sort sites use `compareBookTitles()`; stored titles — database keys, URLs, sync folders, backups — are unchanged. Fixes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)