### PR TITLE
feat: add mobile header layouts with bottom tab navigation

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -9,7 +9,6 @@
   --font-serif: 'Noto Serif JP', serif;
   --color-background-color: var(--background-color);
   --spacing-21: 5.25rem;
-  --container-60vw: 60vw;
 }
 
 @layer base {
@@ -41,7 +40,7 @@
 }
 
 @utility sync-indicator-inset {
-  bottom: var(--sync-indicator-gap);
+  bottom: calc(var(--mobile-navigation-height) + var(--sync-indicator-gap));
   left: var(--sync-indicator-gap);
 }
 
@@ -53,10 +52,27 @@
 :root {
   --font-color: rgba(0, 0, 0, 0.87);
   --background-color: #eceff1;
+  --header-height: 3rem;
   --sync-indicator-gap: 0.25rem;
   --sync-indicator-size: 2rem;
   --sync-safe-inline-inset: calc(var(--sync-indicator-size) + var(--sync-indicator-gap) * 2);
+  --mobile-navigation-height: 0px;
   scrollbar-color: #c1c1c1 #c1c1c100;
+}
+
+@media (width < theme(--breakpoint-md)) {
+  body:has([data-mobile-navigation]) {
+    --mobile-navigation-height: calc(var(--header-height) + env(safe-area-inset-bottom));
+  }
+
+  /* The reader page marks the bottom navigation `inert` while its chrome is hidden. */
+  body:has([data-mobile-navigation][inert]) {
+    --mobile-navigation-height: 0px;
+  }
+}
+
+#app-shell {
+  padding-bottom: var(--mobile-navigation-height);
 }
 
 @media (width >= 40rem) {

--- a/src/lib/components/book-card/book-card-actions.svelte
+++ b/src/lib/components/book-card/book-card-actions.svelte
@@ -124,10 +124,15 @@
   {/if}
 {/snippet}
 
-<div class="mt-2.5 grid grid-cols-[1fr_1fr_auto] gap-1">
-  {@render cardAction(faChartLine, 'Stats', `View statistics for ${title}`, {
-    href: resolve(getBookStatisticsURL(bookCard.title))
-  })}
+<div
+  data-book-card-actions
+  class="mt-2.5 grid grid-cols-[1fr_auto] gap-1 sm:grid-cols-[1fr_1fr_auto]"
+>
+  <div class="hidden sm:contents">
+    {@render cardAction(faChartLine, 'Stats', `View statistics for ${title}`, {
+      href: resolve(getBookStatisticsURL(bookCard.title))
+    })}
+  </div>
 
   {#if bookCard.isPlaceholder}
     {@render cardAction(faDownload, 'Download', `Download ${title}`, {
@@ -136,15 +141,16 @@
   {:else}
     <Popover
       bind:this={detailsPopover}
-      placement="top"
-      fallbackPlacements={['right', 'left', 'bottom']}
+      innerContainerStyles="width: 100%;"
+      placement="top-start"
+      fallbackPlacements={['bottom-start', 'top-end', 'bottom-end']}
       yOffset={5}
     >
       {#snippet icon()}
         {@render cardAction(faCircleInfo, 'Details', `Details for ${title}`, {}, true)}
       {/snippet}
       {#snippet content()}
-        <div class="w-80 max-w-[calc(100vw-2rem)] p-4 font-normal">
+        <div data-book-details class="w-80 max-w-[calc(100vw-2rem)] p-4 font-normal">
           <div class="wrap-break-word font-medium">{title}</div>
           <dl class="mt-3 grid gap-2 text-xs">
             {#each detailRows as row (row.label)}

--- a/src/lib/components/book-card/book-manager-header.svelte
+++ b/src/lib/components/book-card/book-manager-header.svelte
@@ -1,29 +1,25 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import type { ResolvedPathname } from '$app/types';
-  import HeaderButton from '$lib/components/header-button.svelte';
+  import BookSortMenuButton from '$lib/components/book-card/book-sort-menu-button.svelte';
+  import HeaderButton, { type HeaderAction } from '$lib/components/header-button.svelte';
   import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import Popover from '$lib/components/popover/popover.svelte';
   import { baseHeaderClasses, headerDividerClasses } from '$lib/css-classes';
-  import { SortDirection, type SortOption } from '$lib/functions/sorting';
   import { FilesystemStorageHandler } from '$lib/data/storage/handler/filesystem-handler';
-  import { booklistSortOptions$ } from '$lib/data/store';
   import { inputAllowDirectory } from '$lib/functions/file-dom/input-allow-directory';
   import { inputFile } from '$lib/functions/file-dom/input-file';
   import {
-    faArrowDownShortWide,
-    faArrowDownWideShort,
     faBug,
     faCalendarXmark,
     faChartLine,
     faCircleXmark,
     faDownload,
+    faEllipsis,
     faFile,
     faFlag,
     faFolder,
-    faSortDown,
-    faSortUp,
     faTrash
   } from '@fortawesome/free-solid-svg-icons';
   import Fa from 'svelte-fa';
@@ -88,20 +84,80 @@
     showLoadCount = new URLSearchParams(window.location.search).has('count');
   }
 
-  const sortMenuItems: { property: SortOption['property']; label: string }[] = [
-    { property: 'addedOrder', label: 'Added' },
-    { property: 'title', label: 'Title' },
-    { property: 'characters', label: 'Characters' },
-    { property: 'lastBookModified', label: 'Last Update' },
-    { property: 'lastBookOpen', label: 'Last Read' },
-    { property: 'progress', label: 'Progress' },
-    { property: 'lastBookmarkModified', label: 'Bookmarked' }
-  ];
-
   let allBooksSelected = $derived(bookCount > 0 && selectedCount === bookCount);
   let allSelectedBooksCompleted = $derived(
     selectedCount > 0 && selectedCompletedCount === selectedCount
   );
+
+  const importActions: HeaderAction[] = [
+    {
+      faIcon: faFile,
+      label: 'Import Files',
+      title: 'Import book files',
+      onclick: () => fileImportElm?.click()
+    },
+    ...(supportsDirectoryPicking
+      ? [
+          {
+            faIcon: faFolder,
+            label: 'Import Folder',
+            title: 'Import books from a folder',
+            onclick: () => folderImportElm?.click()
+          }
+        ]
+      : [])
+  ];
+
+  let primarySelectionActions: HeaderAction[] = $derived([
+    ...(statisticsHref
+      ? [
+          {
+            faIcon: faChartLine,
+            label: 'View Stats',
+            menuLabel: 'View Statistics',
+            title: 'View statistics for selected books',
+            href: statisticsHref
+          }
+        ]
+      : []),
+    {
+      faIcon: faFlag,
+      label: allSelectedBooksCompleted ? 'In Progress' : 'Complete',
+      menuLabel: allSelectedBooksCompleted ? 'Mark In Progress' : 'Mark Complete',
+      title: allSelectedBooksCompleted
+        ? 'Mark selected books as in progress'
+        : 'Mark selected books as complete',
+      width: 'wide' as const,
+      onclick: () => oncompletionChange?.(!allSelectedBooksCompleted)
+    },
+    ...(selectedPlaceholderCount > 0
+      ? [
+          {
+            faIcon: faDownload,
+            label: 'Download',
+            title: 'Download selected books to this device',
+            onclick: () => ondownloadClick?.()
+          }
+        ]
+      : [])
+  ]);
+  const destructiveSelectionActions: HeaderAction[] = [
+    {
+      faIcon: faCalendarXmark,
+      label: 'Delete Stats',
+      menuLabel: 'Delete Statistics',
+      title: 'Delete statistics for selected books',
+      onclick: () => ondeleteStatistics?.()
+    },
+    {
+      faIcon: faTrash,
+      label: 'Remove',
+      menuLabel: 'Remove Books',
+      title: 'Remove selected books from the library',
+      onclick: () => onremoveClick?.()
+    }
+  ];
+  let selectionMenuItems = $derived([...primarySelectionActions, ...destructiveSelectionActions]);
 
   function dispatchFilesChange(fileList: FileList) {
     onfilesChange?.(fileList);
@@ -139,15 +195,20 @@
   use:inputFile={setCountData}
   bind:this={countImportElm}
 />
-<div class={baseHeaderClasses}>
+<div class={baseHeaderClasses} role="toolbar" aria-label="Library controls">
   {#if !replicationToProgress}
-    <div class="flex h-full justify-between">
-      <div class="flex">
+    <div
+      data-mobile-actions
+      class="grid h-full grid-flow-col auto-cols-fr md:flex md:justify-between"
+    >
+      <div class="contents md:flex">
         <HeaderButton
           title={selectMode ? 'Disable book selection' : 'Enable book selection'}
           label="Select"
           selected={selectMode}
-          onclick={() => (selectMode = bookCount > 0 && !selectMode)}
+          onclick={() => {
+            selectMode = bookCount > 0 && !selectMode;
+          }}
         >
           {#snippet icon()}
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="size-3.5">
@@ -159,30 +220,32 @@
           {/snippet}
         </HeaderButton>
         {#if !selectMode}
-          <div class={headerDividerClasses}></div>
-          <HeaderButton
-            faIcon={faFile}
-            title="Import book files"
-            label="Import Files"
-            onclick={() => fileImportElm?.click()}
-          />
-          {#if supportsDirectoryPicking}
-            <HeaderButton
-              faIcon={faFolder}
-              title="Import books from a folder"
-              label="Import Folder"
-              onclick={() => folderImportElm?.click()}
+          <div class="hidden md:block {headerDividerClasses}"></div>
+          <div class="hidden md:contents">
+            {#each importActions as importAction (importAction.label)}
+              <HeaderButton {...importAction} />
+            {/each}
+          </div>
+          <div class="contents md:hidden">
+            <HeaderMenuButton
+              faIcon={faFile}
+              label="Import"
+              fill
+              title="Import books"
+              items={importActions}
             />
-          {/if}
+          </div>
+          <!-- On narrow viewports the sort menu (from the trailing cluster) slots in before this. -->
           <HeaderButton
             faIcon={faBug}
             title="Report a bug"
             label="Bug Report"
+            class="max-md:order-last"
             onclick={() => onbugReportClick?.()}
           />
         {:else}
           <span
-            class="flex w-12 shrink-0 items-center justify-center text-xl font-medium tabular-nums"
+            class="flex w-full items-center justify-center text-xl font-medium tabular-nums md:w-12 md:shrink-0"
             title="{selectedCount} {selectedCount === 1 ? 'book' : 'books'} selected"
             aria-live="polite"
           >
@@ -205,121 +268,47 @@
             {/snippet}
           </HeaderButton>
           {#if selectedCount > 0}
-            <div class={headerDividerClasses}></div>
-            {#if statisticsHref}
-              <HeaderButton
-                faIcon={faChartLine}
-                title="View statistics for selected books"
-                label="View Stats"
-                href={statisticsHref}
+            <div class="hidden md:contents">
+              <div class={headerDividerClasses}></div>
+              {#each primarySelectionActions as selectionAction (selectionAction.label)}
+                <HeaderButton {...selectionAction} />
+              {/each}
+              <div class={headerDividerClasses}></div>
+              {#each destructiveSelectionActions as selectionAction (selectionAction.label)}
+                <HeaderButton {...selectionAction} />
+              {/each}
+            </div>
+            <div class="contents md:hidden">
+              <HeaderMenuButton
+                faIcon={faEllipsis}
+                label="Actions"
+                fill
+                title="Actions for selected books"
+                items={selectionMenuItems}
               />
-            {/if}
-            <HeaderButton
-              faIcon={faFlag}
-              title={allSelectedBooksCompleted
-                ? 'Mark selected books as in progress'
-                : 'Mark selected books as complete'}
-              label={allSelectedBooksCompleted ? 'In Progress' : 'Complete'}
-              width="wide"
-              onclick={() => oncompletionChange?.(!allSelectedBooksCompleted)}
-            />
-            {#if selectedPlaceholderCount > 0}
-              <HeaderButton
-                faIcon={faDownload}
-                title="Download selected books to this device"
-                label="Download"
-                onclick={() => ondownloadClick?.()}
-              />
-            {/if}
-            <div class={headerDividerClasses}></div>
-            <HeaderButton
-              faIcon={faCalendarXmark}
-              title="Delete statistics for selected books"
-              label="Delete Stats"
-              onclick={() => ondeleteStatistics?.()}
-            />
-            <HeaderButton
-              faIcon={faTrash}
-              title="Remove selected books from the library"
-              label="Remove"
-              onclick={() => onremoveClick?.()}
-            />
+            </div>
           {/if}
         {/if}
       </div>
 
-      <div class="flex">
+      <div class="contents md:flex">
         {#if !selectMode}
-          <div class="relative transform-gpu">
-            <HeaderMenuButton
-              title="Select sort options"
-              label="Sort"
-              faIcon={$booklistSortOptions$.direction === SortDirection.ASC
-                ? faArrowDownShortWide
-                : faArrowDownWideShort}
-              items={sortMenuItems}
-            >
-              {#snippet item(sortMenuItem, close)}
-                {@const isCurrentSort = $booklistSortOptions$.property === sortMenuItem.property}
-                {@const isCurrentSortAsc =
-                  isCurrentSort && $booklistSortOptions$.direction === SortDirection.ASC}
-                <div
-                  class="grid cursor-default grid-cols-[auto_auto_auto] text-sm hover:bg-white hover:text-gray-700"
-                  class:bg-white={isCurrentSort}
-                  class:text-gray-700={isCurrentSort}
-                  class:hover:opacity-70={isCurrentSort}
-                >
-                  <button
-                    type="button"
-                    aria-label={`Sort by ${sortMenuItem.label} ascending`}
-                    class="self-center justify-self-start"
-                    class:text-red-500={isCurrentSortAsc}
-                    class:hover:text-gray-700={isCurrentSortAsc}
-                    class:hover:text-red-500={!isCurrentSortAsc}
-                    onclick={() => {
-                      booklistSortOptions$.set({
-                        property: sortMenuItem.property,
-                        direction: SortDirection.ASC
-                      });
-                      close();
-                    }}
-                  >
-                    <Fa icon={faSortUp} class="px-4" />
-                  </button>
-                  <div class="py-2">
-                    {sortMenuItem.label}
-                  </div>
-                  <button
-                    type="button"
-                    aria-label={`Sort by ${sortMenuItem.label} descending`}
-                    class="justify-self-end hover:text-red-500"
-                    class:text-red-500={isCurrentSort && !isCurrentSortAsc}
-                    class:hover:text-gray-700={isCurrentSort && !isCurrentSortAsc}
-                    class:hover:text-red-500={!isCurrentSort || isCurrentSortAsc}
-                    onclick={() => {
-                      booklistSortOptions$.set({
-                        property: sortMenuItem.property,
-                        direction: SortDirection.DESC
-                      });
-                      close();
-                    }}
-                  >
-                    <Fa icon={faSortDown} class="mt-1 px-4" />
-                  </button>
-                </div>
-              {/snippet}
-            </HeaderMenuButton>
+          <div class="contents md:relative md:block md:transform-gpu">
+            <BookSortMenuButton />
           </div>
-          <div class={headerDividerClasses}></div>
+          <div class="hidden md:block {headerDividerClasses}"></div>
           {#if showLoadCount}
             <button
               type="button"
+              class="hidden md:block"
               style:color={fileCountData ? 'red' : undefined}
               onclick={() => countImportElm?.click()}>C</button
             >
           {/if}
         {/if}
-        <HeaderNavTabs />
+        <div class="hidden md:contents">
+          <HeaderNavTabs />
+        </div>
       </div>
     </div>
   {:else}

--- a/src/lib/components/book-card/book-sort-menu-button.svelte
+++ b/src/lib/components/book-card/book-sort-menu-button.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
+  import { SortDirection, type SortOption } from '$lib/functions/sorting';
+  import { booklistSortOptions$ } from '$lib/data/store';
+  import {
+    faArrowDownShortWide,
+    faArrowDownWideShort,
+    faSortDown,
+    faSortUp
+  } from '@fortawesome/free-solid-svg-icons';
+  import Fa from 'svelte-fa';
+
+  const sortMenuItems: { property: SortOption['property']; label: string }[] = [
+    { property: 'addedOrder', label: 'Added' },
+    { property: 'title', label: 'Title' },
+    { property: 'characters', label: 'Characters' },
+    { property: 'lastBookModified', label: 'Last Update' },
+    { property: 'lastBookOpen', label: 'Last Read' },
+    { property: 'progress', label: 'Progress' },
+    { property: 'lastBookmarkModified', label: 'Bookmarked' }
+  ];
+
+  function setSort(property: SortOption['property'], direction: SortDirection, close: () => void) {
+    booklistSortOptions$.set({ property, direction });
+    close();
+  }
+</script>
+
+<HeaderMenuButton
+  title="Select sort options"
+  label="Sort"
+  fill
+  faIcon={$booklistSortOptions$.direction === SortDirection.ASC
+    ? faArrowDownShortWide
+    : faArrowDownWideShort}
+  items={sortMenuItems}
+>
+  {#snippet item(sortMenuItem, close)}
+    {@const isCurrentSort = $booklistSortOptions$.property === sortMenuItem.property}
+    {@const isCurrentSortAsc =
+      isCurrentSort && $booklistSortOptions$.direction === SortDirection.ASC}
+    <div
+      class="grid cursor-default grid-cols-[auto_auto_auto] text-sm hover:bg-white hover:text-gray-700"
+      class:bg-white={isCurrentSort}
+      class:text-gray-700={isCurrentSort}
+      class:hover:opacity-70={isCurrentSort}
+    >
+      <button
+        type="button"
+        aria-label={`Sort by ${sortMenuItem.label} ascending`}
+        class="self-center justify-self-start"
+        class:text-red-500={isCurrentSortAsc}
+        class:hover:text-gray-700={isCurrentSortAsc}
+        class:hover:text-red-500={!isCurrentSortAsc}
+        onclick={() => setSort(sortMenuItem.property, SortDirection.ASC, close)}
+      >
+        <Fa icon={faSortUp} class="px-4" />
+      </button>
+      <div class="py-2">
+        {sortMenuItem.label}
+      </div>
+      <button
+        type="button"
+        aria-label={`Sort by ${sortMenuItem.label} descending`}
+        class="justify-self-end hover:text-red-500"
+        class:text-red-500={isCurrentSort && !isCurrentSortAsc}
+        class:hover:text-gray-700={isCurrentSort && !isCurrentSortAsc}
+        class:hover:text-red-500={!isCurrentSort || isCurrentSortAsc}
+        onclick={() => setSort(sortMenuItem.property, SortDirection.DESC, close)}
+      >
+        <Fa icon={faSortDown} class="mt-1 px-4" />
+      </button>
+    </div>
+  {/snippet}
+</HeaderMenuButton>

--- a/src/lib/components/book-reader/book-reader-header.svelte
+++ b/src/lib/components/book-reader/book-reader-header.svelte
@@ -3,6 +3,7 @@
   import {
     faBookmark as fasBookmark,
     faCrosshairs,
+    faEllipsis,
     faExpand,
     faFlag,
     faHashtag,
@@ -11,7 +12,7 @@
     faRotateLeft
   } from '@fortawesome/free-solid-svg-icons';
   import { readerImageGallery } from '$lib/components/book-reader/book-reader-image-gallery/book-reader-image-gallery-state.svelte';
-  import HeaderButton from '$lib/components/header-button.svelte';
+  import HeaderButton, { type HeaderAction } from '$lib/components/header-button.svelte';
   import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import { baseHeaderClasses, headerDividerClasses } from '$lib/css-classes';
@@ -20,7 +21,6 @@
   import { ViewMode } from '$lib/data/view-mode';
 
   interface Props {
-    currentBookTitle?: string;
     hasChapterData: boolean;
     hasText: boolean;
     autoScrollMultiplier: number;
@@ -43,7 +43,6 @@
   }
 
   let {
-    currentBookTitle,
     hasChapterData,
     hasText,
     autoScrollMultiplier,
@@ -66,14 +65,64 @@
   }: Props = $props();
 
   let customReadingPointMenuItems = $derived([
-    ...(hasCustomReadingPoint ? [{ label: 'Show Point', action: onshowCustomReadingPoint }] : []),
-    { label: 'Set Point', action: onsetCustomReadingPoint },
-    ...(hasCustomReadingPoint ? [{ label: 'Reset Point', action: onresetCustomReadingPoint }] : [])
+    ...(hasCustomReadingPoint ? [{ label: 'Show Point', onclick: onshowCustomReadingPoint }] : []),
+    { label: 'Set Point', onclick: onsetCustomReadingPoint },
+    ...(hasCustomReadingPoint ? [{ label: 'Reset Point', onclick: onresetCustomReadingPoint }] : [])
+  ]);
+  let showCustomReadingPointMenu = $derived(
+    $customReadingPointEnabled$ || $viewMode$ === ViewMode.Paginated
+  );
+  let secondaryActions: HeaderAction[] = $derived([
+    {
+      faIcon: faFlag,
+      label: isBookCompleted ? 'Undo Complete' : 'Complete Book',
+      title: isBookCompleted ? 'Mark book as not completed' : 'Mark book as completed',
+      onclick: () => (isBookCompleted ? onuncompleteBook?.() : oncompleteBook?.())
+    },
+    ...(showFullscreenButton
+      ? [
+          {
+            faIcon: faExpand,
+            label: 'Fullscreen',
+            title: 'Toggle fullscreen',
+            onclick: () => onfullscreenClick?.()
+          }
+        ]
+      : []),
+    ...(hasText
+      ? [
+          {
+            faIcon: faHashtag,
+            label: 'Jump',
+            menuLabel: 'Jump to Character',
+            title: 'Jump to character',
+            onclick: () => onjumpClick?.()
+          }
+        ]
+      : []),
+    ...(readerImageGallery.hasPictures
+      ? [
+          {
+            faIcon: faImages,
+            label: 'Images',
+            menuLabel: 'Open Image Gallery',
+            title: 'Open image gallery',
+            onclick: () => onreaderImageGalleryClick?.()
+          }
+        ]
+      : [])
+  ]);
+  let mobileMenuItems = $derived([
+    ...secondaryActions,
+    ...(showCustomReadingPointMenu ? customReadingPointMenuItems : [])
   ]);
 </script>
 
-<div class="flex justify-between {baseHeaderClasses}">
-  <div class="flex">
+<div
+  data-mobile-actions
+  class="grid grid-flow-col auto-cols-fr md:flex md:justify-between {baseHeaderClasses}"
+>
+  <div class="contents md:flex">
     {#if hasChapterData}
       <HeaderButton
         faIcon={faList}
@@ -93,57 +142,41 @@
         faIcon={faRotateLeft}
         title="Return to bookmark"
         label="Return to Bookmark"
+        mobileLabel="Return"
         onclick={() => onscrollToBookmarkClick?.()}
       />
     {/if}
     {#if $viewMode$ === ViewMode.Continuous && !deviceEnvironment.isMobile}
-      <div class="flex items-center px-4 text-xl" title="Current autoscroll speed">
+      <div class="hidden items-center px-4 text-xl md:flex" title="Current autoscroll speed">
         {autoScrollMultiplier}x
       </div>
     {/if}
-    <HeaderButton
-      faIcon={faFlag}
-      title={isBookCompleted ? 'Mark book as not completed' : 'Mark book as completed'}
-      label={isBookCompleted ? 'Undo Complete' : 'Complete Book'}
-      onclick={() => (isBookCompleted ? onuncompleteBook?.() : oncompleteBook?.())}
-    />
-    {#if showFullscreenButton}
-      <HeaderButton
-        faIcon={faExpand}
-        title="Toggle fullscreen"
-        label="Fullscreen"
-        onclick={() => onfullscreenClick?.()}
+    <div class="hidden md:contents">
+      {#each secondaryActions as secondaryAction (secondaryAction.label)}
+        <HeaderButton {...secondaryAction} />
+      {/each}
+    </div>
+    <div class="contents md:hidden">
+      <HeaderMenuButton
+        faIcon={faEllipsis}
+        title="More reader actions"
+        label="More"
+        fill
+        items={mobileMenuItems}
       />
-    {/if}
-    {#if hasText}
-      <HeaderButton
-        faIcon={faHashtag}
-        title="Jump to character"
-        label="Jump"
-        onclick={() => onjumpClick?.()}
-      />
-    {/if}
-    {#if readerImageGallery.hasPictures}
-      <HeaderButton
-        faIcon={faImages}
-        title="Open image gallery"
-        label="Images"
-        onclick={() => onreaderImageGalleryClick?.()}
-      />
-    {/if}
+    </div>
   </div>
 
-  <div class="flex">
-    {#if $customReadingPointEnabled$ || $viewMode$ === ViewMode.Paginated}
+  <div class="hidden md:flex">
+    {#if showCustomReadingPointMenu}
       <HeaderMenuButton
         faIcon={faCrosshairs}
         title="Open custom point actions"
         label="Point"
         items={customReadingPointMenuItems}
-        onselect={(actionItem) => actionItem.action?.()}
       />
       <div class={headerDividerClasses}></div>
     {/if}
-    <HeaderNavTabs {currentBookTitle} />
+    <HeaderNavTabs />
   </div>
 </div>

--- a/src/lib/components/header-button.svelte
+++ b/src/lib/components/header-button.svelte
@@ -1,37 +1,66 @@
-<script lang="ts">
+<script lang="ts" module>
   import type { ResolvedPathname } from '$app/types';
   import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
-  import { ripple } from '$lib/components/ripple';
   import type { Snippet } from 'svelte';
-  import Fa from 'svelte-fa';
 
   type Variant = 'action' | 'tab';
   type Width = 'default' | 'wide';
 
+  /**
+   * Wider than a DOM click handler so the same function can back a button, which passes the
+   * `MouseEvent` through, and a `HeaderMenuButton` entry, which awaits the result before closing
+   * the menu.
+   */
+  export type HeaderClickHandler = (event: MouseEvent) => void | Promise<void>;
+
   interface CommonProps {
     faIcon?: IconDefinition;
-    label?: string;
+    label: string;
+    /** Replaces `label` below the `md` breakpoint, where horizontal space is scarce. */
+    mobileLabel?: string;
     title?: string;
     selected?: boolean;
+    fill?: boolean;
     variant?: Variant;
     width?: Width;
+    class?: string;
     icon?: Snippet;
   }
 
   type Props = CommonProps &
     (
       | { href: ResolvedPathname; disabled?: never; onclick?: never }
-      | { href?: undefined; disabled?: boolean; onclick?: (event: MouseEvent) => void }
+      | { href?: undefined; disabled?: boolean; onclick?: HeaderClickHandler }
     );
+
+  /**
+   * A header control described as data, so a header can spread it straight onto a `HeaderButton`
+   * on wide viewports and pass it as a `HeaderMenuButton` item below the `md` breakpoint.
+   * `faIcon` and `title` are required here even though buttons render without them: a data record
+   * cannot carry the `icon` snippet alternative, and only tab-style usages go without tooltips.
+   */
+  export type HeaderAction = Props &
+    Required<Pick<CommonProps, 'faIcon' | 'title'>> & {
+      /** Menu entries have room for longer labels; falls back to `label`. */
+      menuLabel?: string;
+    };
+</script>
+
+<script lang="ts">
+  import { ripple } from '$lib/components/ripple';
+  import Fa from 'svelte-fa';
 
   let {
     faIcon,
     label,
+    mobileLabel,
     title,
     disabled = false,
     selected = false,
+    fill = false,
     variant = 'action',
     width = 'default',
+    class: extraClasses = '',
     href,
     onclick,
     icon
@@ -43,21 +72,26 @@
     action: 'opacity-60 transition-opacity',
     tab: ''
   } satisfies Record<Variant, string>;
+  // `fill` and `wide` only shape their own breakpoints: below `md` a button either stretches to
+  // its container (`fill`) or keeps its natural minimum, while `wide` reserves extra room for
+  // labels that toggle (e.g. "Complete"/"In Progress") without shifting neighboring buttons.
   const widthClasses = {
     default: '',
-    wide: 'w-20 shrink-0'
+    wide: 'md:w-20 md:shrink-0'
   } satisfies Record<Width, string>;
 
   let classes = $derived(
     [
-      'flex h-12 min-w-16 flex-col items-center justify-center px-2 text-center text-xs select-none',
+      'flex h-(--header-height) min-w-16 flex-col items-center justify-center px-2 text-center text-xs select-none',
+      fill ? 'max-md:w-full max-md:min-w-0' : '',
       variantClasses[variant],
       widthClasses[width],
       variant === 'action' && selected ? 'opacity-100' : '',
       variant === 'tab' && selected ? 'bg-gray-900 hover:bg-gray-800' : '',
       variant === 'tab' && !selected ? 'hover:bg-gray-900' : '',
       variant === 'action' && !disabled ? 'hover:opacity-100' : '',
-      disabled ? 'cursor-not-allowed opacity-30' : ''
+      disabled ? 'cursor-not-allowed opacity-30' : '',
+      extraClasses
     ]
       .filter(Boolean)
       .join(' ')
@@ -74,7 +108,12 @@
   {/if}
 
   {#if label}
-    <span>{label}</span>
+    {#if mobileLabel !== undefined && mobileLabel !== label}
+      <span class="md:hidden">{mobileLabel}</span>
+      <span class="hidden md:inline">{label}</span>
+    {:else}
+      <span>{label}</span>
+    {/if}
   {/if}
 {/snippet}
 

--- a/src/lib/components/header-menu-button.svelte
+++ b/src/lib/components/header-menu-button.svelte
@@ -1,28 +1,41 @@
-<script lang="ts">
+<script lang="ts" module>
+  import type { ResolvedPathname } from '$app/types';
+  import type { HeaderClickHandler } from '$lib/components/header-button.svelte';
+
+  /**
+   * The contract of the default item renderer: entries show `menuLabel` (falling back to
+   * `label`), `href` items render as links, and everything else renders as a button invoking
+   * `onclick` — awaited, so slow work finishes before the menu closes. `HeaderAction` records
+   * satisfy this shape, so headers can pass the same objects here and to `HeaderButton`.
+   */
+  export interface HeaderMenuItem {
+    label: string;
+    menuLabel?: string;
+    title?: string;
+    href?: ResolvedPathname;
+    selected?: boolean;
+    disabled?: boolean;
+    onclick?: HeaderClickHandler;
+  }
+</script>
+
+<script lang="ts" generics="T extends HeaderMenuItem">
   import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
   import HeaderButton from '$lib/components/header-button.svelte';
   import Popover from '$lib/components/popover/popover.svelte';
   import type { Snippet } from 'svelte';
 
-  interface Props<T> {
+  interface Props {
     faIcon?: IconDefinition;
     label: string;
     title?: string;
+    fill?: boolean;
     items?: T[];
-    onselect?: (item: T) => void | Promise<void>;
     icon?: Snippet;
     item?: Snippet<[T, () => void]>;
   }
 
-  let {
-    faIcon,
-    label,
-    title,
-    items = [],
-    onselect,
-    icon: iconSnippet,
-    item
-  }: Props<any> = $props();
+  let { faIcon, label, title, fill = false, items = [], icon: iconSnippet, item }: Props = $props();
 
   let popover = $state<Popover>();
 
@@ -30,12 +43,12 @@
     popover?.toggleOpen();
   }
 
-  async function handleSelect(itemToSelect: any) {
+  async function handleSelect(itemToSelect: T, event: MouseEvent) {
     if (itemToSelect.disabled) {
       return;
     }
 
-    await onselect?.(itemToSelect);
+    await itemToSelect.onclick?.(event);
     closeMenu();
   }
 </script>
@@ -43,30 +56,55 @@
 <Popover
   placement="bottom"
   fallbackPlacements={['bottom-end', 'bottom-start']}
+  innerContainerClasses={fill ? 'max-md:min-w-0 max-md:flex-1' : ''}
   yOffset={0}
   bind:this={popover}
 >
   {#snippet icon()}
-    <HeaderButton {faIcon} {title} label={`${label} ▾`} icon={iconSnippet} />
+    <HeaderButton
+      {faIcon}
+      {title}
+      {fill}
+      label={`${label} ▾`}
+      mobileLabel={label}
+      icon={iconSnippet}
+    />
   {/snippet}
   {#snippet content()}
     <div class="inline-flex flex-col bg-gray-700">
       {#each items as menuItem (menuItem)}
         {#if item}
           {@render item(menuItem, closeMenu)}
+        {:else if menuItem.href !== undefined && !menuItem.disabled}
+          <!-- Internal destinations are resolved by the caller before reaching this renderer. -->
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+          <a
+            href={menuItem.href}
+            aria-current={menuItem.selected ? 'page' : undefined}
+            class="w-full px-4 py-2 text-left text-sm whitespace-nowrap hover:bg-white hover:text-gray-700"
+            class:bg-white={menuItem.selected}
+            class:text-gray-700={menuItem.selected}
+            title={menuItem.title}
+            onclick={closeMenu}
+          >
+            {menuItem.menuLabel ?? menuItem.label}
+          </a>
         {:else}
           <button
             type="button"
+            aria-current={menuItem.selected ? 'page' : undefined}
             class="w-full px-4 py-2 text-left text-sm whitespace-nowrap hover:bg-white hover:text-gray-700"
+            class:bg-white={menuItem.selected}
+            class:text-gray-700={menuItem.selected}
             class:cursor-not-allowed={menuItem.disabled}
             class:text-gray-500={menuItem.disabled}
             class:hover:bg-white={!menuItem.disabled}
             class:hover:text-gray-700={!menuItem.disabled}
             disabled={menuItem.disabled}
             title={menuItem.title}
-            onclick={() => handleSelect(menuItem)}
+            onclick={(event) => handleSelect(menuItem, event)}
           >
-            {menuItem.label}
+            {menuItem.menuLabel ?? menuItem.label}
           </button>
         {/if}
       {/each}

--- a/src/lib/components/header-nav-tabs.svelte
+++ b/src/lib/components/header-nav-tabs.svelte
@@ -1,56 +1,14 @@
 <script lang="ts">
-  import type { RouteId } from '$app/types';
-  import { resolve } from '$app/paths';
-  import { page } from '$app/state';
-  import { faBookOpen, faChartLine, faCog, faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
-  import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
   import HeaderButton from '$lib/components/header-button.svelte';
-  import { getBookStatisticsURL } from '$lib/components/statistics/statistics-view';
-  import { database } from '$lib/data/store';
-  import { getBookURL } from '$lib/functions/book-url';
-
-  type HeaderRouteId = Extract<RouteId, '/b' | '/statistics' | '/settings' | '/manage'>;
-
-  interface Props {
-    currentBookTitle?: string;
-  }
-
-  let { currentBookTitle }: Props = $props();
-
-  const tabs = [
-    { routeId: '/statistics', label: 'Statistics', icon: faChartLine },
-    { routeId: '/settings', label: 'Settings', icon: faCog },
-    { routeId: '/manage', label: 'Manager', icon: faSignOutAlt }
-  ] satisfies { routeId: HeaderRouteId; label: string; icon: IconDefinition }[];
-
-  function isSelectedRoute(routeId: HeaderRouteId) {
-    return page.route.id === routeId || page.route.id?.startsWith(`${routeId}/`);
-  }
-
-  function getTabHref(routeId: HeaderRouteId) {
-    if (routeId === '/statistics' && page.route.id === '/b' && currentBookTitle) {
-      return getBookStatisticsURL(currentBookTitle);
-    }
-
-    return routeId;
-  }
+  import { getNavTabs } from '$lib/components/header-nav';
 </script>
 
-{#if database.lastItemTitle !== undefined}
-  <HeaderButton
-    faIcon={faBookOpen}
-    label="Book"
-    selected={page.route.id === '/b'}
-    variant="tab"
-    href={resolve(getBookURL(database.lastItemTitle))}
-  />
-{/if}
-{#each tabs as tab (tab.routeId)}
+{#each getNavTabs() as tab (tab.label)}
   <HeaderButton
     faIcon={tab.icon}
     label={tab.label}
-    selected={isSelectedRoute(tab.routeId)}
+    selected={tab.selected}
     variant="tab"
-    href={resolve(getTabHref(tab.routeId))}
+    href={tab.href}
   />
 {/each}

--- a/src/lib/components/header-nav.ts
+++ b/src/lib/components/header-nav.ts
@@ -1,0 +1,78 @@
+import { browser } from '$app/environment';
+import { resolve } from '$app/paths';
+import { page } from '$app/state';
+import type { ResolvedPathname, RouteId } from '$app/types';
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faBookOpen, faChartLine, faCog, faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
+import { getBookStatisticsURL } from '$lib/components/statistics/statistics-view';
+import { database } from '$lib/data/store';
+import { getBookURL } from '$lib/functions/book-url';
+
+type HeaderRouteId = Extract<RouteId, '/b' | '/statistics' | '/settings' | '/manage'>;
+
+export interface NavTab {
+  label: string;
+  icon: IconDefinition;
+  href: ResolvedPathname;
+  selected: boolean;
+}
+
+const tabs = [
+  { routeId: '/statistics', label: 'Statistics', icon: faChartLine },
+  { routeId: '/settings', label: 'Settings', icon: faCog },
+  { routeId: '/manage', label: 'Manager', icon: faSignOutAlt }
+] satisfies { routeId: HeaderRouteId; label: string; icon: IconDefinition }[];
+
+/**
+ * On the reader route the canonical book title lives in the `t` query parameter (see
+ * `getBookURL`), so navigation can deep-link to the current book without the reader threading
+ * its title through every header component. Guarded by `browser` because search params are
+ * unavailable while prerendering; hydration fills in the book-specific link.
+ */
+function currentBookTitle() {
+  if (!browser || page.route.id !== '/b') {
+    return undefined;
+  }
+
+  return page.url.searchParams.get('t') ?? undefined;
+}
+
+function isSelectedRoute(routeId: HeaderRouteId) {
+  return page.route.id === routeId || !!page.route.id?.startsWith(`${routeId}/`);
+}
+
+function getTabHref(routeId: HeaderRouteId) {
+  const bookTitle = currentBookTitle();
+
+  if (routeId === '/statistics' && bookTitle !== undefined) {
+    return getBookStatisticsURL(bookTitle);
+  }
+
+  return routeId;
+}
+
+/**
+ * The primary navigation targets, shared by the inline tabs in wide-viewport headers
+ * (`HeaderNavTabs`) and the bottom navigation bar on narrow viewports (`MobileNavigation`).
+ * Reads reactive state (`page`, `database`), so call it from a template or other tracked context.
+ */
+export function getNavTabs(): NavTab[] {
+  return [
+    ...(database.lastItemTitle !== undefined
+      ? [
+          {
+            label: 'Book',
+            icon: faBookOpen,
+            href: resolve(getBookURL(database.lastItemTitle)),
+            selected: page.route.id === '/b'
+          }
+        ]
+      : []),
+    ...tabs.map(({ routeId, label, icon }) => ({
+      label,
+      icon,
+      href: resolve(getTabHref(routeId)),
+      selected: isSelectedRoute(routeId)
+    }))
+  ];
+}

--- a/src/lib/components/mobile-navigation.svelte
+++ b/src/lib/components/mobile-navigation.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import HeaderButton from '$lib/components/header-button.svelte';
+  import { getNavTabs } from '$lib/components/header-nav';
+  import { readerChrome } from '$lib/data/reader-chrome.svelte';
+  import { replicationProgressState } from '$lib/functions/replication/replication-progress.svelte';
+
+  let hidden = $derived(
+    (page.route.id === '/b' && readerChrome.hidden) ||
+      (page.route.id === '/manage' && replicationProgressState.toProgress > 0)
+  );
+</script>
+
+<!--
+  `data-mobile-navigation` and the `inert` attribute drive the `mobile-navigation-height`
+  custom property in `app.css`, which insets the rest of the app while the bar is shown.
+-->
+<nav
+  data-mobile-navigation
+  aria-label="Primary navigation"
+  inert={hidden}
+  class="elevation-4 writing-horizontal-tb fixed inset-x-0 bottom-0 z-30 flex bg-gray-700 pb-[env(safe-area-inset-bottom)] text-white transition-opacity duration-150 ease-in-out md:hidden"
+  class:opacity-0={hidden}
+>
+  {#each getNavTabs() as tab (tab.label)}
+    <div class="flex min-w-0 flex-1">
+      <HeaderButton
+        faIcon={tab.icon}
+        label={tab.label}
+        fill
+        selected={tab.selected}
+        variant="tab"
+        href={tab.href}
+      />
+    </div>
+  {/each}
+</nav>

--- a/src/lib/components/popover/popover.svelte
+++ b/src/lib/components/popover/popover.svelte
@@ -6,6 +6,7 @@
   import type { Instance, Placement } from '@popperjs/core';
   import flip from '@popperjs/core/lib/modifiers/flip';
   import offset from '@popperjs/core/lib/modifiers/offset';
+  import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow';
   import { createPopper } from '@popperjs/core/lib/popper-lite';
   import { tick } from 'svelte';
 
@@ -13,6 +14,7 @@
     contentText?: string;
     containerStyles?: string;
     innerContainerStyles?: string;
+    innerContainerClasses?: string;
     contentStyles?: string;
     eventType?: string;
     fallbackPlacements?: string[];
@@ -39,6 +41,7 @@
     contentText = '',
     containerStyles = '',
     innerContainerStyles = '',
+    innerContainerClasses = '',
     contentStyles = 'padding: 0',
     eventType = 'click',
     fallbackPlacements = ['left', 'bottom', 'right'],
@@ -118,6 +121,12 @@
             options: {
               offset: [xOffset, yOffset]
             }
+          },
+          {
+            ...preventOverflow,
+            options: {
+              padding: 8
+            }
           }
         ]
       });
@@ -173,13 +182,19 @@
 
 <div data-popover class="flex items-center" style={containerStyles}>
   <div
-    style={innerContainerStyles}
+    class={iconSnippet ? undefined : innerContainerClasses}
+    style={iconSnippet ? undefined : innerContainerStyles}
     use:conditionalClickHandlerAndClass={!iconSnippet}
     bind:this={contentElement}
   >
     {@render children?.()}
   </div>
-  <div use:conditionalClickHandlerAndClass={!!iconSnippet} bind:this={iconElement}>
+  <div
+    class={iconSnippet ? innerContainerClasses : undefined}
+    style={iconSnippet ? innerContainerStyles : undefined}
+    use:conditionalClickHandlerAndClass={!!iconSnippet}
+    bind:this={iconElement}
+  >
     {@render iconSnippet?.()}
   </div>
 </div>
@@ -187,7 +202,7 @@
 {#if isOpen}
   <div
     data-popover
-    class="max-w-60vw z-10 rounded-sm bg-[#333] text-sm font-bold text-white md:max-w-lg"
+    class="z-10 max-w-[calc(100vw-2rem)] rounded-sm bg-[#333] text-sm font-bold text-white md:max-w-lg"
     class:absolute={strategy === 'absolute'}
     class:fixed={strategy === 'fixed'}
     class:whitespace-pre-wrap={contentText}

--- a/src/lib/components/settings/settings-header.svelte
+++ b/src/lib/components/settings/settings-header.svelte
@@ -38,9 +38,14 @@
   ];
 </script>
 
-<div class={baseHeaderClasses}>
+<div class={baseHeaderClasses} role="toolbar" aria-label="Settings controls">
   <div class="flex h-full justify-between">
-    <div class="flex" data-sveltekit-keepfocus data-sveltekit-noscroll>
+    <div
+      data-mobile-actions
+      class="grid w-full grid-flow-col auto-cols-fr md:flex md:w-auto"
+      data-sveltekit-keepfocus
+      data-sveltekit-noscroll
+    >
       {#each settingItems as settingItem (settingItem.label)}
         <HeaderButton
           faIcon={settingItem.icon}
@@ -51,7 +56,7 @@
         />
       {/each}
     </div>
-    <div class="flex">
+    <div class="hidden md:flex">
       <HeaderNavTabs />
     </div>
   </div>

--- a/src/lib/components/statistics/statistics-header.svelte
+++ b/src/lib/components/statistics/statistics-header.svelte
@@ -3,12 +3,13 @@
   import {
     faCalendarDays,
     faCopy,
+    faEllipsis,
     faFilter,
     faMap,
     faSliders
   } from '@fortawesome/free-solid-svg-icons';
-  import HeaderButton from '$lib/components/header-button.svelte';
-  import HeaderMenuButton from '$lib/components/header-menu-button.svelte';
+  import HeaderButton, { type HeaderAction } from '$lib/components/header-button.svelte';
+  import HeaderMenuButton, { type HeaderMenuItem } from '$lib/components/header-menu-button.svelte';
   import HeaderNavTabs from '$lib/components/header-nav-tabs.svelte';
   import type { StatisticsView } from '$lib/components/statistics/statistics-view';
   import type {
@@ -41,15 +42,33 @@
     { key: 'readingTime', label: 'Reading Time' },
     { key: 'charactersRead', label: 'Characters Read' }
   ];
+  const copyMenuItems: HeaderMenuItem[] = copyStatisticsDataItems.map(({ key, label }) => ({
+    label,
+    onclick: () => oncopydata(key)
+  }));
+
+  const settingsAction: HeaderAction = {
+    faIcon: faSliders,
+    label: 'Statistics Settings',
+    title: 'Open statistics settings',
+    onclick: () => onopensettings()
+  };
 
   let summarySelected = $derived(activeView === 'summary');
   let heatmapSelected = $derived(activeView === 'heatmap');
+  const mobileMenuItems = [
+    ...copyMenuItems.map(({ label, onclick }) => ({ label: `Copy ${label}`, onclick })),
+    settingsAction
+  ];
 </script>
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
-  <div class={baseHeaderClasses}>
-    <div class="flex h-full justify-between">
-      <div class="flex" data-sveltekit-keepfocus data-sveltekit-noscroll>
+  <div class={baseHeaderClasses} role="toolbar" aria-label="Statistics controls">
+    <div
+      data-mobile-actions
+      class="grid h-full grid-flow-col auto-cols-fr md:flex md:justify-between"
+    >
+      <div class="contents md:flex" data-sveltekit-keepfocus data-sveltekit-noscroll>
         <HeaderButton
           faIcon={faCalendarDays}
           label="Summary"
@@ -66,7 +85,7 @@
           title={heatmapSelected ? undefined : 'Switch to Heatmap tab'}
           href={heatmapHref}
         />
-        <div class={headerDividerClasses}></div>
+        <div class="hidden md:block {headerDividerClasses}"></div>
         <HeaderButton
           faIcon={faFilter}
           title="Open book filter menu"
@@ -78,20 +97,25 @@
             }
           }}
         />
-        <HeaderButton
-          faIcon={faSliders}
-          title="Open statistics settings"
-          label="Statistics Settings"
-          onclick={onopensettings}
-        />
+        <div class="hidden md:contents">
+          <HeaderButton {...settingsAction} />
+        </div>
+        <div class="contents md:hidden">
+          <HeaderMenuButton
+            faIcon={faEllipsis}
+            title="More statistics actions"
+            label="More"
+            fill
+            items={mobileMenuItems}
+          />
+        </div>
       </div>
-      <div class="flex">
+      <div class="hidden md:flex">
         <HeaderMenuButton
           faIcon={faCopy}
           title="Copy data in TMW log format"
           label="Copy"
-          items={copyStatisticsDataItems}
-          onselect={(copyStatisticsDataItem) => oncopydata(copyStatisticsDataItem.key)}
+          items={copyMenuItems}
         />
         <div class={headerDividerClasses}></div>
         <HeaderNavTabs />

--- a/src/lib/css-classes.ts
+++ b/src/lib/css-classes.ts
@@ -1,4 +1,4 @@
-export const baseHeaderClasses = 'relative h-12 bg-gray-700 text-white';
+export const baseHeaderClasses = 'relative h-(--header-height) bg-gray-700 text-white';
 export const pxScreen = 'sync-safe-px max-w-6xl mx-auto';
 export const inputClasses =
   'mt-1 block w-full px-0.5 bg-background-color border-0 border-b-2 border-b-gray-400/50 focus:ring-0 focus:border-b-black focus:outline-hidden transition-colors';

--- a/src/lib/data/reader-chrome.svelte.ts
+++ b/src/lib/data/reader-chrome.svelte.ts
@@ -1,0 +1,7 @@
+/**
+ * Whether the reader page is currently hiding its chrome. Owned by `routes/b/+page.svelte`;
+ * read by layout-level chrome (the mobile bottom navigation) so it hides and shows in sync
+ * with the reader's header. Only meaningful while the reader route is active — consumers must
+ * gate on the route themselves.
+ */
+export const readerChrome = $state({ hidden: false });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/state';
   import { appName, basePath, clearConsoleOnReload } from '$lib/data/env';
   import BottomLeftCluster from '$lib/components/bottom-left-cluster.svelte';
+  import MobileNavigation from '$lib/components/mobile-navigation.svelte';
   import { userFontsCacheName, type UserFont } from '$lib/data/fonts';
   import { reconcileUserFontCache } from '$lib/functions/reconcile-user-font-cache';
   import { loadConnectionsFromDb } from '$lib/data/sync/source-manager';
@@ -97,6 +98,8 @@
 />
 
 {@render children?.()}
+
+<MobileNavigation />
 
 <BottomLeftCluster />
 

--- a/src/routes/b/+page.svelte
+++ b/src/routes/b/+page.svelte
@@ -83,6 +83,7 @@
     type BooksDbStatistic
   } from '$lib/data/database/books-db/versions/books-db';
   import { deviceEnvironment } from '$lib/data/device-environment.svelte';
+  import { readerChrome } from '$lib/data/reader-chrome.svelte';
   import { PAGE_CHANGE } from '$lib/data/events';
   import { fullscreenManager } from '$lib/data/fullscreen-manager';
   import { logger } from '$lib/data/logger';
@@ -134,6 +135,14 @@
   let showSpinner = $state(true);
   let showHeader = $state(false);
   let readerActionPending = $state(false);
+
+  // Set synchronously (not just in the `$effect` below) so the mobile bottom navigation never
+  // flashes during the first frame after navigating into the reader.
+  readerChrome.hidden = true;
+
+  $effect(() => {
+    readerChrome.hidden = !showHeader || readerActionPending;
+  });
   let isBookmarkScreen = $state(false);
   let showFooter = $state(true);
   let exploredCharCount = $state(0);
@@ -1293,7 +1302,6 @@
   use:clickOutside={() => (showHeader = false)}
 >
   <BookReaderHeader
-    currentBookTitle={rawBookData?.title}
     hasChapterData={bookTOCState.hasChapters}
     hasText={!!bookCharCount}
     hasCustomReadingPoint={!!(
@@ -1482,6 +1490,7 @@
   tabindex="0"
   role="button"
   class="writing-horizontal-tb fixed bottom-0 left-0 z-10 flex h-8 w-full items-center justify-end text-xs leading-none"
+  style:bottom="var(--mobile-navigation-height)"
   style:color={themeOption.tooltipTextFontColor}
   onclick={() => (showFooter = !showFooter)}
   onkeyup={dummyFn}
@@ -1500,6 +1509,7 @@
       role="button"
       title="Click to copy progress"
       class="writing-horizontal-tb fixed bottom-2 right-2 z-10 text-xs leading-none select-none whitespace-pre"
+      style:bottom="calc(var(--mobile-navigation-height) + 0.5rem)"
       class:invisible={!$showCharacterCounter$ &&
         !$showPercentage$ &&
         !$showFooterChapterCharacterCounter$ &&

--- a/tests/integration/mobile-headers.spec.ts
+++ b/tests/integration/mobile-headers.spec.ts
@@ -1,0 +1,238 @@
+import { resolve } from 'node:path';
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from './helpers/harness.ts';
+import { fixtureTitle, VALID_BOOK } from './helpers/fixtures.ts';
+import { loadApp } from './helpers/navigation.ts';
+
+test.use({ viewport: { width: 320, height: 844 } });
+
+test('mobile section headers keep labeled controls visible and expose overflow actions', async ({
+  page
+}) => {
+  await loadApp(page);
+
+  const libraryToolbar = page.getByRole('toolbar', { name: 'Library controls' });
+  const libraryActions = libraryToolbar.locator('[data-mobile-actions]');
+  const libraryActionLabels = ['Select', 'Import', 'Sort', 'Bug Report'];
+  await expectVisibleControls(libraryActions, libraryActionLabels);
+  await expectControlsToHaveEqualWidths(libraryActions, libraryActionLabels);
+  await expectToolbarToFitViewport(libraryActions, page);
+
+  let navigation = page.getByRole('navigation', { name: 'Primary navigation' });
+  await expectVisibleControls(navigation, ['Statistics', 'Settings', 'Manager']);
+  await expectControlsToHaveEqualWidths(navigation, ['Statistics', 'Settings', 'Manager']);
+  await expectToolbarToFitViewport(navigation, page);
+
+  await visibleControl(libraryActions, 'Import').click();
+  await expect(visibleControl(libraryToolbar, 'Import Files')).toBeVisible();
+  await expect(visibleControl(libraryToolbar, 'Import Folder')).toBeVisible();
+
+  await visibleControl(navigation, 'Settings').click();
+  await page.waitForURL((url) => url.pathname.startsWith('/settings'));
+
+  const settingsToolbar = page.getByRole('toolbar', { name: 'Settings controls' });
+  const settingsActions = settingsToolbar.locator('[data-mobile-actions]');
+  await expectVisibleControls(settingsActions, ['Reader', 'Sync', 'Statistics']);
+  await expectControlsToHaveEqualWidths(settingsActions, ['Reader', 'Sync', 'Statistics']);
+  await expectToolbarToFitViewport(settingsActions, page);
+
+  navigation = page.getByRole('navigation', { name: 'Primary navigation' });
+  await visibleControl(navigation, 'Statistics').click();
+  await page.waitForURL((url) => url.pathname === '/statistics');
+
+  const statisticsToolbar = page.getByRole('toolbar', { name: 'Statistics controls' });
+  const statisticsActions = statisticsToolbar.locator('[data-mobile-actions]');
+  await expectVisibleControls(statisticsActions, ['Summary', 'Heatmap', 'Filter', 'More']);
+  await expectControlsToHaveEqualWidths(statisticsActions, [
+    'Summary',
+    'Heatmap',
+    'Filter',
+    'More'
+  ]);
+  await expectToolbarToFitViewport(statisticsActions, page);
+
+  await visibleControl(statisticsToolbar, 'More').click();
+  await expect(visibleControl(statisticsToolbar, 'Copy Reading Time')).toBeVisible();
+  await expect(visibleControl(statisticsToolbar, 'Copy Characters Read')).toBeVisible();
+  await expect(visibleControl(statisticsToolbar, 'Statistics Settings')).toBeVisible();
+});
+
+test('mobile library selection and reader actions use labeled overflow menus', async ({ page }) => {
+  await loadApp(page);
+
+  await visibleControl(page.getByRole('toolbar', { name: 'Library controls' }), 'Import').click();
+  const chooserPromise = page.waitForEvent('filechooser');
+  await visibleControl(
+    page.getByRole('toolbar', { name: 'Library controls' }),
+    'Import Files'
+  ).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles(resolve(import.meta.dirname, 'fixtures/books', 'valid-japanese.epub'));
+
+  const title = fixtureTitle(VALID_BOOK);
+  await expect(page.getByText(title, { exact: true })).toBeVisible();
+
+  const card = page.locator('article').filter({ hasText: title });
+  const cardActions = card.locator('[data-book-card-actions]');
+  await expect(
+    card.getByRole('link', { name: `View statistics for ${title}`, includeHidden: true })
+  ).toBeHidden();
+  await expect(card.getByRole('button', { name: `Details for ${title}` })).toBeVisible();
+  await expect(card.getByRole('button', { name: `More actions for ${title}` })).toBeVisible();
+  await expectElementToFitContainer(cardActions, card);
+  await card.getByRole('button', { name: `Details for ${title}` }).click();
+  await expectElementToFitViewport(card.locator('[data-book-details]'), page);
+  await card.getByRole('button', { name: `Details for ${title}` }).click();
+
+  const libraryToolbar = page.getByRole('toolbar', { name: 'Library controls' });
+  const libraryActions = libraryToolbar.locator('[data-mobile-actions]');
+  await visibleControl(libraryActions, 'Select').click();
+  await card.getByRole('button', { name: title, exact: true }).click();
+  await expectVisibleControls(libraryActions, ['Select', 'Clear All', 'Actions']);
+  await expectControlsToHaveEqualWidths(libraryActions, ['Select', 'Clear All', 'Actions']);
+  await expectToolbarToFitViewport(libraryActions, page);
+
+  await visibleControl(libraryActions, 'Actions').click();
+  await expect(visibleControl(libraryToolbar, 'View Statistics')).toBeVisible();
+  await expect(visibleControl(libraryToolbar, 'Mark Complete')).toBeVisible();
+  await expect(visibleControl(libraryToolbar, 'Delete Statistics')).toBeVisible();
+  await expect(visibleControl(libraryToolbar, 'Remove Books')).toBeVisible();
+
+  await visibleControl(libraryActions, 'Select').click();
+  await card.getByRole('link', { name: title, exact: true }).click();
+  await page.waitForURL((url) => url.pathname === '/b' && url.searchParams.has('t'));
+
+  const readerToolbar = page.getByRole('toolbar', { name: 'Reader controls' });
+  if ((await readerToolbar.getAttribute('inert')) !== null) {
+    await page.getByRole('button', { name: 'Show reader header' }).click();
+  }
+
+  const readerActions = readerToolbar.locator('[data-mobile-actions]');
+  await expectVisibleControls(readerActions, ['TOC', 'Bookmark', 'More']);
+  await expectControlsToHaveEqualWidths(readerActions, ['TOC', 'Bookmark', 'More']);
+  await expectToolbarToFitViewport(readerActions, page);
+
+  const navigationBar = page.locator('[data-mobile-navigation]');
+  await visibleControl(readerActions, 'Bookmark').click();
+  await expect(readerToolbar).toHaveAttribute('inert', '');
+  await expect(navigationBar).toHaveAttribute('inert', '');
+  await page.getByRole('button', { name: 'Show reader header' }).click();
+  await expect(readerToolbar).not.toHaveAttribute('inert', '');
+  await expect(navigationBar).not.toHaveAttribute('inert', '');
+  await expectVisibleControls(readerActions, ['TOC', 'Bookmark', 'Return', 'More']);
+  await expectControlsToHaveEqualWidths(readerActions, ['TOC', 'Bookmark', 'Return', 'More']);
+  await expectToolbarToFitViewport(readerActions, page);
+
+  const navigation = page.getByRole('navigation', { name: 'Primary navigation' });
+  await expectVisibleControls(navigation, ['Book', 'Statistics', 'Settings', 'Manager']);
+  await expectControlsToHaveEqualWidths(navigation, ['Book', 'Statistics', 'Settings', 'Manager']);
+  await expectToolbarToFitViewport(navigation, page);
+
+  await visibleControl(readerActions, 'More').click();
+  await expect(visibleControl(readerToolbar, 'Complete Book')).toBeVisible();
+  await expect(visibleControl(readerToolbar, 'Fullscreen')).toBeVisible();
+  await expect(visibleControl(readerToolbar, 'Jump to Character')).toBeVisible();
+  await expect(visibleControl(readerToolbar, 'Set Point')).toBeVisible();
+});
+
+test('mobile navigation is unavailable while a library operation is in progress', async ({
+  page
+}) => {
+  await loadApp(page);
+
+  const libraryToolbar = page.getByRole('toolbar', { name: 'Library controls' });
+  await visibleControl(libraryToolbar, 'Import').click();
+  const chooserPromise = page.waitForEvent('filechooser');
+  await visibleControl(libraryToolbar, 'Import Files').click();
+  const chooser = await chooserPromise;
+  const booksDirectory = resolve(import.meta.dirname, 'fixtures/books');
+  await chooser.setFiles([
+    resolve(booksDirectory, 'cover-refresh-book.epub'),
+    resolve(booksDirectory, 'long-test-book.epub'),
+    resolve(booksDirectory, 'plain-text-book.txt'),
+    ...Array<string>(8).fill(resolve(booksDirectory, 'long-test-book.epub'))
+  ]);
+
+  const navigation = page.locator('[data-mobile-navigation]');
+  await expect(page.getByTitle('Cancel operation')).toBeVisible();
+  await expect(navigation).toHaveAttribute('inert', '');
+  await expect(navigation).toHaveCSS('opacity', '0');
+
+  await expect(page.getByTitle('Cancel operation')).toBeHidden();
+  await expect(navigation).not.toHaveAttribute('inert', '');
+  await expect(navigation).toHaveCSS('opacity', '1');
+});
+
+async function expectVisibleControls(toolbar: Locator, labels: string[]) {
+  for (const label of labels) {
+    await expect(visibleControl(toolbar, label)).toBeVisible();
+  }
+}
+
+async function expectControlsToHaveEqualWidths(toolbar: Locator, labels: string[]) {
+  const widths = await Promise.all(
+    labels.map((label) =>
+      visibleControl(toolbar, label).evaluate((control) => control.getBoundingClientRect().width)
+    )
+  );
+  expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1);
+}
+
+function visibleControl(toolbar: Locator, label: string) {
+  return toolbar
+    .getByRole('button', { name: label, exact: true })
+    .or(toolbar.getByRole('link', { name: label, exact: true }))
+    .filter({ visible: true });
+}
+
+async function expectToolbarToFitViewport(toolbar: Locator, page: Page) {
+  const viewportWidth = page.viewportSize()?.width;
+  expect(viewportWidth).toBeDefined();
+
+  const controlBoxes = await toolbar.locator('button:visible, a:visible').evaluateAll((controls) =>
+    controls.map((control) => {
+      const { left, right } = control.getBoundingClientRect();
+      return { left, right };
+    })
+  );
+
+  expect(controlBoxes.length).toBeGreaterThan(0);
+  for (const box of controlBoxes) {
+    expect(box.left).toBeGreaterThanOrEqual(0);
+    expect(box.right).toBeLessThanOrEqual(viewportWidth!);
+  }
+}
+
+async function expectElementToFitContainer(element: Locator, container: Locator) {
+  const { clientWidth, scrollWidth } = await element.evaluate((node) => ({
+    clientWidth: node.clientWidth,
+    scrollWidth: node.scrollWidth
+  }));
+  const elementBox = await element.boundingBox();
+  const containerBox = await container.boundingBox();
+  expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+  expect(elementBox).not.toBeNull();
+  expect(containerBox).not.toBeNull();
+  expect(elementBox!.x).toBeGreaterThanOrEqual(containerBox!.x);
+  expect(elementBox!.x + elementBox!.width).toBeLessThanOrEqual(
+    containerBox!.x + containerBox!.width
+  );
+}
+
+async function expectElementToFitViewport(element: Locator, page: Page) {
+  await expect(element).toBeVisible();
+  const viewportWidth = page.viewportSize()?.width;
+  expect(viewportWidth).toBeDefined();
+  const { left, right, clientWidth, scrollWidth } = await element.evaluate((node) => {
+    const bounds = node.getBoundingClientRect();
+    return {
+      left: bounds.left,
+      right: bounds.right,
+      clientWidth: node.clientWidth,
+      scrollWidth: node.scrollWidth
+    };
+  });
+  expect(left).toBeGreaterThanOrEqual(0);
+  expect(right).toBeLessThanOrEqual(viewportWidth!);
+  expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+}


### PR DESCRIPTION
On narrow viewports, section headers become equal-width labeled toolbars with overflow menus for secondary actions, and primary navigation moves to a bottom tab bar — rendered from the same responsive DOM and shared action definitions as the desktop layout. Details in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)